### PR TITLE
drivers: update code to match 1.15.3-C-14

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ The Makefile in drivers/linux will build all three drivers when
 ARCH=aarch64, else will build the host version of ionic.  Simply cd to
 the drivers/linux directory and type 'make'.
 
+## History
+
+2020-07-07 - initial drivers using 1.8.0-E-48
+
+2021-01-08 - driver updates to 1.15.3-C-14
+ - FW update fixes
+ - Makefile cleanups
+ - Add support for choosing individual Tx and Rx interrupts rather than paired
+ - Fix memory leaks and timing issues
+ - Kcompat fixes for newer upstream and Red Hat kernels
+ - Add interrupt affinity option for mnic_ionic use
+ - Other optimizations and stability fixes
+

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -52,6 +52,7 @@ KSRC ?= /lib/modules/$(shell uname -r)/build
 ETH_KOPT += CONFIG_IONIC=m
 ETH_KOPT += CONFIG_IONIC_MNIC=_
 ETH_KOPT += CONFIG_MNET=_
+ETH_KOPT += CONFIG_MNET_UIO_PDRV_GENIRQ=_
 
 KCFLAGS = -Werror
 
@@ -89,6 +90,15 @@ KCFLAGS += -Wno-undef
 endif
 endif
 endif
+
+DVER = $(shell echo $$SW_VERSION)
+ifeq ($(DVER),)
+  DVER = $(shell git describe --tags 2>/dev/null)
+  ifeq ($(DVER),)
+    DVER = "0.0.0"
+  endif
+endif
+KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 
 KOPT += KCFLAGS="$(KCFLAGS)"
 

--- a/drivers/linux/eth/ionic/Makefile
+++ b/drivers/linux/eth/ionic/Makefile
@@ -5,11 +5,11 @@ obj-$(CONFIG_IONIC) := ionic.o
 obj-$(CONFIG_IONIC_MNIC) := ionic_mnic.o
 
 # $(M) is abs path of drivers-linux/drivers
-ccflags-y := -I$(M)/../common
+ccflags-y := -I$(M)/../common -g
 
 ionic-y := ionic_main.o ionic_bus_pci.o ionic_dev.o ionic_ethtool.o \
 	   ionic_lif.o ionic_rx_filter.o ionic_txrx.o ionic_debugfs.o \
-	   ionic_api.o ionic_stats.o ionic_devlink.o kcompat.o
+	   ionic_api.o ionic_stats.o ionic_devlink.o kcompat.o ionic_fw.o
 ionic_mnic-y := ionic_main.o ionic_bus_platform.o ionic_dev.o ionic_ethtool.o \
 	        ionic_lif.o ionic_rx_filter.o ionic_txrx.o ionic_debugfs.o \
-	        ionic_api.o ionic_stats.o ionic_devlink.o
+	        ionic_api.o ionic_stats.o ionic_devlink.o ionic_fw.o

--- a/drivers/linux/eth/ionic/ionic.h
+++ b/drivers/linux/eth/ionic/ionic.h
@@ -16,7 +16,7 @@ struct ionic_lif;
 
 #define IONIC_DRV_NAME		"ionic"
 #define IONIC_DRV_DESCRIPTION	"Pensando Ethernet NIC Driver"
-#define IONIC_DRV_VERSION	"1.8.0"
+#define IONIC_DRV_VERSION	drv_ver
 
 #define PCI_VENDOR_ID_PENSANDO			0x1dd8
 
@@ -32,6 +32,7 @@ extern unsigned int max_slaves;
 extern unsigned int rx_copybreak;
 extern unsigned int tx_budget;
 extern unsigned int devcmd_timeout;
+extern unsigned long affinity_mask_override;
 
 struct ionic_vf {
 	u16	 index;

--- a/drivers/linux/eth/ionic/ionic_dev.c
+++ b/drivers/linux/eth/ionic/ionic_dev.c
@@ -704,6 +704,7 @@ static int ionic_eq_alloc(struct ionic *ionic, int index)
 err_out_free_intr:
 	ionic_intr_free(ionic, eq->intr.index);
 err_out:
+	kfree(eq);
 	return err;
 }
 

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -11,10 +11,8 @@
 #include "ionic_api.h"
 #include "ionic_regs.h"
 
-#define IONIC_MIN_MTU			ETH_MIN_MTU
-#define IONIC_MAX_MTU			9194
 #define IONIC_MAX_TX_DESC		8192
-#define IONIC_MAX_RX_DESC		16384
+#define IONIC_MAX_RX_DESC		8192
 #define IONIC_MIN_TXRX_DESC		16
 #define IONIC_DEF_TXRX_DESC		4096
 #define IONIC_LIFS_MAX			1024
@@ -86,6 +84,8 @@ static_assert(sizeof(struct ionic_q_init_cmd) == 64);
 static_assert(sizeof(struct ionic_q_init_comp) == 16);
 static_assert(sizeof(struct ionic_q_control_cmd) == 64);
 static_assert(sizeof(ionic_q_control_comp) == 16);
+static_assert(sizeof(struct ionic_q_identify_cmd) == 64);
+static_assert(sizeof(struct ionic_q_identify_comp) == 16);
 
 static_assert(sizeof(struct ionic_rx_mode_set_cmd) == 64);
 static_assert(sizeof(ionic_rx_mode_set_comp) == 16);
@@ -331,6 +331,11 @@ void ionic_dev_cmd_go(struct ionic_dev *idev, union ionic_dev_cmd *cmd);
 u8 ionic_dev_cmd_status(struct ionic_dev *idev);
 bool ionic_dev_cmd_done(struct ionic_dev *idev);
 void ionic_dev_cmd_comp(struct ionic_dev *idev, union ionic_dev_cmd_comp *comp);
+
+#define IONIC_FW_INSTALL_TIMEOUT			(25 * 60)
+#define IONIC_FW_ACTIVATE_TIMEOUT			(30)
+
+int ionic_firmware_update(struct ionic_lif *lif, const void *const fw_data, u32 fw_sz);
 
 void ionic_dev_cmd_identify(struct ionic_dev *idev, u8 ver);
 void ionic_dev_cmd_init(struct ionic_dev *idev);

--- a/drivers/linux/eth/ionic/ionic_devlink.c
+++ b/drivers/linux/eth/ionic/ionic_devlink.c
@@ -91,13 +91,6 @@ int ionic_devlink_register(struct ionic *ionic)
 		return err;
 	}
 
-#if ( LINUX_VERSION_CODE < KERNEL_VERSION(5,2,0) )
-	devlink_port_attrs_set(&ionic->dl_port, DEVLINK_PORT_FLAVOUR_PHYSICAL,
-			       0, false, 0);
-#else
-	devlink_port_attrs_set(&ionic->dl_port, DEVLINK_PORT_FLAVOUR_PHYSICAL,
-			       0, false, 0, NULL, 0);
-#endif
 	err = devlink_port_register(dl, &ionic->dl_port, 0);
 	if (err)
 		dev_err(ionic->dev, "devlink_port_register failed: %d\n", err);

--- a/drivers/linux/eth/ionic/ionic_fw.c
+++ b/drivers/linux/eth/ionic/ionic_fw.c
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright(c) 2017 - 2020 Pensando Systems, Inc */
+
+#include <linux/kernel.h>
+#include <linux/types.h>
+#include <linux/errno.h>
+
+#include "ionic.h"
+#include "ionic_dev.h"
+#include "ionic_lif.h"
+
+static void
+ionic_dev_cmd_firmware_download(struct ionic_dev *idev, uint64_t addr,
+				uint32_t offset, uint32_t length)
+{
+	union ionic_dev_cmd cmd = {
+		.fw_download.opcode = IONIC_CMD_FW_DOWNLOAD,
+		.fw_download.offset = offset,
+		.fw_download.addr = addr,
+		.fw_download.length = length
+	};
+
+	ionic_dev_cmd_go(idev, &cmd);
+}
+
+static void
+ionic_dev_cmd_firmware_install(struct ionic_dev *idev)
+{
+	union ionic_dev_cmd cmd = {
+		.fw_control.opcode = IONIC_CMD_FW_CONTROL,
+		.fw_control.oper = IONIC_FW_INSTALL_ASYNC
+	};
+
+	ionic_dev_cmd_go(idev, &cmd);
+}
+
+static void
+ionic_dev_cmd_firmware_status(struct ionic_dev *idev)
+{
+	union ionic_dev_cmd cmd = {
+		.fw_control.opcode = IONIC_CMD_FW_CONTROL,
+		.fw_control.oper = IONIC_FW_INSTALL_STATUS
+	};
+
+	ionic_dev_cmd_go(idev, &cmd);
+}
+
+static void
+ionic_dev_cmd_firmware_activate(struct ionic_dev *idev, uint8_t slot)
+{
+	union ionic_dev_cmd cmd = {
+		.fw_control.opcode = IONIC_CMD_FW_CONTROL,
+		.fw_control.oper = IONIC_FW_ACTIVATE,
+		.fw_control.slot = slot
+	};
+
+	ionic_dev_cmd_go(idev, &cmd);
+}
+
+int
+ionic_firmware_update(struct ionic_lif *lif, const void *const fw_data, u32 fw_sz)
+{
+	struct ionic_dev *idev = &lif->ionic->idev;
+	struct net_device *netdev = lif->netdev;
+	struct ionic *ionic = lif->ionic;
+	union ionic_dev_cmd_comp comp;
+	u32 buf_sz, copy_sz, offset;
+	int err = 0;
+	u8 fw_slot;
+
+	buf_sz = sizeof(idev->dev_cmd_regs->data);
+
+	netdev_info(netdev,
+		"downloading firmware - size %d part_sz %d nparts %d\n",
+		fw_sz, buf_sz, DIV_ROUND_UP(fw_sz, buf_sz));
+
+	offset = 0;
+	while (offset < fw_sz) {
+		copy_sz = min(buf_sz, fw_sz - offset);
+		mutex_lock(&ionic->dev_cmd_lock);
+		memcpy_toio(&idev->dev_cmd_regs->data, fw_data + offset, copy_sz);
+		ionic_dev_cmd_firmware_download(idev,
+			offsetof(union ionic_dev_cmd_regs, data), offset, copy_sz);
+		err = ionic_dev_cmd_wait(ionic, devcmd_timeout);
+		mutex_unlock(&ionic->dev_cmd_lock);
+		if (err) {
+			netdev_err(netdev,
+				"download failed offset 0x%x addr 0x%lx len 0x%x\n",
+				offset, offsetof(union ionic_dev_cmd_regs, data), copy_sz);
+			goto err_out;
+		}
+		offset += copy_sz;
+	}
+
+	netdev_info(netdev, "installing firmware\n");
+
+	mutex_lock(&ionic->dev_cmd_lock);
+	ionic_dev_cmd_firmware_install(idev);
+	err = ionic_dev_cmd_wait(ionic, devcmd_timeout);
+	ionic_dev_cmd_comp(idev, (union ionic_dev_cmd_comp *)&comp);
+	fw_slot = comp.fw_control.slot;
+	mutex_unlock(&ionic->dev_cmd_lock);
+	if (err) {
+		netdev_err(netdev, "failed to start firmware install\n");
+		goto err_out;
+	}
+
+	mutex_lock(&ionic->dev_cmd_lock);
+	ionic_dev_cmd_firmware_status(idev);
+	err = ionic_dev_cmd_wait(ionic, IONIC_FW_INSTALL_TIMEOUT);
+	mutex_unlock(&ionic->dev_cmd_lock);
+	if (err) {
+		netdev_err(netdev, "firmware install failed\n");
+		goto err_out;
+	}
+
+	netdev_info(netdev, "activating firmware - slot %d\n", fw_slot);
+
+	mutex_lock(&ionic->dev_cmd_lock);
+	ionic_dev_cmd_firmware_activate(idev, fw_slot);
+	err = ionic_dev_cmd_wait(ionic, IONIC_FW_ACTIVATE_TIMEOUT);
+	mutex_unlock(&ionic->dev_cmd_lock);
+	if (err) {
+		netdev_err(netdev, "firmware activation failed\n");
+		goto err_out;
+	}
+
+err_out:
+	return err;
+}

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -138,9 +138,7 @@ enum ionic_lif_state_flags {
 	IONIC_LIF_F_INITED,
 	IONIC_LIF_F_SW_DEBUG_STATS,
 	IONIC_LIF_F_UP,
-	IONIC_LIF_F_TRANS,
 	IONIC_LIF_F_LINK_CHECK_REQUESTED,
-	IONIC_LIF_F_QUEUE_RESET,
 	IONIC_LIF_F_FW_RESET,
 	IONIC_LIF_F_RDMA_SNIFFER,
 	IONIC_LIF_F_SPLIT_INTR,
@@ -176,6 +174,7 @@ struct ionic_lif {
 	struct ionic *ionic;
 	unsigned int index;
 	unsigned int hw_index;
+	struct mutex queue_lock;	/* lock for queue structures */
 	spinlock_t adminq_lock;		/* lock for AdminQ operations */
 	struct ionic_qcq *adminqcq;
 	struct ionic_qcq *notifyqcq;
@@ -237,12 +236,6 @@ struct ionic_lif {
 #define lif_to_txq(lif, i)	(&lif_to_txqcq((lif), i)->q)
 #define lif_to_rxq(lif, i)	(&lif_to_txqcq((lif), i)->q)
 #define is_master_lif(lif)	((lif)->index == 0)
-
-/* returns 0 if successfully set the bit, else non-zero */
-static inline int ionic_wait_for_bit(struct ionic_lif *lif, int bitname)
-{
-	return wait_on_bit_lock(lif->state, bitname, TASK_INTERRUPTIBLE);
-}
 
 static inline u32 ionic_coal_usec_to_hw(struct ionic *ionic, u32 usecs)
 {

--- a/drivers/linux/eth/ionic/ionic_rx_filter.c
+++ b/drivers/linux/eth/ionic/ionic_rx_filter.c
@@ -2,6 +2,7 @@
 /* Copyright(c) 2017 - 2019 Pensando Systems, Inc */
 
 #include <linux/netdevice.h>
+#include <linux/dynamic_debug.h>
 #include <linux/etherdevice.h>
 
 #include "ionic.h"

--- a/drivers/linux/eth/ionic/ionic_stats.c
+++ b/drivers/linux/eth/ionic/ionic_stats.c
@@ -159,12 +159,14 @@ static const struct ionic_stat_desc ionic_tx_stats_desc[] = {
 	IONIC_TX_STAT_DESC(clean),
 	IONIC_TX_STAT_DESC(dma_map_err),
 	IONIC_TX_STAT_DESC(linearize),
-	IONIC_TX_STAT_DESC(frags),
 	IONIC_TX_STAT_DESC(tso),
 	IONIC_TX_STAT_DESC(tso_bytes),
-	IONIC_TX_STAT_DESC(csum_none),
-	IONIC_TX_STAT_DESC(csum),
+#ifdef IONIC_DEBUG_STATS
 	IONIC_TX_STAT_DESC(vlan_inserted),
+	IONIC_TX_STAT_DESC(frags),
+	IONIC_TX_STAT_DESC(csum),
+	IONIC_TX_STAT_DESC(csum_none),
+#endif
 };
 
 static const struct ionic_stat_desc ionic_rx_stats_desc[] = {
@@ -172,11 +174,13 @@ static const struct ionic_stat_desc ionic_rx_stats_desc[] = {
 	IONIC_RX_STAT_DESC(bytes),
 	IONIC_RX_STAT_DESC(dma_map_err),
 	IONIC_RX_STAT_DESC(alloc_err),
+#ifdef IONIC_DEBUG_STATS
+	IONIC_RX_STAT_DESC(vlan_stripped),
 	IONIC_RX_STAT_DESC(csum_none),
 	IONIC_RX_STAT_DESC(csum_complete),
+#endif
 	IONIC_RX_STAT_DESC(csum_error),
 	IONIC_RX_STAT_DESC(dropped),
-	IONIC_RX_STAT_DESC(vlan_stripped),
 };
 
 static const struct ionic_stat_desc ionic_txq_stats_desc[] = {

--- a/drivers/linux/mnet/mnet_drv.h
+++ b/drivers/linux/mnet/mnet_drv.h
@@ -18,6 +18,7 @@ struct mnet_dev_create_req_t {
 	uint64_t drvcfg_pa;
 	uint64_t msixcfg_pa;
 	uint64_t doorbell_pa;
+	int is_uio_dev;
 	char iface_name[MNIC_NAME_LEN];
 };
 


### PR DESCRIPTION
Updates include:
 - FW update fixes
 - Makefile cleanups
 - Add support for choosing individual Tx and Rx interrupts rather than paired
 - Fix memory leaks and timing issues
 - Kcompat fixes for newer upstream and Red Hat kernels
 - Add interrupt affinity option for mnic_ionic use
 - Other optimizations and stability fixes

Signed-off-by: Shannon Nelson <snelson@pensando.io>