### PR TITLE
drivers: driver updates to 1.15.4-C-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ The Makefile in drivers/linux will build all three drivers when
 ARCH=aarch64, else will build the host version of ionic.  Simply cd to
 the drivers/linux directory and type 'make'.
 
+Well, okay maybe not that simple any more - it should be, but some things
+changed in the makefiles internally, and it's a little more complex.  Also,
+we wanted to keep this archive closer to what is used internally.
+
+If the headers for your current Linux kernel are findable under
+/lib/modules with kernel config values defined, this should work:
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.4.8\\\"" modules
+
+If the kernel config file doesn't have the Pensando configuration strings
+set in it, you can add them in the make line.
+
+For Naples drivers:
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.4.8\\\"" CONFIG_IONIC_MNIC=m CONFIG_MNET=m CONFIG_MNET_UIO_PDRV_GENIRQ=m modules
+
+For the host driver:
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.4.8\\\"" CONFIG_IONIC=m modules
+
+As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
+    make -C <kernel-header-path> M=`pwd` ...
+
 ## History
 
 2020-07-07 - initial drivers using 1.8.0-E-48
@@ -56,4 +76,15 @@ the drivers/linux directory and type 'make'.
  - Kcompat fixes for newer upstream and Red Hat kernels
  - Add interrupt affinity option for mnic_ionic use
  - Other optimizations and stability fixes
+
+2021-02-02 - driver updates to 1.15.4-C-8
+ - Added support for PTP
+ - Dropped support for macvlan offload
+ - Cleaned some 'sparse' complaints
+ - Add support for devlink firmware update
+ - Dynamic interrupt coalescing
+ - Add support for separate Tx interrupts
+ - Rework queue reconfiguration for better memory handling
+ - Reorder some configuration steps to remove race conditions
+ - Changes to napi handling for better performance
 

--- a/drivers/common/ionic_if.h
+++ b/drivers/common/ionic_if.h
@@ -40,6 +40,7 @@ enum ionic_cmd_opcode {
 	IONIC_CMD_LIF_RESET			= 22,
 	IONIC_CMD_LIF_GETATTR			= 23,
 	IONIC_CMD_LIF_SETATTR			= 24,
+	IONIC_CMD_LIF_SETPHC			= 25,
 
 	IONIC_CMD_RX_MODE_SET			= 30,
 	IONIC_CMD_RX_FILTER_ADD			= 31,
@@ -73,7 +74,7 @@ enum ionic_cmd_opcode {
 	IONIC_CMD_QOS_CLASS_RESET		= 242,
 	IONIC_CMD_QOS_CLASS_UPDATE		= 243,
 	IONIC_CMD_QOS_CLEAR_STATS		= 244,
-	IONIC_CMD_QOS_RESET 			= 245,
+	IONIC_CMD_QOS_RESET			= 245,
 
 	/* Firmware commands */
 	IONIC_CMD_FW_DOWNLOAD                   = 252,
@@ -109,6 +110,7 @@ enum ionic_status_code {
 	IONIC_RC_ERROR		= 29,	/* Generic error */
 	IONIC_RC_ERDMA		= 30,	/* Generic RDMA error */
 	IONIC_RC_EVFID		= 31,	/* VF ID does not exist */
+	IONIC_RC_BAD_FW		= 32,	/* FW file is invalid or corrupted */
 };
 
 enum ionic_notifyq_opcode {
@@ -281,6 +283,9 @@ union ionic_drv_identity {
  *                    value in usecs to device units using:
  *                    device units = usecs * mult / div
  * @eq_count:         Number of shared event queues
+ * @hwstamp_mask:     Bitmask for subtraction of hardware tick values.
+ * @hwstamp_mult:     Hardware tick to nanosecond multiplier.
+ * @hwstamp_shift:    Hardware tick to nanosecond divisor (power of two).
  */
 union ionic_dev_identity {
 	struct {
@@ -295,6 +300,9 @@ union ionic_dev_identity {
 		__le32 intr_coal_mult;
 		__le32 intr_coal_div;
 		__le32 eq_count;
+		__le64 hwstamp_mask;
+		__le32 hwstamp_mult;
+		__le32 hwstamp_shift;
 	};
 	__le32 words[478];
 };
@@ -332,7 +340,7 @@ struct ionic_lif_identify_comp {
 /**
  * enum ionic_lif_capability - LIF capabilities
  * @IONIC_LIF_CAP_ETH:     LIF supports Ethernet
- * @IONIC_LIF_CAP_RDMA:    LIF support RDMA
+ * @IONIC_LIF_CAP_RDMA:    LIF supports RDMA
  */
 enum ionic_lif_capability {
 	IONIC_LIF_CAP_ETH        = BIT(0),
@@ -355,6 +363,68 @@ enum ionic_logical_qtype {
 	IONIC_QTYPE_TXQ     = 3,
 	IONIC_QTYPE_EQ      = 4,
 	IONIC_QTYPE_MAX     = 16,
+};
+
+/**
+ * enum ionic_q_feature - Common Features for most queue types
+ *
+ * Common features use bits 0-15. Per-queue-type features use higher bits.
+ *
+ * @IONIC_QIDENT_F_CQ:      Queue has completion ring
+ * @IONIC_QIDENT_F_SG:      Queue has scatter/gather ring
+ * @IONIC_QIDENT_F_EQ:      Queue can use event queue
+ * @IONIC_QIDENT_F_CMB:     Queue is in cmb bar
+ * @IONIC_Q_F_2X_DESC:      Double main descriptor size
+ * @IONIC_Q_F_2X_CQ_DESC:   Double cq descriptor size
+ * @IONIC_Q_F_2X_SG_DESC:   Double sg descriptor size
+ * @IONIC_Q_F_4X_DESC:      Quadruple main descriptor size
+ * @IONIC_Q_F_4X_CQ_DESC:   Quadruple cq descriptor size
+ * @IONIC_Q_F_4X_SG_DESC:   Quadruple sg descriptor size
+ */
+enum ionic_q_feature {
+	IONIC_QIDENT_F_CQ		= BIT_ULL(0),
+	IONIC_QIDENT_F_SG		= BIT_ULL(1),
+	IONIC_QIDENT_F_EQ		= BIT_ULL(2),
+	IONIC_QIDENT_F_CMB		= BIT_ULL(3),
+	IONIC_Q_F_2X_DESC		= BIT_ULL(4),
+	IONIC_Q_F_2X_CQ_DESC		= BIT_ULL(5),
+	IONIC_Q_F_2X_SG_DESC		= BIT_ULL(6),
+	IONIC_Q_F_4X_DESC		= BIT_ULL(7),
+	IONIC_Q_F_4X_CQ_DESC		= BIT_ULL(8),
+	IONIC_Q_F_4X_SG_DESC		= BIT_ULL(9),
+};
+
+/**
+ * enum ionic_rxq_feature - RXQ-specific Features
+ *
+ * Per-queue-type features use bits 16 and higher.
+ *
+ * @IONIC_RXQ_F_HWSTAMP:   Queue supports Hardware Timestamping
+ */
+enum ionic_rxq_feature {
+	IONIC_RXQ_F_HWSTAMP		= BIT_ULL(16),
+};
+
+/**
+ * enum ionic_txq_feature - TXQ-specific Features
+ *
+ * Per-queue-type features use bits 16 and higher.
+ *
+ * @IONIC_TXQ_F_HWSTAMP:   Queue supports Hardware Timestamping
+ */
+enum ionic_txq_feature {
+	IONIC_TXQ_F_HWSTAMP		= BIT(16),
+};
+
+/**
+ * struct ionic_hwstamp_bits - Hardware timestamp decoding bits
+ * @IONIC_HWSTAMP_INVALID:          Invalid hardware timestamp value
+ * @IONIC_HWSTAMP_CQ_NEGOFFSET:     Timestamp field negative offset
+ *                                  from the base cq descriptor.
+ */
+enum ionic_hwstamp_bits {
+	IONIC_HWSTAMP_INVALID	    = ~0ull,
+	IONIC_HWSTAMP_CQ_NEGOFFSET  = 8,
 };
 
 /**
@@ -416,7 +486,9 @@ union ionic_lif_config {
  *     @max_ucast_filters:  Number of perfect unicast addresses supported
  *     @max_mcast_filters:  Number of perfect multicast addresses supported
  *     @min_frame_size:     Minimum size of frames to be sent
- *     @max_frame_size:     Maximim size of frames to be sent
+ *     @max_frame_size:     Maximum size of frames to be sent
+ *     @hwstamp_tx_modes:   Bitmask of BIT_ULL(enum ionic_txstamp_mode)
+ *     @hwstamp_rx_filters: Bitmask of enum ionic_pkt_class
  *     @config:             LIF config struct with features, mtu, mac, q counts
  *
  * @rdma:                RDMA identify structure
@@ -450,7 +522,10 @@ union ionic_lif_identity {
 			__le16 rss_ind_tbl_sz;
 			__le32 min_frame_size;
 			__le32 max_frame_size;
-			u8 rsvd2[106];
+			u8 rsvd2[2];
+			__le64 hwstamp_tx_modes;
+			__le64 hwstamp_rx_filters;
+			u8 rsvd3[88];
 			union ionic_lif_config config;
 		} __attribute__((packed)) eth;
 
@@ -541,7 +616,7 @@ struct ionic_q_identify_comp {
  * union ionic_q_identity - queue identity information
  *     @version:        Queue type version that can be used with FW
  *     @supported:      Bitfield of queue versions, first bit = ver 0
- *     @features:       Queue features
+ *     @features:       Queue features (enum ionic_q_feature, etc)
  *     @desc_sz:        Descriptor size
  *     @comp_sz:        Completion descriptor size
  *     @sg_desc_sz:     Scatter/Gather descriptor size
@@ -553,10 +628,6 @@ union ionic_q_identity {
 		u8      version;
 		u8      supported;
 		u8      rsvd[6];
-#define IONIC_QIDENT_F_CQ	0x01	/* queue has completion ring */
-#define IONIC_QIDENT_F_SG	0x02	/* queue has scatter/gather ring */
-#define IONIC_QIDENT_F_EQ	0x04	/* queue can use event queue */
-#define IONIC_QIDENT_F_CMB	0x08	/* queue is in cmb bar */
 		__le64  features;
 		__le16  desc_sz;
 		__le16  comp_sz;
@@ -597,6 +668,7 @@ union ionic_q_identity {
  * @ring_base:    Queue ring base address
  * @cq_ring_base: Completion queue ring base address
  * @sg_ring_base: Scatter/Gather ring base address
+ * @features:     Mask of queue features to enable, if not in the flags above.
  */
 struct ionic_q_init_cmd {
 	u8     opcode;
@@ -620,8 +692,11 @@ struct ionic_q_init_cmd {
 	__le64 ring_base;
 	__le64 cq_ring_base;
 	__le64 sg_ring_base;
-	u8     rsvd2[20];
+	u8     rsvd2[12];
+	__le64 features;
 } __attribute__((packed));
+
+IONIC_CHECK_CMD_LENGTH(ionic_q_init_cmd);
 
 /**
  * struct ionic_q_init_comp - Queue init command completion
@@ -704,7 +779,7 @@ enum ionic_txq_desc_opcode {
  *                      checksums are also updated.
  *
  *                   IONIC_TXQ_DESC_OPCODE_TSO:
- *                      Device preforms TCP segmentation offload
+ *                      Device performs TCP segmentation offload
  *                      (TSO).  @hdr_len is the number of bytes
  *                      to the end of TCP header (the offset to
  *                      the TCP payload).  @mss is the desired
@@ -994,19 +1069,19 @@ struct ionic_rxq_comp {
 };
 
 enum ionic_pkt_type {
-	IONIC_PKT_TYPE_NON_IP			= 0x00,
-	IONIC_PKT_TYPE_IPV4				= 0x01,
-	IONIC_PKT_TYPE_IPV4_TCP			= 0x03,
-	IONIC_PKT_TYPE_IPV4_UDP			= 0x05,
-	IONIC_PKT_TYPE_IPV6				= 0x08,
-	IONIC_PKT_TYPE_IPV6_TCP			= 0x18,
-	IONIC_PKT_TYPE_IPV6_UDP			= 0x28,
+	IONIC_PKT_TYPE_NON_IP		= 0x00,
+	IONIC_PKT_TYPE_IPV4		= 0x01,
+	IONIC_PKT_TYPE_IPV4_TCP		= 0x03,
+	IONIC_PKT_TYPE_IPV4_UDP		= 0x05,
+	IONIC_PKT_TYPE_IPV6		= 0x08,
+	IONIC_PKT_TYPE_IPV6_TCP		= 0x18,
+	IONIC_PKT_TYPE_IPV6_UDP		= 0x28,
 	/* below types are only used if encap offloads are enabled on lif */
-	IONIC_PKT_TYPE_ENCAP_NON_IP		= 0x40,
-	IONIC_PKT_TYPE_ENCAP_IPV4		= 0x41,
-	IONIC_PKT_TYPE_ENCAP_IPV4_TCP 	= 0x43,
+	IONIC_PKT_TYPE_ENCAP_NON_IP	= 0x40,
+	IONIC_PKT_TYPE_ENCAP_IPV4	= 0x41,
+	IONIC_PKT_TYPE_ENCAP_IPV4_TCP	= 0x43,
 	IONIC_PKT_TYPE_ENCAP_IPV4_UDP	= 0x45,
-	IONIC_PKT_TYPE_ENCAP_IPV6		= 0x48,
+	IONIC_PKT_TYPE_ENCAP_IPV6	= 0x48,
 	IONIC_PKT_TYPE_ENCAP_IPV6_TCP	= 0x58,
 	IONIC_PKT_TYPE_ENCAP_IPV6_UDP	= 0x68,
 };
@@ -1031,7 +1106,64 @@ enum ionic_eth_hw_features {
 	IONIC_ETH_HW_TSO_UDP_CSUM	= BIT(16),
 	IONIC_ETH_HW_RX_CSUM_GENEVE	= BIT(17),
 	IONIC_ETH_HW_TX_CSUM_GENEVE	= BIT(18),
-	IONIC_ETH_HW_TSO_GENEVE		= BIT(19)
+	IONIC_ETH_HW_TSO_GENEVE		= BIT(19),
+	IONIC_ETH_HW_TIMESTAMP		= BIT(20),
+};
+
+/**
+ * enum ionic_pkt_class - Packet classification mask.
+ *
+ * Used with rx steering filter, packets indicated by the mask can be steered
+ * toward a specific receive queue.
+ *
+ * @IONIC_PKT_CLS_NTP_ALL:          All NTP packets.
+ * @IONIC_PKT_CLS_PTP1_SYNC:        PTPv1 sync
+ * @IONIC_PKT_CLS_PTP1_DREQ:        PTPv1 delay-request
+ * @IONIC_PKT_CLS_PTP1_ALL:         PTPv1 all packets
+ * @IONIC_PKT_CLS_PTP2_L4_SYNC:     PTPv2-UDP sync
+ * @IONIC_PKT_CLS_PTP2_L4_DREQ:     PTPv2-UDP delay-request
+ * @IONIC_PKT_CLS_PTP2_L4_ALL:      PTPv2-UDP all packets
+ * @IONIC_PKT_CLS_PTP2_L2_SYNC:     PTPv2-ETH sync
+ * @IONIC_PKT_CLS_PTP2_L2_DREQ:     PTPv2-ETH delay-request
+ * @IONIC_PKT_CLS_PTP2_L2_ALL:      PTPv2-ETH all packets
+ * @IONIC_PKT_CLS_PTP2_SYNC:        PTPv2 sync
+ * @IONIC_PKT_CLS_PTP2_DREQ:        PTPv2 delay-request
+ * @IONIC_PKT_CLS_PTP2_ALL:         PTPv2 all packets
+ * @IONIC_PKT_CLS_PTP_SYNC:         PTP sync
+ * @IONIC_PKT_CLS_PTP_DREQ:         PTP delay-request
+ * @IONIC_PKT_CLS_PTP_ALL:          PTP all packets
+ */
+enum ionic_pkt_class {
+	IONIC_PKT_CLS_NTP_ALL		= BIT(0),
+
+	IONIC_PKT_CLS_PTP1_SYNC		= BIT(1),
+	IONIC_PKT_CLS_PTP1_DREQ		= BIT(2),
+	IONIC_PKT_CLS_PTP1_ALL		= BIT(3) |
+		IONIC_PKT_CLS_PTP1_SYNC | IONIC_PKT_CLS_PTP1_DREQ,
+
+	IONIC_PKT_CLS_PTP2_L4_SYNC	= BIT(4),
+	IONIC_PKT_CLS_PTP2_L4_DREQ	= BIT(5),
+	IONIC_PKT_CLS_PTP2_L4_ALL	= BIT(6) |
+		IONIC_PKT_CLS_PTP2_L4_SYNC | IONIC_PKT_CLS_PTP2_L4_DREQ,
+
+	IONIC_PKT_CLS_PTP2_L2_SYNC	= BIT(7),
+	IONIC_PKT_CLS_PTP2_L2_DREQ	= BIT(8),
+	IONIC_PKT_CLS_PTP2_L2_ALL	= BIT(9) |
+		IONIC_PKT_CLS_PTP2_L2_SYNC | IONIC_PKT_CLS_PTP2_L2_DREQ,
+
+	IONIC_PKT_CLS_PTP2_SYNC		=
+		IONIC_PKT_CLS_PTP2_L4_SYNC | IONIC_PKT_CLS_PTP2_L2_SYNC,
+	IONIC_PKT_CLS_PTP2_DREQ		=
+		IONIC_PKT_CLS_PTP2_L4_DREQ | IONIC_PKT_CLS_PTP2_L2_DREQ,
+	IONIC_PKT_CLS_PTP2_ALL		=
+		IONIC_PKT_CLS_PTP2_L4_ALL | IONIC_PKT_CLS_PTP2_L2_ALL,
+
+	IONIC_PKT_CLS_PTP_SYNC		=
+		IONIC_PKT_CLS_PTP1_SYNC | IONIC_PKT_CLS_PTP2_SYNC,
+	IONIC_PKT_CLS_PTP_DREQ		=
+		IONIC_PKT_CLS_PTP1_DREQ | IONIC_PKT_CLS_PTP2_DREQ,
+	IONIC_PKT_CLS_PTP_ALL		=
+		IONIC_PKT_CLS_PTP1_ALL | IONIC_PKT_CLS_PTP2_ALL,
 };
 
 /**
@@ -1123,6 +1255,8 @@ enum ionic_xcvr_pid {
 	IONIC_XCVR_PID_QSFP_100G_CWDM4  = 69,
 	IONIC_XCVR_PID_QSFP_100G_PSM4   = 70,
 	IONIC_XCVR_PID_SFP_25GBASE_ACC  = 71,
+	IONIC_XCVR_PID_SFP_10GBASE_T    = 72,
+	IONIC_XCVR_PID_SFP_1000BASE_T   = 73,
 };
 
 /**
@@ -1237,9 +1371,9 @@ union ionic_port_config {
  * @status:             link status (enum ionic_port_oper_status)
  * @id:                 port id
  * @speed:              link speed (in Mbps)
- * @link_down_count:    number of times link went from from up to down
+ * @link_down_count:    number of times link went from up to down
  * @fec_type:           fec type (enum ionic_port_fec_type)
- * @xcvr:               tranceiver status
+ * @xcvr:               transceiver status
  */
 struct ionic_port_status {
 	__le32 id;
@@ -1327,11 +1461,25 @@ enum ionic_stats_ctl_cmd {
 };
 
 /**
+ * enum ionic_txstamp_mode - List of TX Timestamping Modes
+ * @IONIC_TXSTAMP_OFF:           Disable TX hardware timetamping.
+ * @IONIC_TXSTAMP_ON:            Enable local TX hardware timetamping.
+ * @IONIC_TXSTAMP_ONESTEP_SYNC:  Modify TX PTP Sync packets.
+ * @IONIC_TXSTAMP_ONESTEP_P2P:   Modify TX PTP Sync and PDelayResp.
+ */
+enum ionic_txstamp_mode {
+	IONIC_TXSTAMP_OFF		= 0,
+	IONIC_TXSTAMP_ON		= 1,
+	IONIC_TXSTAMP_ONESTEP_SYNC	= 2,
+	IONIC_TXSTAMP_ONESTEP_P2P	= 3,
+};
+
+/**
  * enum ionic_port_attr - List of device attributes
  * @IONIC_PORT_ATTR_STATE:      Port state attribute
  * @IONIC_PORT_ATTR_SPEED:      Port speed attribute
  * @IONIC_PORT_ATTR_MTU:        Port MTU attribute
- * @IONIC_PORT_ATTR_AUTONEG:    Port autonegotation attribute
+ * @IONIC_PORT_ATTR_AUTONEG:    Port autonegotiation attribute
  * @IONIC_PORT_ATTR_FEC:        Port FEC attribute
  * @IONIC_PORT_ATTR_PAUSE:      Port pause attribute
  * @IONIC_PORT_ATTR_LOOPBACK:   Port loopback attribute
@@ -1568,6 +1716,7 @@ enum ionic_rss_hash_types {
  * @IONIC_LIF_ATTR_FEATURES:    LIF features attribute
  * @IONIC_LIF_ATTR_RSS:         LIF RSS attribute
  * @IONIC_LIF_ATTR_STATS_CTRL:  LIF statistics control attribute
+ * @IONIC_LIF_ATTR_TXSTAMP:     LIF TX timestamping mode
  */
 enum ionic_lif_attr {
 	IONIC_LIF_ATTR_STATE        = 0,
@@ -1577,6 +1726,7 @@ enum ionic_lif_attr {
 	IONIC_LIF_ATTR_FEATURES     = 4,
 	IONIC_LIF_ATTR_RSS          = 5,
 	IONIC_LIF_ATTR_STATS_CTRL   = 6,
+	IONIC_LIF_ATTR_TXSTAMP      = 7,
 };
 
 /**
@@ -1594,6 +1744,7 @@ enum ionic_lif_attr {
  *              @key:       The hash secret key
  *              @addr:      Address for the indirection table shared memory
  * @stats_ctl:  stats control commands (enum ionic_stats_ctl_cmd)
+ * @txstamp:    TX Timestamping Mode (enum ionic_txstamp_mode)
  */
 struct ionic_lif_setattr_cmd {
 	u8     opcode;
@@ -1612,6 +1763,7 @@ struct ionic_lif_setattr_cmd {
 			__le64 addr;
 		} rss;
 		u8      stats_ctl;
+		__le16 txstamp_mode;
 		u8      rsvd[60];
 	} __attribute__((packed));
 };
@@ -1656,6 +1808,7 @@ struct ionic_lif_getattr_cmd {
  * @mtu:        Mtu
  * @mac:        Station mac
  * @features:   Features (enum ionic_eth_hw_features)
+ * @txstamp:    TX Timestamping Mode (enum ionic_txstamp_mode)
  * @color:      Color bit
  */
 struct ionic_lif_getattr_comp {
@@ -1667,10 +1820,36 @@ struct ionic_lif_getattr_comp {
 		__le32  mtu;
 		u8      mac[6];
 		__le64  features;
+		__le16 txstamp_mode;
 		u8      rsvd2[11];
 	} __attribute__((packed));
 	u8     color;
 };
+
+/**
+ * struct ionic_lif_setphc_cmd - Set LIF PTP Hardware Clock
+ * @opcode:     Opcode
+ * @lif_index:  LIF index
+ * @tick:       Hardware stamp tick of an instant in time.
+ * @nsec:       Nanosecond stamp of the same instant.
+ * @frac:       Fractional nanoseconds at the same instant.
+ * @mult:       Cycle to nanosecond multiplier.
+ * @shift:      Cycle to nanosecond divisor (power of two).
+ */
+struct ionic_lif_setphc_cmd {
+	u8	opcode;
+	u8	rsvd1;
+	__le16  lif_index;
+	u8      rsvd2[4];
+	__le64	tick;
+	__le64	nsec;
+	__le64	frac;
+	__le32	mult;
+	__le32	shift;
+	u8     rsvd3[24];
+};
+
+IONIC_CHECK_CMD_LENGTH(ionic_lif_setphc_cmd);
 
 enum ionic_rx_mode {
 	IONIC_RX_MODE_F_UNICAST		= BIT(0),
@@ -1704,9 +1883,10 @@ struct ionic_rx_mode_set_cmd {
 typedef struct ionic_admin_comp ionic_rx_mode_set_comp;
 
 enum ionic_rx_filter_match_type {
-	IONIC_RX_FILTER_MATCH_VLAN = 0,
-	IONIC_RX_FILTER_MATCH_MAC,
-	IONIC_RX_FILTER_MATCH_MAC_VLAN,
+	IONIC_RX_FILTER_MATCH_VLAN	= 0x0,
+	IONIC_RX_FILTER_MATCH_MAC	= 0x1,
+	IONIC_RX_FILTER_MATCH_MAC_VLAN	= 0x2,
+	IONIC_RX_FILTER_STEER_PKTCLASS	= 0x10,
 };
 
 /**
@@ -1723,6 +1903,7 @@ enum ionic_rx_filter_match_type {
  * @mac_vlan:   MACVLAN filter
  *              @vlan:  VLAN ID
  *              @addr:  MAC address (network-byte order)
+ * @pkt_class:  Packet classification filter
  */
 struct ionic_rx_filter_add_cmd {
 	u8     opcode;
@@ -1741,8 +1922,9 @@ struct ionic_rx_filter_add_cmd {
 			__le16 vlan;
 			u8     addr[6];
 		} mac_vlan;
+		__le64 pkt_class;
 		u8 rsvd[54];
-	};
+	} __attribute__((packed));
 };
 
 /**
@@ -1942,7 +2124,7 @@ enum ionic_qos_sched_type {
  *	IONIC_QOS_CONFIG_F_NO_DROP		drop/nodrop
  *	IONIC_QOS_CONFIG_F_RW_DOT1Q_PCP		enable dot1q pcp rewrite
  *	IONIC_QOS_CONFIG_F_RW_IP_DSCP		enable ip dscp rewrite
- *	IONIC_QOS_CONFIG_F_NON_DISRUPTIVE 	Non-disruptive TC update
+ *	IONIC_QOS_CONFIG_F_NON_DISRUPTIVE	Non-disruptive TC update
  * @sched_type:		QoS class scheduling type (enum ionic_qos_sched_type)
  * @class_type:		QoS class type (enum ionic_qos_class_type)
  * @pause_type:		QoS pause type (enum ionic_qos_pause_type)
@@ -1951,8 +2133,8 @@ enum ionic_qos_sched_type {
  * @pfc_cos:		Priority-Flow Control class of service
  * @dwrr_weight:	QoS class scheduling weight
  * @strict_rlmt:	Rate limit for strict priority scheduling
- * @rw_dot1q_pcp:	Rewrite dot1q pcp to this value	(valid iff F_RW_DOT1Q_PCP)
- * @rw_ip_dscp:		Rewrite ip dscp to this value	(valid iff F_RW_IP_DSCP)
+ * @rw_dot1q_pcp:	Rewrite dot1q pcp to value (valid iff F_RW_DOT1Q_PCP)
+ * @rw_ip_dscp:		Rewrite ip dscp to value (valid iff F_RW_IP_DSCP)
  * @dot1q_pcp:		Dot1q pcp value
  * @ndscp:		Number of valid dscp values in the ip_dscp field
  * @ip_dscp:		IP dscp values
@@ -1965,7 +2147,7 @@ union ionic_qos_config {
 #define IONIC_QOS_CONFIG_F_RW_DOT1Q_PCP		BIT(2)
 #define IONIC_QOS_CONFIG_F_RW_IP_DSCP		BIT(3)
 /* Non-disruptive TC update */
-#define IONIC_QOS_CONFIG_F_NON_DISRUPTIVE 	BIT(4)
+#define IONIC_QOS_CONFIG_F_NON_DISRUPTIVE	BIT(4)
 		u8      flags;
 		u8      sched_type;
 		u8      class_type;
@@ -2088,6 +2270,7 @@ enum ionic_fw_control_oper {
 	IONIC_FW_INSTALL_STATUS		= 4,
 	IONIC_FW_ACTIVATE_ASYNC		= 5,
 	IONIC_FW_ACTIVATE_STATUS	= 6,
+	IONIC_FW_UPDATE_CLEANUP		= 7,
 };
 
 /**
@@ -2218,6 +2401,7 @@ IONIC_CHECK_COMP_LENGTH(ionic_hii_identify_comp);
  */
 enum ionic_hii_capabilities {
 	IONIC_HII_CAPABILITY_NCSI = 0,
+	IONIC_HII_CAPABILITY_OOB  = 1,
 };
 
 /**
@@ -2364,7 +2548,9 @@ struct ionic_hii_getattr_comp {
 	u8     color;
 };
 
+#ifndef __CHECKER__
 IONIC_CHECK_COMP_LENGTH(ionic_hii_getattr_comp);
+#endif
 
 /**
  * struct ionic_hii_reset_cmd - HII configuration reset command
@@ -2985,6 +3171,16 @@ union ionic_dev_cmd_comp {
 };
 
 /**
+ * struct ionic_hwstamp_regs - Hardware current timestamp registers
+ * @tick_low:        Low 32 bits of hardware timestamp
+ * @tick_high:       High 32 bits of hardware timestamp
+ */
+struct ionic_hwstamp_regs {
+	u32    tick_low;
+	u32    tick_high;
+};
+
+/**
  * union ionic_dev_info_regs - Device info register format (read-only)
  * @signature:       Signature value of 0x44455649 ('DEVI')
  * @version:         Current version of info
@@ -2994,6 +3190,7 @@ union ionic_dev_cmd_comp {
  * @fw_heartbeat:    Firmware heartbeat counter
  * @serial_num:      Serial number
  * @fw_version:      Firmware version
+ * @hwstamp_regs:    Hardware current timestamp registers
  */
 union ionic_dev_info_regs {
 #define IONIC_DEVINFO_FWVERS_BUFLEN 32
@@ -3008,6 +3205,8 @@ union ionic_dev_info_regs {
 		u32    fw_heartbeat;
 		char   fw_version[IONIC_DEVINFO_FWVERS_BUFLEN];
 		char   serial_num[IONIC_DEVINFO_SERIAL_BUFLEN];
+		u8     rsvd_pad1024[948];
+		struct ionic_hwstamp_regs hwstamp;
 	};
 	u32 words[512];
 };
@@ -3055,6 +3254,7 @@ union ionic_adminq_cmd {
 	struct ionic_q_control_cmd q_control;
 	struct ionic_lif_setattr_cmd lif_setattr;
 	struct ionic_lif_getattr_cmd lif_getattr;
+	struct ionic_lif_setphc_cmd lif_setphc;
 	struct ionic_rx_mode_set_cmd rx_mode_set;
 	struct ionic_rx_filter_add_cmd rx_filter_add;
 	struct ionic_rx_filter_del_cmd rx_filter_del;
@@ -3071,6 +3271,7 @@ union ionic_adminq_comp {
 	struct ionic_q_init_comp q_init;
 	struct ionic_lif_setattr_comp lif_setattr;
 	struct ionic_lif_getattr_comp lif_getattr;
+	struct ionic_admin_comp lif_setphc;
 	struct ionic_rx_filter_add_comp rx_filter_add;
 	ionic_fw_download_comp fw_download;
 	struct ionic_fw_control_comp fw_control;

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -3,7 +3,7 @@ obj-$(CONFIG_IONIC) += eth/ionic/
 obj-$(CONFIG_IONIC_MNIC) += eth/ionic/
 obj-$(CONFIG_MNET) += mnet/
 obj-$(CONFIG_MNET_UIO_PDRV_GENIRQ) += mnet_uio_pdrv_genirq/
-obj-$(CONFIG_INFINIBAND_IONIC) += rdma/drv/ionic/
+#obj-$(CONFIG_INFINIBAND_IONIC) += rdma/drv/ionic/
 else
 
 IONIC_ETH_SRC = $(CURDIR)/eth/ionic
@@ -19,7 +19,6 @@ ETH_KOPT += CONFIG_INFINIBAND_IONIC=_
 RDMA_KOPT += CONFIG_INFINIBAND_IONIC=m
 
 default: all
-ALL = eth
 
 # Discover kernel and open fabrics configuration.
 #
@@ -35,12 +34,15 @@ ifeq ($(ARCH),aarch64)
 
 # Ionic mnic and mnet for drivers ARM
 include ${MKINFRA}/config_${ARCH}.mk
-KSRC ?= $(AARCH64_LINUX_HEADERS)
+KSRC ?= ${NICDIR}/buildroot/output/${ASIC}/linux-headers
+KMOD_OUT_DIR ?= ${BLD_OUT_DIR}/drivers_submake
+KMOD_SRC_DIR ?= ${TOPDIR}/platform/drivers/linux
 ETH_KOPT += CONFIG_IONIC_MNIC=m
 ETH_KOPT += CONFIG_MNET=m
 ETH_KOPT += CONFIG_MNET_UIO_PDRV_GENIRQ=m
 ETH_KOPT += CROSS_COMPILE=aarch64-linux-gnu-
 ETH_KOPT += ARCH=arm64
+ALL = mnic
 ALL += mnet
 ALL += mnet_uio_pdrv_genirq
 export PATH := $(PATH):$(TOOLCHAIN_DIR)/bin
@@ -48,6 +50,8 @@ export PATH := $(PATH):$(TOOLCHAIN_DIR)/bin
 else
 
 # Ionic driver for host
+include linux_ver.mk
+
 KSRC ?= /lib/modules/$(shell uname -r)/build
 ETH_KOPT += CONFIG_IONIC=m
 ETH_KOPT += CONFIG_IONIC_MNIC=_
@@ -55,9 +59,9 @@ ETH_KOPT += CONFIG_MNET=_
 ETH_KOPT += CONFIG_MNET_UIO_PDRV_GENIRQ=_
 
 KCFLAGS = -Werror
-
-include linux_ver.mk
 KCFLAGS += $(EXTRA_CFLAGS)
+
+ALL = eth
 
 # Ionic rdma driver, if present
 ifneq ($(wildcard $(IONIC_RDMA_SRC)),)
@@ -95,7 +99,7 @@ DVER = $(shell echo $$SW_VERSION)
 ifeq ($(DVER),)
   DVER = $(shell git describe --tags 2>/dev/null)
   ifeq ($(DVER),)
-    DVER = "0.0.0"
+    DVER = "1.15.4.8"
   endif
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
@@ -105,15 +109,22 @@ KOPT += KCFLAGS="$(KCFLAGS)"
 all: $(ALL)
 
 KBUILD_RULE = $(MAKE) -C $(KSRC) $(KOPT) M=$(CURDIR)
-mnet: eth mnet_uio_pdrv_genirq
+
+mnic: KOPT+=$(ETH_KOPT)
+mnic:
+	@echo "===> Building MNIC driver "
+	touch $(BLD_OUT_DIR)/drivers_submake/Makefile
+	$(MAKE) -C $(KSRC) V=1 M=$(KMOD_OUT_DIR) src=$(KMOD_SRC_DIR)/eth/ionic $(KOPT)
+
 mnet: KOPT+=$(ETH_KOPT)
-mnet:
-	$(KBUILD_RULE)
+mnet: mnet_uio_pdrv_genirq
+	@echo "===> Building MNET driver "
+	$(MAKE) -C $(KSRC) V=1 M=$(KMOD_OUT_DIR) src=$(KMOD_SRC_DIR)/mnet $(KOPT)
 
 mnet_uio_pdrv_genirq: KOPT+=$(ETH_KOPT)
 mnet_uio_pdrv_genirq:
-	$(KBUILD_RULE)
-
+	@echo "===> Building MNET_UIO driver "
+	$(MAKE) -C $(KSRC) V=1 M=$(KMOD_OUT_DIR) src=$(KMOD_SRC_DIR)/mnet_uio_pdrv_genirq $(KOPT)
 
 eth: KOPT+=$(ETH_KOPT)
 eth:
@@ -139,6 +150,6 @@ cscope:
 	find $(IONIC_ETH_SRC) $(IONIC_RDMA_SRC) -name '*.[ch]' > cscope.files
 	cscope -bkq
 
-.PHONY: default all eth rdma clean install modules_install cscope
+.PHONY: default all mnic mnet mnet_uio_pdrv_genirq eth rdma clean install modules_install cscope
 
 endif

--- a/drivers/linux/eth/ionic/Makefile
+++ b/drivers/linux/eth/ionic/Makefile
@@ -9,7 +9,12 @@ ccflags-y := -I$(M)/../common -g
 
 ionic-y := ionic_main.o ionic_bus_pci.o ionic_dev.o ionic_ethtool.o \
 	   ionic_lif.o ionic_rx_filter.o ionic_txrx.o ionic_debugfs.o \
-	   ionic_api.o ionic_stats.o ionic_devlink.o kcompat.o ionic_fw.o
+	   ionic_api.o ionic_stats.o ionic_devlink.o kcompat.o ionic_fw.o \
+	   dim.o net_dim.o
+ionic-$(CONFIG_PTP_1588_CLOCK) += ionic_phc.o
+
 ionic_mnic-y := ionic_main.o ionic_bus_platform.o ionic_dev.o ionic_ethtool.o \
 	        ionic_lif.o ionic_rx_filter.o ionic_txrx.o ionic_debugfs.o \
-	        ionic_api.o ionic_stats.o ionic_devlink.o ionic_fw.o
+	        ionic_api.o ionic_stats.o ionic_devlink.o ionic_fw.o \
+		dim.o net_dim.o
+ionic_mnic-$(CONFIG_PTP_1588_CLOCK) += ionic_phc.o

--- a/drivers/linux/eth/ionic/ionic_api.h
+++ b/drivers/linux/eth/ionic/ionic_api.h
@@ -71,7 +71,7 @@ void *ionic_get_handle_from_netdev(struct net_device *netdev,
  * ionic_api_stay_registered() - stay registered through net interface changes
  * @handle:		Handle to lif
  *
- * Return: true if the slave device should ignore net deregistration events
+ * Return: true if the child device should ignore net deregistration events
  */
 bool ionic_api_stay_registered(void *handle);
 

--- a/drivers/linux/eth/ionic/ionic_debugfs.h
+++ b/drivers/linux/eth/ionic/ionic_debugfs.h
@@ -33,6 +33,7 @@ static inline void ionic_debugfs_add_bars(struct ionic *ionic) { }
 static inline void ionic_debugfs_add_dev_cmd(struct ionic *ionic) { }
 static inline void ionic_debugfs_add_ident(struct ionic *ionic) { }
 static inline void ionic_debugfs_add_sizes(struct ionic *ionic) { }
+static inline void ionic_debugfs_add_eq(struct ionic_eq *eq) { }
 static inline void ionic_debugfs_add_lif(struct ionic_lif *lif) { }
 static inline void ionic_debugfs_add_qcq(struct ionic_lif *lif, struct ionic_qcq *qcq) { }
 static inline void ionic_debugfs_del_lif(struct ionic_lif *lif) { }

--- a/drivers/linux/eth/ionic/ionic_devlink.h
+++ b/drivers/linux/eth/ionic/ionic_devlink.h
@@ -4,7 +4,11 @@
 #ifndef _IONIC_DEVLINK_H_
 #define _IONIC_DEVLINK_H_
 
+#if IS_ENABLED(CONFIG_NET_DEVLINK)
 #include <net/devlink.h>
+#endif
+
+int ionic_firmware_update(struct ionic_lif *lif, const char *fw_name);
 
 /* make sure we've got a new-enough devlink support to use dev info */
 #ifdef DEVLINK_INFO_VERSION_GENERIC_BOARD_ID
@@ -22,5 +26,12 @@ void ionic_devlink_unregister(struct ionic *ionic);
 #define ionic_devlink_register(x)    0
 #define ionic_devlink_unregister(x)
 #endif
+
+#if !IS_ENABLED(CONFIG_NET_DEVLINK)
+#define priv_to_devlink(i)  0
+#define devlink_flash_update_begin_notify(d)
+#define devlink_flash_update_end_notify(d)
+#define devlink_flash_update_status_notify(d, s, c, n, t)
+#endif /* CONFIG_NET_DEVLINK */
 
 #endif /* _IONIC_DEVLINK_H_ */

--- a/drivers/linux/eth/ionic/ionic_lif.c
+++ b/drivers/linux/eth/ionic/ionic_lif.c
@@ -7,7 +7,6 @@
 #include <linux/interrupt.h>
 #include <linux/pci.h>
 #include <linux/cpumask.h>
-#include <linux/if_macvlan.h>
 
 #include "ionic.h"
 #include "ionic_bus.h"
@@ -36,17 +35,28 @@ static void ionic_link_status_check(struct ionic_lif *lif);
 static void ionic_lif_handle_fw_down(struct ionic_lif *lif);
 static void ionic_lif_handle_fw_up(struct ionic_lif *lif);
 
+static void ionic_txrx_deinit(struct ionic_lif *lif);
+static int ionic_txrx_init(struct ionic_lif *lif);
 static int ionic_start_queues(struct ionic_lif *lif);
-static int ionic_lif_open(struct ionic_lif *lif);
+static int ionic_open(struct net_device *netdev);
 static void ionic_stop_queues(struct ionic_lif *lif);
-static int ionic_lif_stop(struct ionic_lif *lif);
-static struct ionic_lif *ionic_lif_alloc(struct ionic *ionic, unsigned int index);
-static int ionic_lif_init(struct ionic_lif *lif);
-static int ionic_lif_set_netdev_info(struct ionic_lif *lif);
-static void ionic_lif_deinit(struct ionic_lif *lif);
-static void ionic_lif_free(struct ionic_lif *lif);
+static int ionic_stop(struct net_device *netdev);
 static void ionic_lif_queue_identify(struct ionic_lif *lif);
-static int ionic_lif_set_netdev_info(struct ionic_lif *lif);
+static void ionic_lif_set_netdev_info(struct ionic_lif *lif);
+
+static void ionic_dim_work(struct work_struct *work)
+{
+	struct dim *dim = container_of(work, struct dim, work);
+	struct dim_cq_moder cur_moder;
+	struct ionic_qcq *qcq;
+	u32 new_coal;
+
+	cur_moder = net_dim_get_rx_moderation(dim->mode, dim->profile_ix);
+	qcq = container_of(dim, struct ionic_qcq, dim);
+	new_coal = ionic_coal_usec_to_hw(qcq->q.lif->ionic, cur_moder.usec);
+	qcq->intr.dim_coal_hw = new_coal ? new_coal : 1;
+	dim->state = DIM_START_MEASURE;
+}
 
 static void ionic_lif_deferred_work(struct work_struct *work)
 {
@@ -54,15 +64,18 @@ static void ionic_lif_deferred_work(struct work_struct *work)
 	struct ionic_deferred *def = &lif->deferred;
 	struct ionic_deferred_work *w = NULL;
 
-	spin_lock_bh(&def->lock);
-	if (!list_empty(&def->list)) {
-		w = list_first_entry(&def->list,
-				     struct ionic_deferred_work, list);
-		list_del(&w->list);
-	}
-	spin_unlock_bh(&def->lock);
+	do {
+		spin_lock_bh(&def->lock);
+		if (!list_empty(&def->list)) {
+			w = list_first_entry(&def->list,
+					     struct ionic_deferred_work, list);
+			list_del(&w->list);
+		}
+		spin_unlock_bh(&def->lock);
 
-	if (w) {
+		if (!w)
+			break;
+
 		switch (w->type) {
 		case IONIC_DW_TYPE_RX_MODE:
 			ionic_lif_rx_mode(lif, w->rx_mode);
@@ -82,10 +95,12 @@ static void ionic_lif_deferred_work(struct work_struct *work)
 			else
 				ionic_lif_handle_fw_down(lif);
 			break;
+		default:
+			break;
 		}
 		kfree(w);
-		schedule_work(&def->work);
-	}
+		w = NULL;
+	} while (true);
 }
 
 void ionic_lif_deferred_enqueue(struct ionic_deferred *def,
@@ -100,9 +115,7 @@ void ionic_lif_deferred_enqueue(struct ionic_deferred *def,
 static void ionic_link_status_check(struct ionic_lif *lif)
 {
 	struct net_device *netdev = lif->netdev;
-	struct ionic_lif *slif;
 	u16 link_status;
-	unsigned long i;
 	bool link_up;
 
 	/* If we're here but the bit is not set, then another thread
@@ -111,46 +124,44 @@ static void ionic_link_status_check(struct ionic_lif *lif)
 	if (!test_bit(IONIC_LIF_F_LINK_CHECK_REQUESTED, lif->state))
 		return;
 
+	/* Don't put carrier back up if we're in a broken state */
+	if (test_bit(IONIC_LIF_F_BROKEN, lif->state)) {
+		clear_bit(IONIC_LIF_F_LINK_CHECK_REQUESTED, lif->state);
+		return;
+	}
+
 	link_status = le16_to_cpu(lif->info->status.link_status);
 	link_up = link_status == IONIC_PORT_OPER_STATUS_UP;
 
 	if (link_up) {
+		int err = 0;
+
 		if (lif->netdev->flags & IFF_UP && netif_running(netdev)) {
 			mutex_lock(&lif->queue_lock);
-			ionic_start_queues(lif);
-
-			for_each_eth_lif(lif->ionic, i, slif)
-				if (!is_master_lif(slif))
-					ionic_start_queues(slif);
+			err = ionic_start_queues(lif);
+			if (err) {
+				netdev_err(lif->netdev,
+					   "Failed to start queues: %d\n", err);
+				set_bit(IONIC_LIF_F_BROKEN, lif->state);
+				netif_carrier_off(lif->netdev);
+			}
 			mutex_unlock(&lif->queue_lock);
 		}
 
-		if (!netif_carrier_ok(netdev)) {
+		if (!err && !netif_carrier_ok(netdev)) {
 			netdev_info(netdev, "Link up - %d Gbps\n",
-				    le32_to_cpu(lif->info->status.link_speed / 1000));
+				    le32_to_cpu(lif->info->status.link_speed) / 1000);
 			netif_carrier_on(netdev);
-
-			for_each_eth_lif(lif->ionic, i, slif)
-				if (!is_master_lif(slif))
-					netif_carrier_on(slif->upper_dev);
 		}
 	} else {
 		if (netif_carrier_ok(netdev)) {
 			netdev_info(netdev, "Link down\n");
 			netif_carrier_off(netdev);
-
-			for_each_eth_lif(lif->ionic, i, slif)
-				if (!is_master_lif(slif))
-					netif_carrier_off(slif->upper_dev);
 		}
 
 		if (lif->netdev->flags & IFF_UP && netif_running(netdev)) {
 			mutex_lock(&lif->queue_lock);
 			ionic_stop_queues(lif);
-
-			for_each_eth_lif(lif->ionic, i, slif)
-				if (!is_master_lif(slif))
-					ionic_stop_queues(slif);
 			mutex_unlock(&lif->queue_lock);
 		}
 	}
@@ -158,7 +169,7 @@ static void ionic_link_status_check(struct ionic_lif *lif)
 	clear_bit(IONIC_LIF_F_LINK_CHECK_REQUESTED, lif->state);
 }
 
-void ionic_link_status_check_request(struct ionic_lif *lif)
+void ionic_link_status_check_request(struct ionic_lif *lif, bool can_sleep)
 {
 	struct ionic_deferred_work *work;
 
@@ -166,10 +177,12 @@ void ionic_link_status_check_request(struct ionic_lif *lif)
 	if (test_and_set_bit(IONIC_LIF_F_LINK_CHECK_REQUESTED, lif->state))
 		return;
 
-	if (in_interrupt()) {
+	if (!can_sleep) {
 		work = kzalloc(sizeof(*work), GFP_ATOMIC);
-		if (!work)
+		if (!work) {
+			clear_bit(IONIC_LIF_F_LINK_CHECK_REQUESTED, lif->state);
 			return;
+		}
 
 		work->type = IONIC_DW_TYPE_LINK_STATUS;
 		ionic_lif_deferred_enqueue(&lif->deferred, work);
@@ -196,8 +209,6 @@ static int ionic_request_napi_irq(struct ionic_lif *lif, struct ionic_qcq *qcq)
 
 	if (lif->registered)
 		name = lif->netdev->name;
-	else if (!is_master_lif(lif) && lif->upper_dev)
-		name = lif->upper_dev->name;
 	else
 		name = dev_name(dev);
 
@@ -206,18 +217,6 @@ static int ionic_request_napi_irq(struct ionic_lif *lif, struct ionic_qcq *qcq)
 
 	return devm_request_irq(dev, intr->vector, ionic_napi_isr,
 				0, intr->name, &qcq->napi);
-}
-
-static int ionic_intr_remaining(struct ionic *ionic)
-{
-	int intrs_remaining;
-	unsigned long bit;
-
-	intrs_remaining = ionic->nintrs;
-	for_each_set_bit(bit, ionic->intrs, ionic->nintrs)
-		intrs_remaining--;
-
-	return intrs_remaining;
 }
 
 int ionic_intr_alloc(struct ionic *ionic, struct ionic_intr_info *intr)
@@ -293,41 +292,51 @@ static int ionic_qcq_enable(struct ionic_qcq *qcq)
 	return 0;
 }
 
-static int ionic_qcq_disable(struct ionic_qcq *qcq)
+static int ionic_qcq_disable(struct ionic_qcq *qcq, bool send_to_hw)
 {
-	struct ionic_queue *q = &qcq->q;
-	struct ionic_lif *lif = q->lif;
-	struct ionic_dev *idev;
-	struct device *dev;
+	struct ionic_queue *q;
+	struct ionic_lif *lif;
+	int err = 0;
 
 	struct ionic_admin_ctx ctx = {
 		.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
 		.cmd.q_control = {
 			.opcode = IONIC_CMD_Q_CONTROL,
-			.lif_index = cpu_to_le16(lif->index),
-			.type = q->type,
-			.index = cpu_to_le32(q->index),
 			.oper = IONIC_Q_DISABLE,
 		},
 	};
 
-	idev = &lif->ionic->idev;
-	dev = lif->ionic->dev;
+	if (!qcq) {
+		pr_err("%s: bad qcq\n", __func__);
+		return -ENXIO;
+	}
 
-	dev_dbg(dev, "q_disable.index %d q_disable.qtype %d\n",
-		ctx.cmd.q_control.index, ctx.cmd.q_control.type);
+	q = &qcq->q;
+	lif = q->lif;
 
 	if (qcq->napi.poll)
 		napi_disable(&qcq->napi);
 
 	if (qcq->flags & IONIC_QCQ_F_INTR) {
+		struct ionic_dev *idev = &lif->ionic->idev;
+
 		ionic_intr_mask(idev->intr_ctrl, qcq->intr.index,
 				IONIC_INTR_MASK_SET);
 		synchronize_irq(qcq->intr.vector);
 		irq_set_affinity_hint(qcq->intr.vector, NULL);
 	}
 
-	return ionic_adminq_post_wait(lif, &ctx);
+	if (send_to_hw) {
+		ctx.cmd.q_control.lif_index = cpu_to_le16(lif->index);
+		ctx.cmd.q_control.type = q->type;
+		ctx.cmd.q_control.index = cpu_to_le32(q->index);
+		dev_dbg(lif->ionic->dev, "q_disable.index %d q_disable.qtype %d\n",
+			ctx.cmd.q_control.index, ctx.cmd.q_control.type);
+
+		err = ionic_adminq_post_wait(lif, &ctx);
+	}
+
+	return err;
 }
 
 static void ionic_lif_qcq_deinit(struct ionic_lif *lif, struct ionic_qcq *qcq)
@@ -349,6 +358,18 @@ static void ionic_lif_qcq_deinit(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	qcq->flags &= ~IONIC_QCQ_F_INITED;
 }
 
+static void ionic_qcq_intr_free(struct ionic_lif *lif, struct ionic_qcq *qcq)
+{
+	if (!(qcq->flags & IONIC_QCQ_F_INTR) || qcq->intr.vector == 0)
+		return;
+
+	irq_set_affinity_hint(qcq->intr.vector, NULL);
+	devm_free_irq(lif->ionic->dev, qcq->intr.vector, &qcq->napi);
+	qcq->intr.vector = 0;
+	ionic_intr_free(lif->ionic, qcq->intr.index);
+	qcq->intr.index = IONIC_INTR_INDEX_NOT_ASSIGNED;
+}
+
 static void ionic_qcq_free(struct ionic_lif *lif, struct ionic_qcq *qcq)
 {
 	struct device *dev = lif->ionic->dev;
@@ -356,66 +377,65 @@ static void ionic_qcq_free(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	if (!qcq)
 		return;
 
+	cancel_work_sync(&qcq->dim.work);
 	ionic_debugfs_del_qcq(qcq);
 
-	dma_free_coherent(dev, qcq->total_size, qcq->base, qcq->base_pa);
-	qcq->base = NULL;
-	qcq->base_pa = 0;
-
-	/* only the slave Tx and Rx qcqs will have master_slot set */
-	if (qcq->master_slot) {
-		struct ionic_lif *master_lif = lif->ionic->master_lif;
-		int max = master_lif->nxqs + (lif->ionic->nlifs - 1);
-
-		if (qcq->master_slot >= max)
-			dev_err(dev, "bad slot number %d\n", qcq->master_slot);
-		else if (qcq->flags & IONIC_QCQ_F_TX_STATS)
-			master_lif->txqcqs[qcq->master_slot].qcq = NULL;
-		else
-			master_lif->rxqcqs[qcq->master_slot].qcq = NULL;
+	if (qcq->q_base) {
+		dma_free_coherent(dev, qcq->q_size, qcq->q_base, qcq->q_base_pa);
+		qcq->q_base = NULL;
+		qcq->q_base_pa = 0;
 	}
 
-	if (qcq->flags & IONIC_QCQ_F_INTR) {
-		irq_set_affinity_hint(qcq->intr.vector, NULL);
-		devm_free_irq(dev, qcq->intr.vector, &qcq->napi);
-		qcq->intr.vector = 0;
-		ionic_intr_free(lif->ionic, qcq->intr.index);
+	if (qcq->cq_base) {
+		dma_free_coherent(dev, qcq->cq_size, qcq->cq_base, qcq->cq_base_pa);
+		qcq->cq_base = NULL;
+		qcq->cq_base_pa = 0;
 	}
 
-	devm_kfree(dev, qcq->cq.info);
-	qcq->cq.info = NULL;
-	devm_kfree(dev, qcq->q.info);
-	qcq->q.info = NULL;
-	devm_kfree(dev, qcq);
+	if (qcq->sg_base) {
+		dma_free_coherent(dev, qcq->sg_size, qcq->sg_base, qcq->sg_base_pa);
+		qcq->sg_base = NULL;
+		qcq->sg_base_pa = 0;
+	}
+
+	ionic_qcq_intr_free(lif, qcq);
+
+	if (qcq->cq.info) {
+		devm_kfree(dev, qcq->cq.info);
+		qcq->cq.info = NULL;
+	}
+	if (qcq->q.info) {
+		devm_kfree(dev, qcq->q.info);
+		qcq->q.info = NULL;
+	}
 }
 
 static void ionic_qcqs_free(struct ionic_lif *lif)
 {
 	struct device *dev = lif->ionic->dev;
-	unsigned int i;
 
 	if (lif->notifyqcq) {
 		ionic_qcq_free(lif, lif->notifyqcq);
+		devm_kfree(dev, lif->notifyqcq);
 		lif->notifyqcq = NULL;
 	}
 
 	if (lif->adminqcq) {
 		ionic_qcq_free(lif, lif->adminqcq);
+		devm_kfree(dev, lif->adminqcq);
 		lif->adminqcq = NULL;
 	}
 
 	if (lif->rxqcqs) {
-		for (i = 0; i < lif->nxqs; i++)
-			if (lif->rxqcqs[i].stats)
-				devm_kfree(dev, lif->rxqcqs[i].stats);
+		devm_kfree(dev, lif->rxqstats);
+		lif->rxqstats = NULL;
 		devm_kfree(dev, lif->rxqcqs);
 		lif->rxqcqs = NULL;
 	}
 
 	if (lif->txqcqs) {
-		for (i = 0; i < lif->nxqs; i++)
-			if (lif->txqcqs[i].stats)
-				devm_kfree(dev, lif->txqcqs[i].stats);
+		devm_kfree(dev, lif->txqstats);
+		lif->txqstats = NULL;
 		devm_kfree(dev, lif->txqcqs);
 		lif->txqcqs = NULL;
 	}
@@ -433,6 +453,71 @@ static void ionic_link_qcq_interrupts(struct ionic_qcq *src_qcq,
 	n_qcq->intr.index = src_qcq->intr.index;
 }
 
+static int ionic_alloc_qcq_interrupt(struct ionic_lif *lif, struct ionic_qcq *qcq)
+{
+	unsigned int cpu;
+	int err;
+
+	if (!(qcq->flags & IONIC_QCQ_F_INTR)) {
+		qcq->intr.index = IONIC_INTR_INDEX_NOT_ASSIGNED;
+		return 0;
+	}
+
+	err = ionic_intr_alloc(lif->ionic, &qcq->intr);
+	if (err) {
+		netdev_warn(lif->netdev, "no intr for %s: %d\n",
+			    qcq->q.name, err);
+		goto err_out;
+	}
+
+	err = ionic_bus_get_irq(lif->ionic, qcq->intr.index);
+	if (err < 0) {
+		netdev_warn(lif->netdev, "no vector for %s: %d\n",
+			    qcq->q.name, err);
+		goto err_out_free_intr;
+	}
+	qcq->intr.vector = err;
+	ionic_intr_mask_assert(lif->ionic->idev.intr_ctrl, qcq->intr.index,
+			       IONIC_INTR_MASK_SET);
+
+	err = ionic_request_napi_irq(lif, qcq);
+	if (err) {
+		netdev_warn(lif->netdev, "irq request failed %d\n", err);
+		goto err_out_free_intr;
+	}
+
+	if (affinity_mask_override) {
+		cpumask_copy(&qcq->intr.affinity_mask, cpu_none_mask);
+
+		netdev_dbg(lif->netdev, "%s: setting irq affinity_mask 0x%lx\n",
+				qcq->q.name, affinity_mask_override);
+		for (cpu = 0; cpu < num_present_cpus(); cpu++) {
+			if (BIT(cpu) & affinity_mask_override)
+				cpumask_set_cpu(cpu, &qcq->intr.affinity_mask);
+		}
+
+		/* set the affinity */
+		irq_set_affinity_hint(qcq->intr.vector, &qcq->intr.affinity_mask);
+
+	} else {
+		netdev_dbg(lif->netdev, "%s: using default irq affinity", qcq->q.name);
+		/* try to get the irq on the local numa node first */
+		qcq->intr.cpu = cpumask_local_spread(qcq->intr.index,
+				dev_to_node(lif->ionic->dev));
+		if (qcq->intr.cpu != -1)
+			cpumask_set_cpu(qcq->intr.cpu,
+					&qcq->intr.affinity_mask);
+	}
+
+	netdev_dbg(lif->netdev, "%s: Interrupt index %d\n", qcq->q.name, qcq->intr.index);
+	return 0;
+
+err_out_free_intr:
+	ionic_intr_free(lif->ionic, qcq->intr.index);
+err_out:
+	return err;
+}
+
 static int ionic_qcq_alloc(struct ionic_lif *lif, unsigned int type,
 			   unsigned int index,
 			   const char *name, unsigned int flags,
@@ -442,32 +527,15 @@ static int ionic_qcq_alloc(struct ionic_lif *lif, unsigned int type,
 			   unsigned int pid, struct ionic_qcq **qcq)
 {
 	struct ionic_dev *idev = &lif->ionic->idev;
-	u32 q_size, cq_size, sg_size, total_size;
 	struct device *dev = lif->ionic->dev;
 	void *q_base, *cq_base, *sg_base;
 	dma_addr_t cq_base_pa = 0;
 	dma_addr_t sg_base_pa = 0;
 	dma_addr_t q_base_pa = 0;
 	struct ionic_qcq *new;
-	unsigned int cpu;
 	int err;
 
 	*qcq = NULL;
-
-	q_size  = num_descs * desc_size;
-	cq_size = num_descs * cq_desc_size;
-	sg_size = num_descs * sg_desc_size;
-
-	total_size = ALIGN(q_size, PAGE_SIZE) + ALIGN(cq_size, PAGE_SIZE);
-	/* Note: aligning q_size/cq_size is not enough due to cq_base
-	 * address aligning as q_base could be not aligned to the page.
-	 * Adding PAGE_SIZE.
-	 */
-	total_size += PAGE_SIZE;
-	if (flags & IONIC_QCQ_F_SG) {
-		total_size += ALIGN(sg_size, PAGE_SIZE);
-		total_size += PAGE_SIZE;
-	}
 
 	new = devm_kzalloc(dev, sizeof(*new), GFP_KERNEL);
 	if (!new) {
@@ -479,12 +547,12 @@ static int ionic_qcq_alloc(struct ionic_lif *lif, unsigned int type,
 	new->q.dev = dev;
 	new->flags = flags;
 
-	new->q.info = devm_kzalloc(dev, sizeof(*new->q.info) * num_descs,
+	new->q.info = devm_kcalloc(dev, num_descs, sizeof(*new->q.info),
 				   GFP_KERNEL);
 	if (!new->q.info) {
 		netdev_err(lif->netdev, "Cannot allocate queue info\n");
 		err = -ENOMEM;
-		goto err_out;
+		goto err_out_free_qcq;
 	}
 
 	new->q.type = type;
@@ -494,61 +562,14 @@ static int ionic_qcq_alloc(struct ionic_lif *lif, unsigned int type,
 			   desc_size, sg_desc_size, pid);
 	if (err) {
 		netdev_err(lif->netdev, "Cannot initialize queue\n");
+		goto err_out_free_q_info;
+	}
+
+	err = ionic_alloc_qcq_interrupt(lif, new);
+	if (err)
 		goto err_out;
-	}
 
-	if (flags & IONIC_QCQ_F_INTR) {
-		err = ionic_intr_alloc(lif->ionic, &new->intr);
-		if (err) {
-			netdev_warn(lif->netdev, "no intr for %s: %d\n",
-				    name, err);
-			goto err_out;
-		}
-
-		err = ionic_bus_get_irq(lif->ionic, new->intr.index);
-		if (err < 0) {
-			netdev_warn(lif->netdev, "no vector for %s: %d\n",
-				    name, err);
-			goto err_out_free_intr;
-		}
-		new->intr.vector = err;
-		ionic_intr_mask_assert(idev->intr_ctrl, new->intr.index,
-				       IONIC_INTR_MASK_SET);
-
-		err = ionic_request_napi_irq(lif, new);
-		if (err) {
-			netdev_warn(lif->netdev, "irq request failed %d\n", err);
-			goto err_out_free_intr;
-		}
-
-		if (affinity_mask_override) {
-			cpumask_copy(&new->intr.affinity_mask, cpu_none_mask);
-
-			netdev_dbg(lif->netdev, "%s: setting irq affinity_mask 0x%lx\n",
-					name, affinity_mask_override);
-			for (cpu = 0; cpu < num_present_cpus(); cpu++) {
-				if (BIT(cpu) & affinity_mask_override)
-					cpumask_set_cpu(cpu, &new->intr.affinity_mask);
-			}
-
-			/* set the affinity */
-			irq_set_affinity_hint(new->intr.vector, &new->intr.affinity_mask);
-
-		} else {
-			netdev_dbg(lif->netdev, "%s: using default irq affinity", name);
-			/* try to get the irq on the local numa node first */
-			new->intr.cpu = cpumask_local_spread(new->intr.index,
-					dev_to_node(dev));
-			if (new->intr.cpu != -1)
-				cpumask_set_cpu(new->intr.cpu,
-						&new->intr.affinity_mask);
-		}
-	} else {
-		netdev_dbg(lif->netdev, "%s: Interrupt index not assigned\n", name);
-		new->intr.index = IONIC_INTR_INDEX_NOT_ASSIGNED;
-	}
-
-	new->cq.info = devm_kzalloc(dev, sizeof(*new->cq.info) * num_descs,
+	new->cq.info = devm_kcalloc(dev, num_descs, sizeof(*new->cq.info),
 				    GFP_KERNEL);
 	if (!new->cq.info) {
 		netdev_err(lif->netdev, "Cannot allocate completion queue info\n");
@@ -559,46 +580,93 @@ static int ionic_qcq_alloc(struct ionic_lif *lif, unsigned int type,
 	err = ionic_cq_init(lif, &new->cq, &new->intr, num_descs, cq_desc_size);
 	if (err) {
 		netdev_err(lif->netdev, "Cannot initialize completion queue\n");
-		goto err_out_free_irq;
+		goto err_out_free_cq_info;
 	}
 
-	new->base = dma_alloc_coherent(dev, total_size, &new->base_pa,
-				       GFP_KERNEL);
-	if (!new->base) {
-		netdev_err(lif->netdev, "Cannot allocate queue DMA memory\n");
-		err = -ENOMEM;
-		goto err_out_free_irq;
+	if (flags & IONIC_QCQ_F_NOTIFYQ) {
+		/* q & cq need to be contiguous in case of notifyq */
+		new->q_size = PAGE_SIZE + ALIGN(num_descs * desc_size, PAGE_SIZE) +
+						ALIGN(num_descs * cq_desc_size, PAGE_SIZE);
+		new->q_base = dma_alloc_coherent(dev, new->q_size + new->cq_size,
+						&new->q_base_pa, GFP_KERNEL);
+		if (!new->q_base) {
+			netdev_err(lif->netdev, "Cannot allocate qcq DMA memory\n");
+			err = -ENOMEM;
+			goto err_out_free_cq_info;
+		}
+		q_base = PTR_ALIGN(new->q_base, PAGE_SIZE);
+		q_base_pa = ALIGN(new->q_base_pa, PAGE_SIZE);
+		ionic_q_map(&new->q, q_base, q_base_pa);
+
+		cq_base = PTR_ALIGN(q_base +
+			ALIGN(num_descs * desc_size, PAGE_SIZE), PAGE_SIZE);
+		cq_base_pa = ALIGN(new->q_base_pa +
+			ALIGN(num_descs * desc_size, PAGE_SIZE), PAGE_SIZE);
+		ionic_cq_map(&new->cq, cq_base, cq_base_pa);
+		ionic_cq_bind(&new->cq, &new->q);
+	} else {
+		new->q_size = PAGE_SIZE + (num_descs * desc_size);
+		new->q_base = dma_alloc_coherent(dev, new->q_size, &new->q_base_pa,
+						 GFP_KERNEL);
+		if (!new->q_base) {
+			netdev_err(lif->netdev, "Cannot allocate queue DMA memory\n");
+			err = -ENOMEM;
+			goto err_out_free_cq_info;
+		}
+		q_base = PTR_ALIGN(new->q_base, PAGE_SIZE);
+		q_base_pa = ALIGN(new->q_base_pa, PAGE_SIZE);
+		ionic_q_map(&new->q, q_base, q_base_pa);
+
+		new->cq_size = PAGE_SIZE + (num_descs * cq_desc_size);
+		new->cq_base = dma_alloc_coherent(dev, new->cq_size, &new->cq_base_pa,
+						  GFP_KERNEL);
+		if (!new->cq_base) {
+			netdev_err(lif->netdev, "Cannot allocate cq DMA memory\n");
+			err = -ENOMEM;
+			goto err_out_free_q;
+		}
+		cq_base = PTR_ALIGN(new->cq_base, PAGE_SIZE);
+		cq_base_pa = ALIGN(new->cq_base_pa, PAGE_SIZE);
+		ionic_cq_map(&new->cq, cq_base, cq_base_pa);
+		ionic_cq_bind(&new->cq, &new->q);
 	}
-
-	new->total_size = total_size;
-
-	q_base = new->base;
-	q_base_pa = new->base_pa;
-
-	cq_base = (void *)ALIGN((uintptr_t)q_base + q_size, PAGE_SIZE);
-	cq_base_pa = ALIGN(q_base_pa + q_size, PAGE_SIZE);
 
 	if (flags & IONIC_QCQ_F_SG) {
-		sg_base = (void *)ALIGN((uintptr_t)cq_base + cq_size,
-					PAGE_SIZE);
-		sg_base_pa = ALIGN(cq_base_pa + cq_size, PAGE_SIZE);
+		new->sg_size = PAGE_SIZE + (num_descs * sg_desc_size);
+		new->sg_base = dma_alloc_coherent(dev, new->sg_size, &new->sg_base_pa,
+						  GFP_KERNEL);
+		if (!new->sg_base) {
+			netdev_err(lif->netdev, "Cannot allocate sg DMA memory\n");
+			err = -ENOMEM;
+			goto err_out_free_cq;
+		}
+		sg_base = PTR_ALIGN(new->sg_base, PAGE_SIZE);
+		sg_base_pa = ALIGN(new->sg_base_pa, PAGE_SIZE);
 		ionic_q_sg_map(&new->q, sg_base, sg_base_pa);
 	}
 
-	ionic_q_map(&new->q, q_base, q_base_pa);
-	ionic_cq_map(&new->cq, cq_base, cq_base_pa);
-	ionic_cq_bind(&new->cq, &new->q);
+	INIT_WORK(&new->dim.work, ionic_dim_work);
+	new->dim.mode = DIM_CQ_PERIOD_MODE_START_FROM_EQE;
 
 	*qcq = new;
 
 	return 0;
 
+err_out_free_cq:
+	dma_free_coherent(dev, new->cq_size, new->cq_base, new->cq_base_pa);
+err_out_free_q:
+	dma_free_coherent(dev, new->q_size, new->q_base, new->q_base_pa);
+err_out_free_cq_info:
+	devm_kfree(dev, new->cq.info);
 err_out_free_irq:
-	if (flags & IONIC_QCQ_F_INTR)
+	if (flags & IONIC_QCQ_F_INTR) {
 		devm_free_irq(dev, new->intr.vector, &new->napi);
-err_out_free_intr:
-	if (flags & IONIC_QCQ_F_INTR)
 		ionic_intr_free(lif->ionic, new->intr.index);
+	}
+err_out_free_q_info:
+	devm_kfree(dev, new->q.info);
+err_out_free_qcq:
+	devm_kfree(dev, new);
 err_out:
 	dev_err(dev, "qcq alloc of %s%d failed %d\n", name, index, err);
 	return err;
@@ -607,10 +675,8 @@ err_out:
 static int ionic_qcqs_alloc(struct ionic_lif *lif)
 {
 	struct device *dev = lif->ionic->dev;
-	unsigned int q_list_size;
 	unsigned int flags;
 	int err;
-	int i;
 
 	flags = IONIC_QCQ_F_INTR;
 	err = ionic_qcq_alloc(lif, IONIC_QTYPE_ADMINQ, 0, "admin", flags,
@@ -622,7 +688,7 @@ static int ionic_qcqs_alloc(struct ionic_lif *lif)
 		return err;
 	ionic_debugfs_add_qcq(lif, lif->adminqcq);
 
-	if (is_master_lif(lif) && lif->ionic->nnqs_per_lif) {
+	if (lif->ionic->nnqs_per_lif) {
 		flags = IONIC_QCQ_F_NOTIFYQ;
 		err = ionic_qcq_alloc(lif, IONIC_QTYPE_NOTIFYQ, 0, "notifyq",
 				      flags, IONIC_NOTIFYQ_LENGTH,
@@ -630,63 +696,36 @@ static int ionic_qcqs_alloc(struct ionic_lif *lif)
 				      sizeof(union ionic_notifyq_comp),
 				      0, lif->kern_pid, &lif->notifyqcq);
 		if (err)
-			goto err_out_free_adminqcq;
+			goto err_out;
 		ionic_debugfs_add_qcq(lif, lif->notifyqcq);
 
 		/* Let the notifyq ride on the adminq interrupt */
 		ionic_link_qcq_interrupts(lif->adminqcq, lif->notifyqcq);
 	}
 
-	q_list_size = sizeof(*lif->txqcqs) * lif->nxqs;
-	if (is_master_lif(lif))
-		q_list_size += sizeof(*lif->txqcqs) * (lif->ionic->nlifs - 1);
-
 	err = -ENOMEM;
-	lif->txqcqs = devm_kzalloc(dev, q_list_size, GFP_KERNEL);
+	lif->txqcqs = devm_kcalloc(dev, lif->ionic->ntxqs_per_lif,
+				   sizeof(struct ionic_qcq *), GFP_KERNEL);
 	if (!lif->txqcqs)
-		goto err_out_free_notifyqcq;
-	for (i = 0; i < lif->nxqs; i++) {
-		lif->txqcqs[i].stats = devm_kzalloc(dev,
-						    sizeof(struct ionic_q_stats),
-						    GFP_KERNEL);
-		if (!lif->txqcqs[i].stats)
-			goto err_out_free_tx_stats;
-	}
-
-	lif->rxqcqs = devm_kzalloc(dev, q_list_size, GFP_KERNEL);
+		goto err_out;
+	lif->rxqcqs = devm_kcalloc(dev, lif->ionic->nrxqs_per_lif,
+				   sizeof(struct ionic_qcq *), GFP_KERNEL);
 	if (!lif->rxqcqs)
-		goto err_out_free_tx_stats;
-	for (i = 0; i < lif->nxqs; i++) {
-		lif->rxqcqs[i].stats = devm_kzalloc(dev,
-						    sizeof(struct ionic_q_stats),
-						    GFP_KERNEL);
-		if (!lif->rxqcqs[i].stats)
-			goto err_out_free_rx_stats;
-	}
+		goto err_out;
+
+	lif->txqstats = devm_kcalloc(dev, lif->ionic->ntxqs_per_lif + 1,
+				     sizeof(struct ionic_tx_stats), GFP_KERNEL);
+	if (!lif->txqstats)
+		goto err_out;
+	lif->rxqstats = devm_kcalloc(dev, lif->ionic->nrxqs_per_lif + 1,
+				     sizeof(struct ionic_rx_stats), GFP_KERNEL);
+	if (!lif->rxqstats)
+		goto err_out;
 
 	return 0;
 
-err_out_free_rx_stats:
-	for (i = 0; i < lif->nxqs; i++)
-		if (lif->rxqcqs[i].stats)
-			devm_kfree(dev, lif->rxqcqs[i].stats);
-	devm_kfree(dev, lif->rxqcqs);
-	lif->rxqcqs = NULL;
-err_out_free_tx_stats:
-	for (i = 0; i < lif->nxqs; i++)
-		if (lif->txqcqs[i].stats)
-			devm_kfree(dev, lif->txqcqs[i].stats);
-	devm_kfree(dev, lif->txqcqs);
-	lif->txqcqs = NULL;
-err_out_free_notifyqcq:
-	if (lif->notifyqcq) {
-		ionic_qcq_free(lif, lif->notifyqcq);
-		lif->notifyqcq = NULL;
-	}
-err_out_free_adminqcq:
-	ionic_qcq_free(lif, lif->adminqcq);
-	lif->adminqcq = NULL;
-
+err_out:
+	ionic_qcqs_free(lif);
 	return err;
 }
 
@@ -700,6 +739,17 @@ static inline int ionic_choose_eq(struct ionic_lif *lif, int q_index)
 		abs_q = q_index;
 
 	return abs_q % lif->ionic->neth_eqs;
+}
+
+static void ionic_qcq_sanitize(struct ionic_qcq *qcq)
+{
+	qcq->q.tail_idx = 0;
+	qcq->q.head_idx = 0;
+	qcq->cq.tail_idx = 0;
+	qcq->cq.done_color = 1;
+	memset(qcq->q_base, 0, qcq->q_size);
+	memset(qcq->cq_base, 0, qcq->cq_size);
+	memset(qcq->sg_base, 0, qcq->sg_size);
 }
 
 static int ionic_lif_txq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
@@ -720,6 +770,7 @@ static int ionic_lif_txq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 			.ring_base = cpu_to_le64(q->base_pa),
 			.cq_ring_base = cpu_to_le64(cq->base_pa),
 			.sg_ring_base = cpu_to_le64(q->sg_base_pa),
+			.features = cpu_to_le64(q->features),
 		},
 	};
 	int err;
@@ -734,10 +785,7 @@ static int ionic_lif_txq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	} else {
 		unsigned int intr_index;
 
-		if (test_bit(IONIC_LIF_F_SPLIT_INTR, lif->state))
-			intr_index = qcq->intr.index;
-		else
-			intr_index = lif->rxqcqs[q->index].qcq->intr.index;
+		intr_index = qcq->intr.index;
 
 		ctx.cmd.q_init.flags = cpu_to_le16(IONIC_QINIT_F_IRQ |
 						   IONIC_QINIT_F_SG);
@@ -754,9 +802,7 @@ static int ionic_lif_txq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	dev_dbg(dev, "txq_init.ver %d\n", ctx.cmd.q_init.ver);
 	dev_dbg(dev, "txq_init.intr_index %d\n", ctx.cmd.q_init.intr_index);
 
-	q->tail_idx = 0;
-	q->head_idx = 0;
-	cq->tail_idx = 0;
+	ionic_qcq_sanitize(qcq);
 
 	err = ionic_adminq_post_wait(lif, &ctx);
 	if (err)
@@ -769,7 +815,7 @@ static int ionic_lif_txq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	dev_dbg(dev, "txq->hw_type %d\n", q->hw_type);
 	dev_dbg(dev, "txq->hw_index %d\n", q->hw_index);
 
-	if (test_bit(IONIC_LIF_F_SPLIT_INTR, lif->state))
+	if (qcq->flags & IONIC_QCQ_F_INTR)
 		netif_napi_add(lif->netdev, &qcq->napi, ionic_tx_napi,
 			       NAPI_POLL_WEIGHT);
 
@@ -796,6 +842,7 @@ static int ionic_lif_rxq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 			.ring_base = cpu_to_le64(q->base_pa),
 			.cq_ring_base = cpu_to_le64(cq->base_pa),
 			.sg_ring_base = cpu_to_le64(q->sg_base_pa),
+			.features = cpu_to_le64(q->features),
 		},
 	};
 	int err;
@@ -823,9 +870,7 @@ static int ionic_lif_rxq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	dev_dbg(dev, "rxq_init.ver %d\n", ctx.cmd.q_init.ver);
 	dev_dbg(dev, "rxq_init.intr_index %d\n", ctx.cmd.q_init.intr_index);
 
-	q->tail_idx = 0;
-	q->head_idx = 0;
-	cq->tail_idx = 0;
+	ionic_qcq_sanitize(qcq);
 
 	err = ionic_adminq_post_wait(lif, &ctx);
 	if (err)
@@ -848,6 +893,249 @@ static int ionic_lif_rxq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	qcq->flags |= IONIC_QCQ_F_INITED;
 
 	return 0;
+}
+
+int ionic_lif_create_hwstamp_txq(struct ionic_lif *lif)
+{
+	unsigned int num_desc, desc_sz, comp_sz, sg_desc_sz;
+	unsigned int txq_i, flags;
+	struct ionic_qcq *txq;
+	u64 features;
+	int err;
+
+	mutex_lock(&lif->queue_lock);
+
+	if (lif->hwstamp_txq)
+		goto out;
+
+	features = IONIC_Q_F_2X_CQ_DESC | IONIC_TXQ_F_HWSTAMP;
+
+	num_desc = IONIC_MIN_TXRX_DESC;
+	desc_sz = sizeof(struct ionic_txq_desc);
+	comp_sz = 2 * sizeof(struct ionic_txq_comp);
+
+	if (lif->qtype_info[IONIC_QTYPE_TXQ].version >= 1 &&
+	    lif->qtype_info[IONIC_QTYPE_TXQ].sg_desc_sz == sizeof(struct ionic_txq_sg_desc_v1))
+		sg_desc_sz = sizeof(struct ionic_txq_sg_desc_v1);
+	else
+		sg_desc_sz = sizeof(struct ionic_txq_sg_desc);
+
+	txq_i = lif->nxqs;
+	flags = IONIC_QCQ_F_TX_STATS | IONIC_QCQ_F_SG;
+
+	err = ionic_qcq_alloc(lif, IONIC_QTYPE_TXQ, txq_i, "hwstamp_tx", flags,
+			      num_desc, desc_sz, comp_sz, sg_desc_sz,
+			      lif->kern_pid, &txq);
+	if (err)
+		goto err_qcq_alloc;
+
+	txq->q.features = features;
+
+	ionic_link_qcq_interrupts(lif->adminqcq, txq);
+	ionic_debugfs_add_qcq(lif, txq);
+
+	lif->hwstamp_txq = txq;
+
+	if (netif_running(lif->netdev)) {
+		err = ionic_lif_txq_init(lif, txq);
+		if (err)
+			goto err_qcq_init;
+
+		if (test_bit(IONIC_LIF_F_UP, lif->state)) {
+			err = ionic_qcq_enable(txq);
+			if (err)
+				goto err_qcq_enable;
+		}
+	}
+
+out:
+	mutex_unlock(&lif->queue_lock);
+
+	return 0;
+
+err_qcq_enable:
+	ionic_lif_qcq_deinit(lif, txq);
+err_qcq_init:
+	lif->hwstamp_txq = NULL;
+	ionic_debugfs_del_qcq(txq);
+	ionic_qcq_free(lif, txq);
+	devm_kfree(lif->ionic->dev, txq);
+err_qcq_alloc:
+	mutex_unlock(&lif->queue_lock);
+	return err;
+}
+
+int ionic_lif_create_hwstamp_rxq(struct ionic_lif *lif)
+{
+	unsigned int num_desc, desc_sz, comp_sz, sg_desc_sz;
+	unsigned int rxq_i, flags;
+	struct ionic_qcq *rxq;
+	u64 features;
+	int err;
+
+	mutex_lock(&lif->queue_lock);
+
+	if (lif->hwstamp_rxq)
+		goto out;
+
+	features = IONIC_Q_F_2X_CQ_DESC | IONIC_RXQ_F_HWSTAMP;
+
+	num_desc = IONIC_MIN_TXRX_DESC;
+	desc_sz = sizeof(struct ionic_rxq_desc);
+	comp_sz = 2 * sizeof(struct ionic_rxq_comp);
+	sg_desc_sz = sizeof(struct ionic_rxq_sg_desc);
+
+	rxq_i = lif->nxqs;
+	flags = IONIC_QCQ_F_RX_STATS | IONIC_QCQ_F_SG;
+
+	err = ionic_qcq_alloc(lif, IONIC_QTYPE_RXQ, rxq_i, "hwstamp_rx", flags,
+			      num_desc, desc_sz, comp_sz, sg_desc_sz,
+			      lif->kern_pid, &rxq);
+	if (err)
+		goto err_qcq_alloc;
+
+	rxq->q.features = features;
+
+	ionic_link_qcq_interrupts(lif->adminqcq, rxq);
+	ionic_debugfs_add_qcq(lif, rxq);
+
+	lif->hwstamp_rxq = rxq;
+
+	if (netif_running(lif->netdev)) {
+		err = ionic_lif_rxq_init(lif, rxq);
+		if (err)
+			goto err_qcq_init;
+
+		if (test_bit(IONIC_LIF_F_UP, lif->state)) {
+			ionic_rx_fill(&rxq->q);
+			err = ionic_qcq_enable(rxq);
+			if (err)
+				goto err_qcq_enable;
+		}
+	}
+
+out:
+	mutex_unlock(&lif->queue_lock);
+
+	return 0;
+
+err_qcq_enable:
+	ionic_lif_qcq_deinit(lif, rxq);
+err_qcq_init:
+	lif->hwstamp_rxq = NULL;
+	ionic_debugfs_del_qcq(rxq);
+	ionic_qcq_free(lif, rxq);
+	devm_kfree(lif->ionic->dev, rxq);
+err_qcq_alloc:
+	mutex_unlock(&lif->queue_lock);
+	return err;
+}
+
+int ionic_lif_config_hwstamp_rxq_all(struct ionic_lif *lif, bool rx_all)
+{
+	struct ionic_queue_params qparam;
+
+	ionic_init_queue_params(lif, &qparam);
+
+	if (rx_all) {
+		qparam.rxq_features = IONIC_Q_F_2X_CQ_DESC | IONIC_RXQ_F_HWSTAMP;
+	} else {
+		qparam.rxq_features = 0;
+	}
+
+	return ionic_reconfigure_queues(lif, &qparam);
+}
+
+int ionic_lif_set_hwstamp_txmode(struct ionic_lif *lif, u16 txstamp_mode)
+{
+	struct ionic_admin_ctx ctx = {
+		.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
+		.cmd.lif_setattr = {
+			.opcode = IONIC_CMD_LIF_SETATTR,
+			.index = cpu_to_le16(lif->index),
+			.attr = IONIC_LIF_ATTR_TXSTAMP,
+			.txstamp_mode = cpu_to_le16(txstamp_mode),
+		},
+	};
+
+	return ionic_adminq_post_wait(lif, &ctx);
+}
+
+static void ionic_lif_del_hwstamp_rxfilt(struct ionic_lif *lif)
+{
+	struct ionic_admin_ctx ctx = {
+		.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
+		.cmd.rx_filter_del = {
+			.opcode = IONIC_CMD_RX_FILTER_DEL,
+			.lif_index = cpu_to_le16(lif->index),
+		},
+	};
+	struct ionic_rx_filter *f;
+	u32 filter_id;
+	int err;
+
+	spin_lock_bh(&lif->rx_filters.lock);
+
+	f = ionic_rx_filter_rxsteer(lif);
+	if (!f) {
+		spin_unlock_bh(&lif->rx_filters.lock);
+		return;
+	}
+
+	filter_id = f->filter_id;
+	ionic_rx_filter_free(lif, f);
+
+	spin_unlock_bh(&lif->rx_filters.lock);
+
+	netdev_dbg(lif->netdev, "rx_filter del RXSTEER (id %d)\n", filter_id);
+
+	ctx.cmd.rx_filter_del.filter_id = cpu_to_le32(filter_id);
+
+	err = ionic_adminq_post_wait(lif, &ctx);
+	if (err && err != -EEXIST)
+		netdev_dbg(lif->netdev, "failed to delete rx_filter RXSTEER (id %d)\n", filter_id);
+}
+
+static int ionic_lif_add_hwstamp_rxfilt(struct ionic_lif *lif, u64 pkt_class)
+{
+	struct ionic_admin_ctx ctx = {
+		.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
+		.cmd.rx_filter_add = {
+			.opcode = IONIC_CMD_RX_FILTER_ADD,
+			.lif_index = cpu_to_le16(lif->index),
+			.match = cpu_to_le16(IONIC_RX_FILTER_STEER_PKTCLASS),
+			.pkt_class = cpu_to_le64(pkt_class),
+		},
+	};
+	u16 qtype;
+	u32 qid;
+	int err;
+
+	if (!lif->hwstamp_rxq)
+		return -EINVAL;
+
+	qtype = lif->hwstamp_rxq->q.type;
+	ctx.cmd.rx_filter_add.qtype = cpu_to_le16(qtype);
+
+	qid = lif->hwstamp_rxq->q.index;
+	ctx.cmd.rx_filter_add.qid = cpu_to_le16(qid);
+
+	netdev_dbg(lif->netdev, "rx_filter add RXSTEER\n");
+	err = ionic_adminq_post_wait(lif, &ctx);
+	if (err && err != -EEXIST)
+		return err;
+
+	return ionic_rx_filter_save(lif, 0, qid, 0, &ctx);
+}
+
+int ionic_lif_set_hwstamp_rxfilt(struct ionic_lif *lif, u64 pkt_class)
+{
+	ionic_lif_del_hwstamp_rxfilt(lif);
+
+	if (!pkt_class)
+		return 0;
+
+	return ionic_lif_add_hwstamp_rxfilt(lif, pkt_class);
 }
 
 static bool ionic_notifyq_service(struct ionic_cq *cq,
@@ -882,7 +1170,7 @@ static bool ionic_notifyq_service(struct ionic_cq *cq,
 
 	switch (le16_to_cpu(comp->event.ecode)) {
 	case IONIC_EVENT_LINK_CHANGE:
-		ionic_link_status_check_request(lif);
+		ionic_link_status_check_request(lif, CAN_NOT_SLEEP);
 		break;
 	case IONIC_EVENT_RESET:
 		work = kzalloc(sizeof(*work), GFP_ATOMIC);
@@ -907,27 +1195,12 @@ static bool ionic_notifyq_service(struct ionic_cq *cq,
 			    eid);
 		break;
 	default:
-		netdev_warn(netdev, "Notifyq unknown event ecode=%d eid=%lld\n",
+		netdev_warn(netdev, "Notifyq event ecode=%d eid=%lld\n",
 			    comp->event.ecode, eid);
 		break;
 	}
 
 	return true;
-}
-
-static int ionic_notifyq_clean(struct ionic_lif *lif, int budget)
-{
-	struct ionic_dev *idev = &lif->ionic->idev;
-	struct ionic_cq *cq = &lif->notifyqcq->cq;
-	u32 work_done;
-
-	work_done = ionic_cq_service(cq, budget, ionic_notifyq_service,
-				     NULL, NULL);
-	if (work_done)
-		ionic_intr_credits(idev->intr_ctrl, cq->bound_intr->index,
-				   work_done, IONIC_INTR_CRED_RESET_COALESCE);
-
-	return work_done;
 }
 
 static bool ionic_adminq_service(struct ionic_cq *cq,
@@ -945,15 +1218,46 @@ static bool ionic_adminq_service(struct ionic_cq *cq,
 
 static int ionic_adminq_napi(struct napi_struct *napi, int budget)
 {
+	struct ionic_intr_info *intr = napi_to_cq(napi)->bound_intr;
 	struct ionic_lif *lif = napi_to_cq(napi)->lif;
+	struct ionic_dev *idev = &lif->ionic->idev;
+	unsigned int flags = 0;
+	int rx_work = 0;
+	int tx_work = 0;
 	int n_work = 0;
 	int a_work = 0;
+	int work_done;
+	int credits;
 
-	if (likely(lif->notifyqcq && lif->notifyqcq->flags & IONIC_QCQ_F_INITED))
-		n_work = ionic_notifyq_clean(lif, budget);
-	a_work = ionic_napi(napi, budget, ionic_adminq_service, NULL, NULL);
+	if (lif->notifyqcq && lif->notifyqcq->flags & IONIC_QCQ_F_INITED)
+		n_work = ionic_cq_service(&lif->notifyqcq->cq, budget,
+					  ionic_notifyq_service, NULL, NULL);
 
-	return max(n_work, a_work);
+	if (lif->adminqcq && lif->adminqcq->flags & IONIC_QCQ_F_INITED)
+		a_work = ionic_cq_service(&lif->adminqcq->cq, budget,
+					  ionic_adminq_service, NULL, NULL);
+
+	if (lif->hwstamp_rxq)
+		rx_work = ionic_cq_service(&lif->hwstamp_rxq->cq, budget,
+					   ionic_rx_service, NULL, NULL);
+
+	if (lif->hwstamp_txq)
+		tx_work = ionic_cq_service(&lif->hwstamp_txq->cq, budget,
+					   ionic_tx_service, NULL, NULL);
+
+	work_done = max(max(n_work, a_work), max(rx_work, tx_work));
+	if (work_done < budget && napi_complete_done(napi, work_done)) {
+		flags |= IONIC_INTR_CRED_UNMASK;
+		lif->adminqcq->cq.bound_intr->rearm_count++;
+	}
+
+	if (work_done || flags) {
+		flags |= IONIC_INTR_CRED_RESET_COALESCE;
+		credits = n_work + a_work + rx_work + tx_work;
+		ionic_intr_credits(idev->intr_ctrl, intr->index, credits, flags);
+	}
+
+	return work_done;
 }
 
 #ifdef HAVE_VOID_NDO_GET_STATS64
@@ -1038,21 +1342,6 @@ static int ionic_lif_addr_add(struct ionic_lif *lif, const u8 *addr)
 	if (f)
 		return 0;
 
-	/* make sure we're not getting a slave's filter */
-	/* TODO: use a global hash rather than search every slave */
-	if (is_master_lif(lif)) {
-		struct ionic_lif *slave_lif;
-		unsigned long i;
-
-		for_each_eth_lif(lif->ionic, i, slave_lif) {
-			spin_lock_bh(&slave_lif->rx_filters.lock);
-			f = ionic_rx_filter_by_addr(slave_lif, addr);
-			spin_unlock_bh(&slave_lif->rx_filters.lock);
-			if (f)
-				return 0;
-		}
-	}
-
 	netdev_dbg(lif->netdev, "rx_filter add ADDR %pM\n", addr);
 
 	memcpy(ctx.cmd.rx_filter_add.mac.addr, addr, ETH_ALEN);
@@ -1096,9 +1385,9 @@ static int ionic_lif_addr_del(struct ionic_lif *lif, const u8 *addr)
 	return 0;
 }
 
-static int ionic_lif_addr(struct ionic_lif *lif, const u8 *addr, bool add)
+static int ionic_lif_addr(struct ionic_lif *lif, const u8 *addr, bool add,
+			  bool can_sleep)
 {
-	struct ionic *ionic = lif->ionic;
 	struct ionic_deferred_work *work;
 	unsigned int nmfilters;
 	unsigned int nufilters;
@@ -1108,8 +1397,8 @@ static int ionic_lif_addr(struct ionic_lif *lif, const u8 *addr, bool add)
 		 * here before checking the need for deferral so that we
 		 * can return an overflow error to the stack.
 		 */
-		nmfilters = le32_to_cpu(ionic->ident.lif.eth.max_mcast_filters);
-		nufilters = le32_to_cpu(ionic->ident.lif.eth.max_ucast_filters);
+		nmfilters = le32_to_cpu(lif->identity->eth.max_mcast_filters);
+		nufilters = le32_to_cpu(lif->identity->eth.max_ucast_filters);
 
 		if ((is_multicast_ether_addr(addr) && lif->nmcast < nmfilters))
 			lif->nmcast++;
@@ -1125,7 +1414,7 @@ static int ionic_lif_addr(struct ionic_lif *lif, const u8 *addr, bool add)
 			lif->nucast--;
 	}
 
-	if (in_interrupt()) {
+	if (!can_sleep) {
 		work = kzalloc(sizeof(*work), GFP_ATOMIC);
 		if (!work) {
 			netdev_err(lif->netdev, "%s OOM\n", __func__);
@@ -1151,12 +1440,22 @@ static int ionic_lif_addr(struct ionic_lif *lif, const u8 *addr, bool add)
 
 static int ionic_addr_add(struct net_device *netdev, const u8 *addr)
 {
-	return ionic_lif_addr(netdev_priv(netdev), addr, true);
+	return ionic_lif_addr(netdev_priv(netdev), addr, ADD_ADDR, CAN_SLEEP);
+}
+
+static int ionic_ndo_addr_add(struct net_device *netdev, const u8 *addr)
+{
+	return ionic_lif_addr(netdev_priv(netdev), addr, ADD_ADDR, CAN_NOT_SLEEP);
 }
 
 static int ionic_addr_del(struct net_device *netdev, const u8 *addr)
 {
-	return ionic_lif_addr(netdev_priv(netdev), addr, false);
+	return ionic_lif_addr(netdev_priv(netdev), addr, DEL_ADDR, CAN_SLEEP);
+}
+
+static int ionic_ndo_addr_del(struct net_device *netdev, const u8 *addr)
+{
+	return ionic_lif_addr(netdev_priv(netdev), addr, DEL_ADDR, CAN_NOT_SLEEP);
 }
 
 static int ionic_lif_rx_mode(struct ionic_lif *lif, unsigned int rx_mode)
@@ -1200,31 +1499,10 @@ static int ionic_lif_rx_mode(struct ionic_lif *lif, unsigned int rx_mode)
 	return err;
 }
 
-static int _ionic_lif_rx_mode(struct ionic_lif *lif, unsigned int rx_mode)
-{
-	struct ionic_deferred_work *work;
-	int err = 0;
-
-	if (in_interrupt()) {
-		work = kzalloc(sizeof(*work), GFP_ATOMIC);
-		if (!work) {
-			netdev_err(lif->netdev, "%s OOM\n", __func__);
-			return -ENOMEM;
-		}
-		work->type = IONIC_DW_TYPE_RX_MODE;
-		work->rx_mode = rx_mode;
-		netdev_dbg(lif->netdev, "deferred: rx_mode\n");
-		ionic_lif_deferred_enqueue(&lif->deferred, work);
-	} else {
-		err = ionic_lif_rx_mode(lif, rx_mode);
-	}
-
-	return err;
-}
-
-void ionic_set_rx_mode(struct net_device *netdev)
+void ionic_set_rx_mode(struct net_device *netdev, bool can_sleep)
 {
 	struct ionic_lif *lif = netdev_priv(netdev);
+	struct ionic_deferred_work *work;
 	struct ionic_identity *ident;
 	unsigned int nfilters;
 	unsigned int rx_mode;
@@ -1247,8 +1525,11 @@ void ionic_set_rx_mode(struct net_device *netdev)
 	 *       we remove our overflow flag and check the netdev flags
 	 *       to see if we can disable NIC PROMISC
 	 */
-	__dev_uc_sync(netdev, ionic_addr_add, ionic_addr_del);
-	nfilters = le32_to_cpu(ident->lif.eth.max_ucast_filters);
+	if (can_sleep)
+		__dev_uc_sync(netdev, ionic_addr_add, ionic_addr_del);
+	else
+		__dev_uc_sync(netdev, ionic_ndo_addr_add, ionic_ndo_addr_del);
+	nfilters = le32_to_cpu(lif->identity->eth.max_ucast_filters);
 	if (netdev_uc_count(netdev) + 1 > nfilters) {
 		rx_mode |= IONIC_RX_MODE_F_PROMISC;
 		lif->uc_overflow = true;
@@ -1259,8 +1540,11 @@ void ionic_set_rx_mode(struct net_device *netdev)
 	}
 
 	/* same for multicast */
-	__dev_mc_sync(netdev, ionic_addr_add, ionic_addr_del);
-	nfilters = le32_to_cpu(ident->lif.eth.max_mcast_filters);
+	if (can_sleep)
+		__dev_mc_sync(netdev, ionic_addr_add, ionic_addr_del);
+	else
+		__dev_mc_sync(netdev, ionic_ndo_addr_add, ionic_ndo_addr_del);
+	nfilters = le32_to_cpu(lif->identity->eth.max_mcast_filters);
 	if (netdev_mc_count(netdev) > nfilters) {
 		rx_mode |= IONIC_RX_MODE_F_ALLMULTI;
 		lif->mc_overflow = true;
@@ -1270,8 +1554,26 @@ void ionic_set_rx_mode(struct net_device *netdev)
 			rx_mode &= ~IONIC_RX_MODE_F_ALLMULTI;
 	}
 
-	if (lif->rx_mode != rx_mode)
-		_ionic_lif_rx_mode(lif, rx_mode);
+	if (lif->rx_mode != rx_mode) {
+		if (!can_sleep) {
+			work = kzalloc(sizeof(*work), GFP_ATOMIC);
+			if (!work) {
+				netdev_err(lif->netdev, "%s OOM\n", __func__);
+				return;
+			}
+			work->type = IONIC_DW_TYPE_RX_MODE;
+			work->rx_mode = rx_mode;
+			netdev_dbg(lif->netdev, "deferred: rx_mode\n");
+			ionic_lif_deferred_enqueue(&lif->deferred, work);
+		} else {
+			ionic_lif_rx_mode(lif, rx_mode);
+		}
+	}
+}
+
+static void ionic_ndo_set_rx_mode(struct net_device *netdev)
+{
+	ionic_set_rx_mode(netdev, CAN_NOT_SLEEP);
 }
 
 static __le64 ionic_netdev_features_to_nic(netdev_features_t features)
@@ -1337,6 +1639,10 @@ static int ionic_set_nic_features(struct ionic_lif *lif,
 	int err;
 
 	ctx.cmd.lif_setattr.features = ionic_netdev_features_to_nic(features);
+
+	if (lif->phc)
+		ctx.cmd.lif_setattr.features |= cpu_to_le64(IONIC_ETH_HW_TIMESTAMP);
+
 	err = ionic_adminq_post_wait(lif, &ctx);
 	if (err)
 		return err;
@@ -1384,6 +1690,8 @@ static int ionic_set_nic_features(struct ionic_lif *lif,
 		dev_dbg(dev, "feature ETH_HW_TSO_UDP\n");
 	if (lif->hw_features & IONIC_ETH_HW_TSO_UDP_CSUM)
 		dev_dbg(dev, "feature ETH_HW_TSO_UDP_CSUM\n");
+	if (lif->hw_features & IONIC_ETH_HW_TIMESTAMP)
+		dev_dbg(dev, "feature ETH_HW_TIMESTAMP\n");
 
 	return 0;
 }
@@ -1411,9 +1719,6 @@ static int ionic_init_nic_features(struct ionic_lif *lif)
 	err = ionic_set_nic_features(lif, features);
 	if (err)
 		return err;
-
-	if (!is_master_lif(lif))
-		return 0;
 
 	/* tell the netdev what we actually can support */
 	netdev->features |= NETIF_F_HIGHDMA;
@@ -1466,12 +1771,6 @@ static int ionic_init_nic_features(struct ionic_lif *lif)
 						      NETIF_F_HW_VLAN_CTAG_RX |
 						   NETIF_F_HW_VLAN_CTAG_FILTER);
 
-	/* Leave L2FW_OFFLOAD out of netdev->features so it will
-	 * be disabled by default, but the user can enable later.
-	 */
-	if (lif->ionic->nlifs > 1)
-		netdev->hw_features |= NETIF_F_HW_L2FW_DOFFLOAD;
-
 	netdev->priv_flags |= IFF_UNICAST_FLT |
 			      IFF_LIVE_ADDR_CHANGE;
 
@@ -1518,6 +1817,35 @@ static int ionic_set_mac_address(struct net_device *netdev, void *sa)
 	return ionic_addr_add(netdev, mac);
 }
 
+static void ionic_stop_queues_reconfig(struct ionic_lif *lif)
+{
+	/* Stop and clean the queues before reconfiguration */
+	mutex_lock(&lif->queue_lock);
+	netif_device_detach(lif->netdev);
+	ionic_stop_queues(lif);
+	ionic_txrx_deinit(lif);
+}
+
+static int ionic_start_queues_reconfig(struct ionic_lif *lif)
+{
+	int err;
+
+	/* Re-init the queues after reconfiguration */
+
+	/* The only way txrx_init can fail here is if communication
+	 * with FW is suddenly broken.  There's not much we can do
+	 * at this point - error messages have already been printed,
+	 * so we can continue on and the user can eventually do a
+	 * DOWN and UP to try to reset and clear the issue.
+	 */
+	err = ionic_txrx_init(lif);
+	mutex_unlock(&lif->queue_lock);
+	ionic_link_status_check_request(lif, CAN_SLEEP);
+	netif_device_attach(lif->netdev);
+
+	return err;
+}
+
 static int ionic_change_mtu(struct net_device *netdev, int new_mtu)
 {
 	struct ionic_lif *lif = netdev_priv(netdev);
@@ -1546,10 +1874,16 @@ static int ionic_change_mtu(struct net_device *netdev, int new_mtu)
 
 	netdev_info(netdev, "Changing MTU from %d to %d\n",
 		    netdev->mtu, new_mtu);
-	netdev->mtu = new_mtu;
-	err = ionic_reset_queues(lif, NULL, NULL);
 
-	return err;
+	/* if we're not running, nothing much to do */
+	if (!netif_running(lif->netdev)) {
+		netdev->mtu = new_mtu;
+		return 0;
+	}
+
+	ionic_stop_queues_reconfig(lif);
+	netdev->mtu = new_mtu;
+	return ionic_start_queues_reconfig(lif);
 }
 
 static void ionic_tx_timeout_work(struct work_struct *ws)
@@ -1560,9 +1894,15 @@ static void ionic_tx_timeout_work(struct work_struct *ws)
 		return;
 
 	// TODO: queue specific reset
-	rtnl_lock();
-	ionic_reset_queues(lif, NULL, NULL);
-	rtnl_unlock();
+
+	/* if we were stopped before this scheduled job was launched,
+	 * don't bother the queues as they are already stopped.
+	 */
+	if (!netif_running(lif->netdev))
+		return;
+
+	ionic_stop_queues_reconfig(lif);
+	ionic_start_queues_reconfig(lif);
 }
 
 #ifdef HAVE_TX_TIMEOUT_TXQUEUE
@@ -1572,7 +1912,7 @@ static void ionic_tx_timeout(struct net_device *netdev)
 #endif
 {
 	struct ionic_lif *lif = netdev_priv(netdev);
-#if ! defined(HAVE_TX_TIMEOUT_TXQUEUE)
+#if !defined(HAVE_TX_TIMEOUT_TXQUEUE)
 	unsigned int txqueue = -1;
 #endif
 
@@ -1698,48 +2038,82 @@ static void ionic_lif_rss_deinit(struct ionic_lif *lif)
 	ionic_lif_rss_config(lif, 0x0, NULL, NULL);
 }
 
+static int ionic_lif_quiesce(struct ionic_lif *lif)
+{
+	struct ionic_admin_ctx ctx = {
+		.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
+		.cmd.lif_setattr = {
+			.opcode = IONIC_CMD_LIF_SETATTR,
+			.index = cpu_to_le16(lif->index),
+			.attr = IONIC_LIF_ATTR_STATE,
+			.state = IONIC_LIF_QUIESCE,
+		},
+	};
+	int err;
+
+	err = ionic_adminq_post_wait(lif, &ctx);
+	if (err) {
+		netdev_err(lif->netdev, "lif quiesce failed %d\n", err);
+		return err;
+	}
+
+	return 0;
+}
+
 static void ionic_txrx_disable(struct ionic_lif *lif)
 {
 	unsigned int i;
-	int err;
+	int err = 0;
 
 	if (lif->txqcqs) {
-		for (i = 0; i < lif->nxqs; i++) {
-			err = ionic_qcq_disable(lif->txqcqs[i].qcq);
-			if (err == -ETIMEDOUT)
-				break;
-		}
+		for (i = 0; i < lif->nxqs; i++)
+			err = ionic_qcq_disable(lif->txqcqs[i], (err != -ETIMEDOUT));
 	}
 
+	if (lif->hwstamp_txq)
+		err = ionic_qcq_disable(lif->hwstamp_txq, (err != -ETIMEDOUT));
+
 	if (lif->rxqcqs) {
-		for (i = 0; i < lif->nxqs; i++) {
-			err = ionic_qcq_disable(lif->rxqcqs[i].qcq);
-			if (err == -ETIMEDOUT)
-				break;
-		}
+		for (i = 0; i < lif->nxqs; i++)
+			err = ionic_qcq_disable(lif->rxqcqs[i], (err != -ETIMEDOUT));
 	}
+
+	if (lif->hwstamp_rxq)
+		err = ionic_qcq_disable(lif->hwstamp_rxq, (err != -ETIMEDOUT));
+
+	ionic_lif_quiesce(lif);
 }
 
 static void ionic_txrx_deinit(struct ionic_lif *lif)
 {
 	unsigned int i;
 
-	if (lif->txqcqs && lif->txqcqs[0].qcq) {
-		for (i = 0; i < lif->nxqs; i++) {
-			ionic_lif_qcq_deinit(lif, lif->txqcqs[i].qcq);
-			ionic_tx_flush(&lif->txqcqs[i].qcq->cq);
-			ionic_tx_empty(&lif->txqcqs[i].qcq->q);
+	if (lif->txqcqs && lif->txqcqs[0]) {
+		for (i = 0; i < lif->nxqs && lif->txqcqs[i]; i++) {
+			ionic_lif_qcq_deinit(lif, lif->txqcqs[i]);
+			ionic_tx_flush(&lif->txqcqs[i]->cq);
+			ionic_tx_empty(&lif->txqcqs[i]->q);
 		}
 	}
 
-	if (lif->rxqcqs && lif->rxqcqs[0].qcq) {
-		for (i = 0; i < lif->nxqs; i++) {
-			ionic_lif_qcq_deinit(lif, lif->rxqcqs[i].qcq);
-			ionic_rx_flush(&lif->rxqcqs[i].qcq->cq);
-			ionic_rx_empty(&lif->rxqcqs[i].qcq->q);
+	if (lif->rxqcqs && lif->rxqcqs[0]) {
+		for (i = 0; i < lif->nxqs && lif->rxqcqs[i]; i++) {
+			ionic_lif_qcq_deinit(lif, lif->rxqcqs[i]);
+			ionic_rx_empty(&lif->rxqcqs[i]->q);
 		}
 	}
 	lif->rx_mode = 0;
+
+	if (lif->hwstamp_txq) {
+		ionic_lif_qcq_deinit(lif, lif->hwstamp_txq);
+		ionic_tx_flush(&lif->hwstamp_txq->cq);
+		ionic_tx_empty(&lif->hwstamp_txq->q);
+	}
+
+	if (lif->hwstamp_rxq) {
+		ionic_lif_qcq_deinit(lif, lif->hwstamp_rxq);
+		ionic_rx_empty(&lif->hwstamp_rxq->q);
+	}
 }
 
 static void ionic_txrx_free(struct ionic_lif *lif)
@@ -1747,48 +2121,44 @@ static void ionic_txrx_free(struct ionic_lif *lif)
 	unsigned int i;
 
 	if (lif->txqcqs) {
-		for (i = 0; i < lif->nxqs; i++) {
-			ionic_qcq_free(lif, lif->txqcqs[i].qcq);
-			lif->txqcqs[i].qcq = NULL;
+		for (i = 0; i < lif->ionic->ntxqs_per_lif && lif->txqcqs[i]; i++) {
+			ionic_qcq_free(lif, lif->txqcqs[i]);
+			devm_kfree(lif->ionic->dev, lif->txqcqs[i]);
+			lif->txqcqs[i] = NULL;
 		}
 	}
 
 	if (lif->rxqcqs) {
-		for (i = 0; i < lif->nxqs; i++) {
-			ionic_qcq_free(lif, lif->rxqcqs[i].qcq);
-			lif->rxqcqs[i].qcq = NULL;
+		for (i = 0; i < lif->ionic->nrxqs_per_lif && lif->rxqcqs[i]; i++) {
+			ionic_qcq_free(lif, lif->rxqcqs[i]);
+			devm_kfree(lif->ionic->dev, lif->rxqcqs[i]);
+			lif->rxqcqs[i] = NULL;
 		}
 	}
-}
 
-static int ionic_link_master_qcq(struct ionic_qcq *qcq,
-				 struct ionic_qcqst *master_qs)
-{
-	struct ionic_lif *master_lif = qcq->q.lif->ionic->master_lif;
-	unsigned int slot;
-
-	slot = master_lif->nxqs + qcq->q.lif->index - 1;
-
-	/* TODO: should never be true */
-	if (master_qs[slot].qcq) {
-		netdev_err(master_lif->netdev,
-			   "bad slot number %d\n", qcq->master_slot);
-		return -ENOSPC;
+	if (lif->hwstamp_txq) {
+		ionic_qcq_free(lif, lif->hwstamp_txq);
+		devm_kfree(lif->ionic->dev, lif->hwstamp_txq);
+		lif->hwstamp_txq = NULL;
 	}
 
-	master_qs[slot].qcq = qcq;
-	master_qs[slot].stats = qcq->stats;
-	qcq->master_slot = slot;
-
-	return 0;
+	if (lif->hwstamp_rxq) {
+		ionic_qcq_free(lif, lif->hwstamp_rxq);
+		devm_kfree(lif->ionic->dev, lif->hwstamp_rxq);
+		lif->hwstamp_rxq = NULL;
+	}
 }
 
 static int ionic_txrx_alloc(struct ionic_lif *lif)
 {
-	unsigned int sg_desc_sz;
+	unsigned int num_desc, desc_sz, comp_sz, sg_desc_sz;
 	unsigned int flags;
 	unsigned int i;
 	int err = 0;
+
+	num_desc = lif->ntxq_descs;
+	desc_sz = sizeof(struct ionic_txq_desc);
+	comp_sz = sizeof(struct ionic_txq_comp);
 
 	if (lif->qtype_info[IONIC_QTYPE_TXQ].version >= 1 &&
 	    lif->qtype_info[IONIC_QTYPE_TXQ].sg_desc_sz ==
@@ -1806,68 +2176,56 @@ static int ionic_txrx_alloc(struct ionic_lif *lif)
 
 	for (i = 0; i < lif->nxqs; i++) {
 		err = ionic_qcq_alloc(lif, IONIC_QTYPE_TXQ, i, "tx", flags,
-				      lif->ntxq_descs,
-				      sizeof(struct ionic_txq_desc),
-				      sizeof(struct ionic_txq_comp),
-				      sg_desc_sz,
-				      lif->kern_pid, &lif->txqcqs[i].qcq);
+				      num_desc, desc_sz, comp_sz, sg_desc_sz,
+				      lif->kern_pid, &lif->txqcqs[i]);
 		if (err)
 			goto err_out;
 
 		if (flags & IONIC_QCQ_F_INTR) {
 			ionic_intr_coal_init(lif->ionic->idev.intr_ctrl,
-					     lif->txqcqs[i].qcq->intr.index,
+					     lif->txqcqs[i]->intr.index,
 					     lif->tx_coalesce_hw);
+			if (test_bit(IONIC_LIF_F_TX_DIM_INTR, lif->state))
+				lif->txqcqs[i]->intr.dim_coal_hw = lif->tx_coalesce_hw;
 		}
 
-		/* this makes the stats block easy to find from qcq context */
-		lif->txqcqs[i].qcq->stats = lif->txqcqs[i].stats;
-		ionic_debugfs_add_qcq(lif, lif->txqcqs[i].qcq);
-
-		if (!is_master_lif(lif)) {
-			struct ionic_qcqst *txqs = lif->ionic->master_lif->txqcqs;
-
-			err = ionic_link_master_qcq(lif->txqcqs[i].qcq, txqs);
-			if (err)
-				goto err_out;
-		}
+		ionic_debugfs_add_qcq(lif, lif->txqcqs[i]);
 	}
 
 	flags = IONIC_QCQ_F_RX_STATS | IONIC_QCQ_F_SG;
 	if (!ionic_use_eqs(lif))
 		flags |= IONIC_QCQ_F_INTR;
 
+	num_desc = lif->nrxq_descs;
+	desc_sz = sizeof(struct ionic_rxq_desc);
+	comp_sz = sizeof(struct ionic_rxq_comp);
+	sg_desc_sz = sizeof(struct ionic_rxq_sg_desc);
+
+	if (lif->rxq_features & IONIC_Q_F_2X_CQ_DESC)
+		comp_sz *= 2;
+
 	for (i = 0; i < lif->nxqs; i++) {
 		err = ionic_qcq_alloc(lif, IONIC_QTYPE_RXQ, i, "rx", flags,
-				      lif->nrxq_descs,
-				      sizeof(struct ionic_rxq_desc),
-				      sizeof(struct ionic_rxq_comp),
-				      sizeof(struct ionic_rxq_sg_desc),
-				      lif->kern_pid, &lif->rxqcqs[i].qcq);
+				      num_desc, desc_sz, comp_sz, sg_desc_sz,
+				      lif->kern_pid, &lif->rxqcqs[i]);
 		if (err)
 			goto err_out;
 
-		/* this makes the stats block easy to find from qcq context */
-		lif->rxqcqs[i].qcq->stats = lif->rxqcqs[i].stats;
-		ionic_debugfs_add_qcq(lif, lif->rxqcqs[i].qcq);
+		lif->rxqcqs[i]->q.features = lif->rxq_features;
 
 		if (flags & IONIC_QCQ_F_INTR) {
 			ionic_intr_coal_init(lif->ionic->idev.intr_ctrl,
-					     lif->rxqcqs[i].qcq->intr.index,
+					     lif->rxqcqs[i]->intr.index,
 					     lif->rx_coalesce_hw);
+			if (test_bit(IONIC_LIF_F_RX_DIM_INTR, lif->state))
+				lif->rxqcqs[i]->intr.dim_coal_hw = lif->rx_coalesce_hw;
 
 			if (!test_bit(IONIC_LIF_F_SPLIT_INTR, lif->state))
-				ionic_link_qcq_interrupts(lif->rxqcqs[i].qcq,
-							  lif->txqcqs[i].qcq);
+				ionic_link_qcq_interrupts(lif->rxqcqs[i],
+							  lif->txqcqs[i]);
 		}
 
-		if (!is_master_lif(lif)) {
-			struct ionic_qcqst *rxqs = lif->ionic->master_lif->rxqcqs;
-
-			err = ionic_link_master_qcq(lif->rxqcqs[i].qcq, rxqs);
-			if (err)
-				goto err_out;
-		}
+		ionic_debugfs_add_qcq(lif, lif->rxqcqs[i]);
 	}
 
 	return 0;
@@ -1884,13 +2242,13 @@ static int ionic_txrx_init(struct ionic_lif *lif)
 	int err;
 
 	for (i = 0; i < lif->nxqs; i++) {
-		err = ionic_lif_txq_init(lif, lif->txqcqs[i].qcq);
+		err = ionic_lif_txq_init(lif, lif->txqcqs[i]);
 		if (err)
 			goto err_out;
 
-		err = ionic_lif_rxq_init(lif, lif->rxqcqs[i].qcq);
+		err = ionic_lif_rxq_init(lif, lif->rxqcqs[i]);
 		if (err) {
-			ionic_lif_qcq_deinit(lif, lif->txqcqs[i].qcq);
+			ionic_lif_qcq_deinit(lif, lif->txqcqs[i]);
 			goto err_out;
 		}
 	}
@@ -1898,14 +2256,14 @@ static int ionic_txrx_init(struct ionic_lif *lif)
 	if (lif->netdev->features & NETIF_F_RXHASH)
 		ionic_lif_rss_init(lif);
 
-	ionic_set_rx_mode(lif->netdev);
+	ionic_set_rx_mode(lif->netdev, CAN_SLEEP);
 
 	return 0;
 
 err_out:
 	while (i--) {
-		ionic_lif_qcq_deinit(lif, lif->txqcqs[i].qcq);
-		ionic_lif_qcq_deinit(lif, lif->rxqcqs[i].qcq);
+		ionic_lif_qcq_deinit(lif, lif->txqcqs[i]);
+		ionic_lif_qcq_deinit(lif, lif->rxqcqs[i]);
 	}
 
 	return err;
@@ -1913,32 +2271,52 @@ err_out:
 
 static int ionic_txrx_enable(struct ionic_lif *lif)
 {
+	int derr = 0;
 	int i, err;
 
 	for (i = 0; i < lif->nxqs; i++) {
-		ionic_rx_fill(&lif->rxqcqs[i].qcq->q);
-		err = ionic_qcq_enable(lif->rxqcqs[i].qcq);
+		if (!(lif->rxqcqs[i] && lif->txqcqs[i])) {
+			dev_err(lif->ionic->dev, "%s: bad qcq %d\n", __func__, i);
+			err = -ENXIO;
+			goto err_out;
+		}
+
+		ionic_rx_fill(&lif->rxqcqs[i]->q);
+		err = ionic_qcq_enable(lif->rxqcqs[i]);
 		if (err)
 			goto err_out;
 
-		err = ionic_qcq_enable(lif->txqcqs[i].qcq);
+		err = ionic_qcq_enable(lif->txqcqs[i]);
 		if (err) {
-			if (err != -ETIMEDOUT)
-				ionic_qcq_disable(lif->rxqcqs[i].qcq);
+			ionic_qcq_disable(lif->rxqcqs[i], (err != -ETIMEDOUT));
 			goto err_out;
 		}
 	}
 
+	if (lif->hwstamp_rxq) {
+		ionic_rx_fill(&lif->hwstamp_rxq->q);
+		err = ionic_qcq_enable(lif->hwstamp_rxq);
+		if (err)
+			goto err_out_hwstamp_rx;
+	}
+
+	if (lif->hwstamp_txq) {
+		err = ionic_qcq_enable(lif->hwstamp_txq);
+		if (err)
+			goto err_out_hwstamp_tx;
+	}
+
 	return 0;
 
+err_out_hwstamp_tx:
+	if (lif->hwstamp_rxq)
+		derr = ionic_qcq_disable(lif->hwstamp_rxq, (derr != -ETIMEDOUT));
+err_out_hwstamp_rx:
+	i = lif->nxqs;
 err_out:
 	while (i--) {
-		err = ionic_qcq_disable(lif->txqcqs[i].qcq);
-		if (err == -ETIMEDOUT)
-			break;
-		err = ionic_qcq_disable(lif->rxqcqs[i].qcq);
-		if (err == -ETIMEDOUT)
-			break;
+		derr = ionic_qcq_disable(lif->txqcqs[i], (derr != -ETIMEDOUT));
+		derr = ionic_qcq_disable(lif->rxqcqs[i], (derr != -ETIMEDOUT));
 	}
 
 	return err;
@@ -1951,26 +2329,36 @@ static int ionic_start_queues(struct ionic_lif *lif)
 	if (test_and_set_bit(IONIC_LIF_F_UP, lif->state))
 		return 0;
 
+	/* If we've noticed that the device is in a broken state, don't
+	 * attempt to bring the queues back up.
+	 */
+	if (test_bit(IONIC_LIF_F_BROKEN, lif->state))
+		return -EIO;
+
 	err = ionic_txrx_enable(lif);
 	if (err) {
 		clear_bit(IONIC_LIF_F_UP, lif->state);
 		return err;
 	}
-
-	if (is_master_lif(lif))
-		netif_tx_wake_all_queues(lif->netdev);
-	else if (lif->upper_dev && netif_running(lif->ionic->master_lif->netdev))
-		netif_tx_wake_all_queues(lif->upper_dev);
+	netif_tx_wake_all_queues(lif->netdev);
 
 	return 0;
 }
 
-static int ionic_lif_open(struct ionic_lif *lif)
+static int ionic_open(struct net_device *netdev)
 {
+	struct ionic_lif *lif = netdev_priv(netdev);
 	int err;
 
-	dev_dbg(lif->ionic->dev, "%s: %s carrier %d\n",
-		__func__, lif->name, netif_carrier_ok(lif->netdev));
+	if (test_bit(IONIC_LIF_F_UP, lif->state)) {
+		dev_dbg(lif->ionic->dev, "%s: %s called when state=UP\n",
+			__func__, lif->name);
+		return 0;
+	}
+
+	/* If recovering from a broken state, clear the bit and we'll try again */
+	if (test_and_clear_bit(IONIC_LIF_F_BROKEN, lif->state))
+		netdev_info(netdev, "clearing broken state\n");
 
 	err = ionic_txrx_alloc(lif);
 	if (err)
@@ -1980,18 +2368,20 @@ static int ionic_lif_open(struct ionic_lif *lif)
 	if (err)
 		goto err_txrx_free;
 
-	/* don't start the queues until we have link */
-	if (is_master_lif(lif)) {
-		if (netif_carrier_ok(lif->netdev))
-			err = ionic_start_queues(lif);
-	} else {
-		if (lif->upper_dev &&
-		   netif_running(lif->ionic->master_lif->netdev) &&
-		   netif_carrier_ok(lif->ionic->master_lif->netdev))
-			err = ionic_start_queues(lif);
-	}
+	err = netif_set_real_num_tx_queues(netdev, lif->nxqs);
 	if (err)
 		goto err_txrx_deinit;
+
+	err = netif_set_real_num_rx_queues(netdev, lif->nxqs);
+	if (err)
+		goto err_txrx_deinit;
+
+	/* don't start the queues until we have link */
+	if (netif_carrier_ok(netdev)) {
+		err = ionic_start_queues(lif);
+		if (err)
+			goto err_txrx_deinit;
+	}
 
 	return 0;
 
@@ -2002,48 +2392,22 @@ err_txrx_free:
 	return err;
 }
 
-int ionic_open(struct net_device *netdev)
-{
-	struct ionic_lif *lif = netdev_priv(netdev);
-	struct ionic_lif *slif;
-	unsigned long i;
-	int err;
-
-	if (test_bit(IONIC_LIF_F_UP, lif->state)) {
-		dev_dbg(lif->ionic->dev, "%s: %s called when state=UP\n",
-			__func__, lif->name);
-		return 0;
-	}
-
-	err = ionic_lif_open(lif);
-	if (err)
-		goto open_out;
-
-	netif_set_real_num_tx_queues(netdev, lif->nxqs);
-	netif_set_real_num_rx_queues(netdev, lif->nxqs);
-
-	for_each_eth_lif(lif->ionic, i, slif)
-		if (!is_master_lif(slif))
-			ionic_lif_open(slif);
-
-open_out:
-	return err;
-}
-
 static void ionic_stop_queues(struct ionic_lif *lif)
 {
 	if (!test_and_clear_bit(IONIC_LIF_F_UP, lif->state))
 		return;
 
-	if (!is_master_lif(lif) && lif->upper_dev)
-		netif_tx_disable(lif->upper_dev);
-	else
-		netif_tx_disable(lif->netdev);
+	netif_tx_disable(lif->netdev);
 	ionic_txrx_disable(lif);
 }
 
-static int ionic_lif_stop(struct ionic_lif *lif)
+static int ionic_stop(struct net_device *netdev)
 {
+	struct ionic_lif *lif = netdev_priv(netdev);
+
+	if (test_bit(IONIC_LIF_F_FW_RESET, lif->state))
+		return 0;
+
 	ionic_stop_queues(lif);
 	ionic_txrx_deinit(lif);
 	ionic_txrx_free(lif);
@@ -2051,241 +2415,18 @@ static int ionic_lif_stop(struct ionic_lif *lif)
 	return 0;
 }
 
-int ionic_stop(struct net_device *netdev)
+static int ionic_do_ioctl(struct net_device *netdev, struct ifreq *ifr, int cmd)
 {
 	struct ionic_lif *lif = netdev_priv(netdev);
-	struct ionic_lif *slif;
-	unsigned long i;
-	int ret;
 
-	if (test_bit(IONIC_LIF_F_FW_RESET, lif->state))
-		return 0;
-
-	for_each_eth_lif(lif->ionic, i, slif)
-		if (!is_master_lif(slif))
-			ionic_lif_stop(slif);
-
-	ret = ionic_lif_stop(lif);
-
-	return ret;
-}
-
-int ionic_slave_alloc(struct ionic *ionic, enum ionic_api_prsn prsn)
-{
-	int index;
-
-	/* slave index starts at 1, master_lif is 0 */
-	index = find_first_zero_bit(ionic->lifbits, ionic->nlifs);
-	if (index > ionic->nlifs)
-		return -ENOSPC;
-
-	set_bit(index, ionic->lifbits);
-	if (prsn == IONIC_PRSN_ETH)
-		set_bit(index, ionic->ethbits);
-
-	return index;
-}
-
-void ionic_slave_free(struct ionic *ionic, int index)
-{
-	if (index > ionic->nlifs)
-		return;
-	clear_bit(index, ionic->lifbits);
-	clear_bit(index, ionic->ethbits);
-}
-
-static void *ionic_dfwd_add_station(struct net_device *lower_dev,
-				    struct net_device *upper_dev)
-{
-	struct ionic_lif *master_lif = netdev_priv(lower_dev);
-	struct ionic *ionic = master_lif->ionic;
-	union ionic_lif_identity *lid;
-	struct ionic_lif *lif;
-	int lif_index = -1;
-	int nqueues;
-	int err = 0;
-
-	if (!macvlan_supports_dest_filter(upper_dev))
-		return NULL;
-
-	/* slaves need 2 interrupts - adminq and txrx queue pair */
-	if (ionic_intr_remaining(ionic) < 2) {
-		netdev_info(lower_dev, "insufficient device interrupts left for macvlan offload\n");
-		return NULL;
+	switch (cmd) {
+	case SIOCSHWTSTAMP:
+		return ionic_lif_hwstamp_set(lif, ifr);
+	case SIOCGHWTSTAMP:
+		return ionic_lif_hwstamp_get(lif, ifr);
+	default:
+		return -EOPNOTSUPP;
 	}
-
-	/* For now, we need to assure we don't try to set up for multiqueue
-	 * macvlan channels.  Sometime in the future this will help us set
-	 * up for those multiqueue channels.
-	 */
-	lid = kzalloc(sizeof(*lid), GFP_KERNEL);
-	if (!lid) {
-		err = -ENOMEM;
-		goto err_out;
-	}
-	ionic_lif_identify(ionic, IONIC_LIF_TYPE_MACVLAN, lid);
-	nqueues = le32_to_cpu(lid->eth.config.queue_count[IONIC_QTYPE_RXQ]);
-
-	if (nqueues > 1)
-		netdev_warn_once(lower_dev, "Only 1 queue used per slave LIF\n");
-
-	/* master_lif index is 0, slave index starts at 1 */
-	lif_index = ionic_slave_alloc(ionic, IONIC_PRSN_ETH);
-	if (lif_index < 0) {
-		err = lif_index;
-		goto err_out_free_identify;
-	}
-	netdev_info(lower_dev, "slave index %d for macvlan dev %s\n",
-		    lif_index, upper_dev->name);
-
-	lif = ionic_lif_alloc(ionic, lif_index);
-	if (IS_ERR(lif)) {
-		ionic_slave_free(ionic, lif_index);
-		err = PTR_ERR(lif);
-		goto err_out_free_identify;
-	}
-	lif->identity = lid;
-	lif->lif_type = IONIC_LIF_TYPE_MACVLAN;
-	ionic_lif_queue_identify(lif);
-
-	lif->upper_dev = upper_dev;
-	err = ionic_lif_init(lif);
-	if (err)
-		goto err_out_free_slave;
-
-	err = ionic_lif_set_netdev_info(lif);
-	if (err)
-		goto err_out_deinit_slave;
-
-	err = _ionic_lif_rx_mode(lif, master_lif->rx_mode);
-	if (err)
-		goto err_out_deinit_slave;
-
-	err = ionic_lif_addr(lif, upper_dev->dev_addr, true);
-	if (err)
-		goto err_out_deinit_slave;
-
-	if (test_bit(IONIC_LIF_F_UP, master_lif->state)) {
-		err = ionic_lif_open(lif);
-		if (err)
-			goto err_out_deinit_slave;
-	}
-
-	netdev_set_sb_channel(upper_dev, lif_index);
-
-	/* bump up the netdev's in-use queue count if needed */
-	if ((master_lif->nxqs + lif_index) > lower_dev->real_num_tx_queues) {
-		int max = lower_dev->real_num_tx_queues + 1;
-
-		netif_set_real_num_tx_queues(lower_dev, max);
-	}
-
-	netdev_info(lower_dev, "%s: %s %s\n",
-		    __func__, lif->name, lif->upper_dev->name);
-
-#ifndef HAVE_MACVLAN_SB_DEV
-	/* WARNING - UGLY HACK */
-	/* This is to work around a bug in versions of the macvlan
-	 * driver prior to v4.18, where macvlan_open() doesn't call
-	 * macvlan_hash_add() in the case of an offload macvlan.  This
-	 * results in vlan->hlist not being initialized and eventually
-	 * causing NULL pointer violations.
-	 * The code below is hijacked from the macvlan driver, since
-	 * it is defined static and unaccessible.
-	 */
-	{
-#define MACVLAN_HASH_SIZE	(1<<MACVLAN_HASH_BITS)
-#define MACVLAN_HASH_BITS	8
-		struct macvlan_port {
-			struct net_device	*dev;
-			struct hlist_head	vlan_hash[MACVLAN_HASH_SIZE];
-			struct list_head	vlans;
-			struct sk_buff_head	bc_queue;
-			struct work_struct	bc_work;
-			u32			flags;
-			int			count;
-			struct hlist_head	vlan_source_hash[MACVLAN_HASH_SIZE];
-			DECLARE_BITMAP(mc_filter, MACVLAN_MC_FILTER_SZ);
-			unsigned char           perm_addr[ETH_ALEN];
-		};
-
-		struct macvlan_dev *vlan = netdev_priv(upper_dev);
-		struct macvlan_port *port = (void *)vlan->port;
-		const unsigned char *addr = vlan->dev->dev_addr;
-		u32 idx;
-		u64 value = get_unaligned((u64 *)addr);
-
-		/* only want 6 bytes */
-#ifdef __BIG_ENDIAN
-		value >>= 16;
-#else
-		value <<= 16;
-#endif
-		idx = hash_64(value, MACVLAN_HASH_BITS);
-		hlist_add_head_rcu(&vlan->hlist, &port->vlan_hash[idx]);
-	}
-#endif
-
-	return lif;
-
-err_out_deinit_slave:
-	ionic_lif_deinit(lif);
-err_out_free_slave:
-	ionic_lif_free(lif);
-err_out_free_identify:
-	kfree(lid);
-err_out:
-	netdev_err(lower_dev, "macvlan offload request failed on slave lif %d for %s: %d\n",
-		   lif_index, upper_dev->name, err);
-
-	return NULL;
-}
-
-static void ionic_dfwd_del_station(struct net_device *lower_dev, void *priv)
-{
-	struct ionic_lif *master_lif = netdev_priv(lower_dev);
-	struct ionic_lif *lif = priv;
-	unsigned long lif_index = lif->index;
-#ifndef HAVE_MACVLAN_SB_DEV
-	/* get vlan* now before lif is dismantled */
-	struct macvlan_dev *vlan = netdev_priv(lif->upper_dev);
-#endif
-
-	netdev_info(lower_dev, "%s: %s %s\n",
-		    __func__, lif->name, lif->upper_dev->name);
-	netdev_unbind_sb_channel(lower_dev, lif->netdev);
-
-	ionic_lif_stop(lif);
-	ionic_lif_deinit(lif);
-	ionic_lif_free(lif);
-
-	/* if this was the highest slot, we can decrement
-	 * the number of queues in use and find the next
-	 * highest one in use
-	 */
-	if ((master_lif->nxqs + lif_index) == lower_dev->real_num_tx_queues) {
-		int max = lower_dev->real_num_tx_queues;
-
-		while (!master_lif->txqcqs[max-1].qcq)
-			max--;
-		netif_set_real_num_tx_queues(lower_dev, max);
-	}
-
-#ifndef HAVE_MACVLAN_SB_DEV
-	/* WARNING - UGLY HACK part deux */
-	/* This is to work around a bug in versions of the macvlan
-	 * driver prior to v4.18, where macvlan_stop() doesn't call
-	 * macvlan_hash_del() in the case of an offload macvlan.  This
-	 * results in vlan->hlist not being cleaned up and eventually
-	 * causing havoc.
-	 * The code below is hijacked from the macvlan driver, since
-	 * it is defined static and unaccessible.
-	 */
-	{
-		hlist_del_rcu(&vlan->hlist);
-		synchronize_rcu();
-	}
-#endif
 }
 
 static int ionic_get_vf_config(struct net_device *netdev,
@@ -2304,11 +2445,11 @@ static int ionic_get_vf_config(struct net_device *netdev,
 		ret = -EINVAL;
 	} else {
 		ivf->vf           = vf;
-		ivf->vlan         = ionic->vfs[vf].vlanid;
-		ivf->qos          = 0;
+		ivf->vlan         = le16_to_cpu(ionic->vfs[vf].vlanid);
+		ivf->qos	  = 0;
 		ivf->spoofchk     = ionic->vfs[vf].spoofchk;
 		ivf->linkstate    = ionic->vfs[vf].linkstate;
-		ivf->max_tx_rate  = ionic->vfs[vf].maxrate;
+		ivf->max_tx_rate  = le32_to_cpu(ionic->vfs[vf].maxrate);
 		ivf->trusted      = ionic->vfs[vf].trusted;
 		ether_addr_copy(ivf->mac, ionic->vfs[vf].macaddr);
 	}
@@ -2385,8 +2526,13 @@ static int ionic_set_vf_mac(struct net_device *netdev, int vf, u8 *mac)
 #if (RHEL_RELEASE_CODE == 0 || \
      defined(HAVE_RHEL7_NETDEV_OPS_EXT_NDO_SET_VF_VLAN) || \
      RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0))
+
+#if (RHEL_RELEASE_CODE == 0 && LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0))
+static int ionic_set_vf_vlan(struct net_device *netdev, int vf, u16 vlan, u8 qos)
+#else
 static int ionic_set_vf_vlan(struct net_device *netdev, int vf, u16 vlan,
 			     u8 qos, __be16 proto)
+#endif
 {
 	struct ionic_lif *lif = netdev_priv(netdev);
 	struct ionic *ionic = lif->ionic;
@@ -2399,9 +2545,6 @@ static int ionic_set_vf_vlan(struct net_device *netdev, int vf, u16 vlan,
 	if (vlan > 4095)
 		return -EINVAL;
 
-	if (proto != htons(ETH_P_8021Q))
-		return -EPROTONOSUPPORT;
-
 	if (!netif_device_present(netdev))
 		return -EBUSY;
 
@@ -2413,7 +2556,7 @@ static int ionic_set_vf_vlan(struct net_device *netdev, int vf, u16 vlan,
 		ret = ionic_set_vf_config(ionic, vf,
 					  IONIC_VF_ATTR_VLAN, (u8 *)&vlan);
 		if (!ret)
-			ionic->vfs[vf].vlanid = vlan;
+			ionic->vfs[vf].vlanid = cpu_to_le16(vlan);
 	}
 
 	up_write(&ionic->vf_op_lock);
@@ -2443,7 +2586,7 @@ static int ionic_set_vf_rate(struct net_device *netdev, int vf,
 		ret = ionic_set_vf_config(ionic, vf,
 					  IONIC_VF_ATTR_RATE, (u8 *)&tx_max);
 		if (!ret)
-			ionic->vfs[vf].maxrate = tx_max;
+			ionic->vfs[vf].maxrate = cpu_to_le32(tx_max);
 	}
 
 	up_write(&ionic->vf_op_lock);
@@ -2546,12 +2689,10 @@ static int ionic_set_vf_link_state(struct net_device *netdev, int vf, int set)
 static const struct net_device_ops ionic_netdev_ops = {
 	.ndo_open               = ionic_open,
 	.ndo_stop               = ionic_stop,
+	.ndo_do_ioctl		= ionic_do_ioctl,
 	.ndo_start_xmit		= ionic_start_xmit,
-#ifndef HAVE_NDO_SELECT_QUEUE_SB_DEV
-	.ndo_select_queue	= ionic_select_queue,
-#endif
 	.ndo_get_stats64	= ionic_get_stats64,
-	.ndo_set_rx_mode	= ionic_set_rx_mode,
+	.ndo_set_rx_mode	= ionic_ndo_set_rx_mode,
 	.ndo_set_features	= ionic_set_features,
 	.ndo_set_mac_address	= ionic_set_mac_address,
 	.ndo_validate_addr	= eth_validate_addr,
@@ -2565,8 +2706,6 @@ static const struct net_device_ops ionic_netdev_ops = {
 	.ndo_vlan_rx_kill_vid   = ionic_vlan_rx_kill_vid,
 
 #ifdef HAVE_RHEL7_NET_DEVICE_OPS_EXT
-	.extended.ndo_dfwd_add_station = ionic_dfwd_add_station,
-	.extended.ndo_dfwd_del_station = ionic_dfwd_del_station,
 #ifdef HAVE_RHEL7_NETDEV_OPS_EXT_NDO_SET_VF_VLAN
 	.extended.ndo_set_vf_vlan	= ionic_set_vf_vlan,
 #endif
@@ -2574,8 +2713,6 @@ static const struct net_device_ops ionic_netdev_ops = {
 	.extended.ndo_set_vf_trust	= ionic_set_vf_trust,
 #endif
 #else
-	.ndo_dfwd_add_station	= ionic_dfwd_add_station,
-	.ndo_dfwd_del_station	= ionic_dfwd_del_station,
 	.ndo_set_vf_vlan	= ionic_set_vf_vlan,
 	.ndo_set_vf_trust	= ionic_set_vf_trust,
 #endif
@@ -2599,9 +2736,10 @@ static const struct net_device_ops ionic_netdev_ops = {
 static const struct net_device_ops ionic_mnic_netdev_ops = {
 	.ndo_open               = ionic_open,
 	.ndo_stop               = ionic_stop,
+	.ndo_do_ioctl		= ionic_do_ioctl,
 	.ndo_start_xmit		= ionic_start_xmit,
 	.ndo_get_stats64	= ionic_get_stats64,
-	.ndo_set_rx_mode	= ionic_set_rx_mode,
+	.ndo_set_rx_mode	= ionic_ndo_set_rx_mode,
 	.ndo_set_features	= ionic_set_features,
 	.ndo_set_mac_address	= ionic_set_mac_address,
 	.ndo_validate_addr	= eth_validate_addr,
@@ -2624,89 +2762,303 @@ static const struct net_device_ops ionic_mnic_netdev_ops = {
 #endif
 };
 
-int ionic_reset_queues(struct ionic_lif *lif, ionic_reset_cb cb, void *arg)
+static void ionic_swap_queues(struct ionic_qcq *a, struct ionic_qcq *b)
 {
-	bool running;
-	int err = 0;
+	/* only swapping the queues, not the napi, flags, or other stuff */
+	swap(a->q.features,   b->q.features);
+	swap(a->q.num_descs,  b->q.num_descs);
+	swap(a->q.desc_size,  b->q.desc_size);
+	swap(a->q.base,       b->q.base);
+	swap(a->q.base_pa,    b->q.base_pa);
+	swap(a->q.info,       b->q.info);
+	swap(a->q_base,       b->q_base);
+	swap(a->q_base_pa,    b->q_base_pa);
+	swap(a->q_size,       b->q_size);
 
-	mutex_lock(&lif->queue_lock);
+	swap(a->q.sg_desc_size, b->q.sg_desc_size);
+	swap(a->q.sg_base,    b->q.sg_base);
+	swap(a->q.sg_base_pa, b->q.sg_base_pa);
+	swap(a->sg_base,      b->sg_base);
+	swap(a->sg_base_pa,   b->sg_base_pa);
+	swap(a->sg_size,      b->sg_size);
 
-	running = netif_running(lif->netdev);
-	if (running) {
-		netif_device_detach(lif->netdev);
-		err = ionic_stop(lif->netdev);
+	swap(a->cq.num_descs, b->cq.num_descs);
+	swap(a->cq.desc_size, b->cq.desc_size);
+	swap(a->cq.base,      b->cq.base);
+	swap(a->cq.base_pa,   b->cq.base_pa);
+	swap(a->cq.info,      b->cq.info);
+	swap(a->cq_base,      b->cq_base);
+	swap(a->cq_base_pa,   b->cq_base_pa);
+	swap(a->cq_size,      b->cq_size);
+}
+
+int ionic_reconfigure_queues(struct ionic_lif *lif,
+			     struct ionic_queue_params *qparam)
+{
+	unsigned int num_desc, desc_sz, comp_sz, sg_desc_sz;
+	struct ionic_qcq **tx_qcqs = NULL;
+	struct ionic_qcq **rx_qcqs = NULL;
+	unsigned int flags;
+	int err = -ENOMEM;
+	unsigned int i;
+
+	/* allocate temporary qcq arrays to hold new queue structs */
+	if (qparam->nxqs != lif->nxqs || qparam->ntxq_descs != lif->ntxq_descs) {
+		tx_qcqs = devm_kcalloc(lif->ionic->dev, lif->ionic->ntxqs_per_lif,
+				       sizeof(struct ionic_qcq *), GFP_KERNEL);
+		if (!tx_qcqs)
+			goto err_out;
+	}
+	if (qparam->nxqs != lif->nxqs ||
+	    qparam->nrxq_descs != lif->nrxq_descs ||
+	    qparam->rxq_features != lif->rxq_features) {
+		rx_qcqs = devm_kcalloc(lif->ionic->dev, lif->ionic->nrxqs_per_lif,
+				       sizeof(struct ionic_qcq *), GFP_KERNEL);
+		if (!rx_qcqs)
+			goto err_out;
 	}
 
-	if (cb)
-		cb(lif, arg);
+	/* allocate new desc_info and rings, but leave the interrupt setup
+	 * until later so as to not mess with the still-running queues
+	 */
+	if (tx_qcqs) {
+		num_desc = qparam->ntxq_descs;
+		desc_sz = sizeof(struct ionic_txq_desc);
+		comp_sz = sizeof(struct ionic_txq_comp);
 
-	if (!err && running) {
-		err = ionic_open(lif->netdev);
-		netif_device_attach(lif->netdev);
+		if (lif->qtype_info[IONIC_QTYPE_TXQ].version >= 1 &&
+		    lif->qtype_info[IONIC_QTYPE_TXQ].sg_desc_sz ==
+		    sizeof(struct ionic_txq_sg_desc_v1))
+			sg_desc_sz = sizeof(struct ionic_txq_sg_desc_v1);
+		else
+			sg_desc_sz = sizeof(struct ionic_txq_sg_desc);
+
+		for (i = 0; i < qparam->nxqs; i++) {
+			flags = lif->txqcqs[i]->flags & ~IONIC_QCQ_F_INTR;
+			err = ionic_qcq_alloc(lif, IONIC_QTYPE_TXQ, i, "tx", flags,
+					      num_desc, desc_sz, comp_sz, sg_desc_sz,
+					      lif->kern_pid, &tx_qcqs[i]);
+			if (err)
+				goto err_out;
+		}
 	}
 
-	mutex_unlock(&lif->queue_lock);
+	if (rx_qcqs) {
+		num_desc = qparam->nrxq_descs;
+		desc_sz = sizeof(struct ionic_rxq_desc);
+		comp_sz = sizeof(struct ionic_rxq_comp);
+		sg_desc_sz = sizeof(struct ionic_rxq_sg_desc);
+
+		if (qparam->rxq_features & IONIC_Q_F_2X_CQ_DESC)
+			comp_sz *= 2;
+
+		for (i = 0; i < qparam->nxqs; i++) {
+			flags = lif->rxqcqs[i]->flags & ~IONIC_QCQ_F_INTR;
+			err = ionic_qcq_alloc(lif, IONIC_QTYPE_RXQ, i, "rx", flags,
+					      num_desc, desc_sz, comp_sz, sg_desc_sz,
+					      lif->kern_pid, &rx_qcqs[i]);
+			if (err)
+				goto err_out;
+
+			rx_qcqs[i]->q.features = qparam->rxq_features;
+		}
+	}
+
+	/* stop and clean the queues */
+	ionic_stop_queues_reconfig(lif);
+
+	if (qparam->nxqs != lif->nxqs) {
+		err = netif_set_real_num_tx_queues(lif->netdev, qparam->nxqs);
+		if (err)
+			goto err_out_reinit_unlock;
+		err = netif_set_real_num_rx_queues(lif->netdev, qparam->nxqs);
+		if (err) {
+			netif_set_real_num_tx_queues(lif->netdev, lif->nxqs);
+			goto err_out_reinit_unlock;
+		}
+	}
+
+	/* swap new desc_info and rings, keeping existing interrupt config */
+	if (tx_qcqs) {
+		lif->ntxq_descs = qparam->ntxq_descs;
+		for (i = 0; i < qparam->nxqs; i++)
+			ionic_swap_queues(lif->txqcqs[i], tx_qcqs[i]);
+	}
+
+	if (rx_qcqs) {
+		lif->nrxq_descs = qparam->nrxq_descs;
+		for (i = 0; i < qparam->nxqs; i++)
+			ionic_swap_queues(lif->rxqcqs[i], rx_qcqs[i]);
+	}
+
+	/* if we need to change the interrupt layout, this is the time */
+	if (qparam->intr_split != test_bit(IONIC_LIF_F_SPLIT_INTR, lif->state) ||
+	    qparam->nxqs != lif->nxqs) {
+		if (qparam->intr_split) {
+			set_bit(IONIC_LIF_F_SPLIT_INTR, lif->state);
+		} else {
+			clear_bit(IONIC_LIF_F_SPLIT_INTR, lif->state);
+			lif->tx_coalesce_usecs = lif->rx_coalesce_usecs;
+			lif->tx_coalesce_hw = lif->rx_coalesce_hw;
+		}
+
+		/* clear existing interrupt assignments */
+		for (i = 0; i < lif->ionic->ntxqs_per_lif; i++) {
+			ionic_qcq_intr_free(lif, lif->txqcqs[i]);
+			ionic_qcq_intr_free(lif, lif->rxqcqs[i]);
+		}
+
+		/* re-assign the interrupts */
+		for (i = 0; i < qparam->nxqs; i++) {
+			lif->rxqcqs[i]->flags |= IONIC_QCQ_F_INTR;
+			err = ionic_alloc_qcq_interrupt(lif, lif->rxqcqs[i]);
+			ionic_intr_coal_init(lif->ionic->idev.intr_ctrl,
+					     lif->rxqcqs[i]->intr.index,
+					     lif->rx_coalesce_hw);
+
+			if (qparam->intr_split) {
+				lif->txqcqs[i]->flags |= IONIC_QCQ_F_INTR;
+				err = ionic_alloc_qcq_interrupt(lif, lif->txqcqs[i]);
+				ionic_intr_coal_init(lif->ionic->idev.intr_ctrl,
+						     lif->txqcqs[i]->intr.index,
+						     lif->tx_coalesce_hw);
+				if (test_bit(IONIC_LIF_F_TX_DIM_INTR, lif->state))
+					lif->txqcqs[i]->intr.dim_coal_hw = lif->tx_coalesce_hw;
+			} else {
+				lif->txqcqs[i]->flags &= ~IONIC_QCQ_F_INTR;
+				ionic_link_qcq_interrupts(lif->rxqcqs[i], lif->txqcqs[i]);
+			}
+		}
+	}
+
+	/* now we can rework the debugfs mappings */
+	if (tx_qcqs) {
+		for (i = 0; i < qparam->nxqs; i++) {
+			ionic_debugfs_del_qcq(lif->txqcqs[i]);
+			ionic_debugfs_add_qcq(lif, lif->txqcqs[i]);
+		}
+	}
+
+	if (rx_qcqs) {
+		for (i = 0; i < qparam->nxqs; i++) {
+			ionic_debugfs_del_qcq(lif->rxqcqs[i]);
+			ionic_debugfs_add_qcq(lif, lif->rxqcqs[i]);
+		}
+	}
+
+	swap(lif->nxqs, qparam->nxqs);
+	swap(lif->rxq_features, qparam->rxq_features);
+
+err_out_reinit_unlock:
+	/* re-init the queues, but don't lose an error code */
+	if (err)
+		ionic_start_queues_reconfig(lif);
+	else
+		err = ionic_start_queues_reconfig(lif);
+
+err_out:
+	/* free old allocs without cleaning intr */
+	for (i = 0; i < qparam->nxqs; i++) {
+		if (tx_qcqs && tx_qcqs[i]) {
+			tx_qcqs[i]->flags &= ~IONIC_QCQ_F_INTR;
+			ionic_qcq_free(lif, tx_qcqs[i]);
+			devm_kfree(lif->ionic->dev, tx_qcqs[i]);
+			tx_qcqs[i] = NULL;
+		}
+		if (rx_qcqs && rx_qcqs[i]) {
+			rx_qcqs[i]->flags &= ~IONIC_QCQ_F_INTR;
+			ionic_qcq_free(lif, rx_qcqs[i]);
+			devm_kfree(lif->ionic->dev, rx_qcqs[i]);
+			rx_qcqs[i] = NULL;
+		}
+	}
+
+	/* free q array */
+	if (rx_qcqs) {
+		devm_kfree(lif->ionic->dev, rx_qcqs);
+		rx_qcqs = NULL;
+	}
+	if (tx_qcqs) {
+		devm_kfree(lif->ionic->dev, tx_qcqs);
+		tx_qcqs = NULL;
+	}
+
+	/* clean the unused dma and info allocations when new set is smaller
+	 * than the full array, but leave the qcq shells in place
+	 */
+	for (i = lif->nxqs; i < lif->ionic->ntxqs_per_lif; i++) {
+		lif->txqcqs[i]->flags &= ~IONIC_QCQ_F_INTR;
+		ionic_qcq_free(lif, lif->txqcqs[i]);
+
+		lif->rxqcqs[i]->flags &= ~IONIC_QCQ_F_INTR;
+		ionic_qcq_free(lif, lif->rxqcqs[i]);
+	}
 
 	return err;
 }
 
-static struct ionic_lif *ionic_lif_alloc(struct ionic *ionic, unsigned int index)
+int ionic_lif_alloc(struct ionic *ionic)
 {
 	struct device *dev = ionic->dev;
 	union ionic_lif_identity *lid;
+	struct net_device *netdev;
 	struct ionic_lif *lif;
+	u32 minfs, maxfs;
 	int tbl_sz;
 	int err;
 
 	lid = kzalloc(sizeof(*lid), GFP_KERNEL);
 	if (!lid)
-		return ERR_PTR(-ENOMEM);
+		return -ENOMEM;
 
-	if (index == 0) {
-		struct net_device *netdev;
-
-		netdev = ionic_alloc_netdev(ionic);
-		if (!netdev) {
-			dev_err(dev, "Cannot allocate netdev, aborting\n");
-			err = -ENOMEM;
-			goto err_out_free_lid;
-		}
-
-		SET_NETDEV_DEV(netdev, dev);
-
-		lif = netdev_priv(netdev);
-		lif->netdev = netdev;
-		ionic->master_lif = lif;
-
-		if (ionic->is_mgmt_nic || ionic->pfdev)
-			netdev->netdev_ops = &ionic_mnic_netdev_ops;
-		else
-			netdev->netdev_ops = &ionic_netdev_ops;
-
-		ionic_ethtool_set_ops(netdev);
-		netdev->watchdog_timeo = 2 * HZ;
-		netif_carrier_off(netdev);
-
-		lif->nrdma_eqs_avail = ionic->nrdma_eqs_per_lif;
-		lif->nrdma_eqs = ionic->nrdma_eqs_per_lif;
-		lif->nxqs = ionic->ntxqs_per_lif;
-	} else {
-		/* slave lifs */
-
-		lif = kzalloc(sizeof(*lif), GFP_KERNEL);
-		if (!lif) {
-			dev_err(dev, "Cannot allocate slave lif %d\n", index);
-			return ERR_PTR(-ENOMEM);
-		}
-		lif->netdev = ionic->master_lif->netdev;
-		lif->nxqs = 1;
+	netdev = ionic_alloc_netdev(ionic);
+	if (!netdev) {
+		dev_err(dev, "Cannot allocate netdev, aborting\n");
+		err = -ENOMEM;
+		goto err_out_free_lid;
 	}
 
+	SET_NETDEV_DEV(netdev, dev);
+
+	lif = netdev_priv(netdev);
+	lif->netdev = netdev;
+	ionic->lif = lif;
+
+	if (ionic->is_mgmt_nic || ionic->pfdev)
+		netdev->netdev_ops = &ionic_mnic_netdev_ops;
+	else
+		netdev->netdev_ops = &ionic_netdev_ops;
+
+	ionic_ethtool_set_ops(netdev);
+	netdev->watchdog_timeo = 2 * HZ;
+	netif_carrier_off(netdev);
+
+	lif->nrdma_eqs_avail = ionic->nrdma_eqs_per_lif;
+	lif->nrdma_eqs = ionic->nrdma_eqs_per_lif;
+	lif->nxqs = ionic->ntxqs_per_lif;
+
 	lif->identity = lid;
+	lif->lif_type = IONIC_LIF_TYPE_CLASSIC;
+	ionic_lif_identify(ionic, lif->lif_type, lif->identity);
+
 	lif->ionic = ionic;
-	lif->index = index;
+	lif->index = 0;
 	lif->ntxq_descs = IONIC_DEF_TXRX_DESC;
 	lif->nrxq_descs = IONIC_DEF_TXRX_DESC;
+
+	/* find mtu limits */
+	minfs = __le32_to_cpu(lif->identity->eth.min_frame_size);
+	minfs = max_t(unsigned int, minfs, ETH_MIN_MTU);
+	maxfs = __le32_to_cpu(lif->identity->eth.max_frame_size)  - ETH_HLEN - VLAN_HLEN;
+#ifdef HAVE_NETDEVICE_MIN_MAX_MTU
+#ifdef HAVE_RHEL7_EXTENDED_MIN_MAX_MTU
+	lif->netdev->extended->min_mtu = minfs;
+	lif->netdev->extended->max_mtu = maxfs;
+#else
+	lif->netdev->min_mtu = minfs;
+	lif->netdev->max_mtu = maxfs;
+#endif /* HAVE_RHEL7_EXTENDED_MIN_MAX_MTU */
+#endif /* HAVE_NETDEVICE_MIN_MAX_MTU */
 
 	/* Convert the default coalesce value to actual hw resolution */
 	lif->rx_coalesce_usecs = IONIC_ITR_COAL_USEC_DEFAULT;
@@ -2714,8 +3066,10 @@ static struct ionic_lif *ionic_lif_alloc(struct ionic *ionic, unsigned int index
 						    lif->rx_coalesce_usecs);
 	lif->tx_coalesce_usecs = lif->rx_coalesce_usecs;
 	lif->tx_coalesce_hw = lif->rx_coalesce_hw;
+	set_bit(IONIC_LIF_F_RX_DIM_INTR, lif->state);
+	set_bit(IONIC_LIF_F_TX_DIM_INTR, lif->state);
 
-	snprintf(lif->name, sizeof(lif->name), "lif%u", index);
+	snprintf(lif->name, sizeof(lif->name), "lif%u", lif->index);
 
 	spin_lock_init(&lif->adminq_lock);
 
@@ -2735,7 +3089,8 @@ static struct ionic_lif *ionic_lif_alloc(struct ionic *ionic, unsigned int index
 
 	ionic_debugfs_add_lif(lif);
 
-	/* allocate queues */
+	/* allocate control queues and txrx queue arrays */
+	ionic_lif_queue_identify(lif);
 	err = ionic_qcqs_alloc(lif);
 	if (err)
 		goto err_out_free_lif_info;
@@ -2754,19 +3109,10 @@ static struct ionic_lif *ionic_lif_alloc(struct ionic *ionic, unsigned int index
 	}
 	netdev_rss_key_fill(lif->rss_hash_key, IONIC_RSS_HASH_KEY_SIZE);
 
-	err = radix_tree_insert(&ionic->lifs, lif->index, lif);
-	if (err) {
-		dev_err(dev, "Radix tree insertion failed %d, aborting\n", err);
-		goto err_out_free_rss;
-	}
+	ionic_lif_alloc_phc(lif);
 
-	return lif;
+	return 0;
 
-err_out_free_rss:
-	dma_free_coherent(dev, lif->rss_ind_tbl_sz, lif->rss_ind_tbl,
-			  lif->rss_ind_tbl_pa);
-	lif->rss_ind_tbl = NULL;
-	lif->rss_ind_tbl_pa = 0;
 err_out_free_qcqs:
 	ionic_qcqs_free(lif);
 err_out_free_lif_info:
@@ -2774,55 +3120,12 @@ err_out_free_lif_info:
 	lif->info = NULL;
 	lif->info_pa = 0;
 err_out_free_netdev:
-	if (is_master_lif(lif))
-		free_netdev(lif->netdev);
-	else
-		kfree(lif);
+	free_netdev(lif->netdev);
 	lif = NULL;
 err_out_free_lid:
 	kfree(lid);
 
-	return ERR_PTR(err);
-}
-
-int ionic_lifs_alloc(struct ionic *ionic)
-{
-	struct ionic_lif *lif;
-	u32 minfs, maxfs;
-
-	INIT_RADIX_TREE(&ionic->lifs, GFP_KERNEL);
-
-	/* only build the first lif, others are for dynamic macvlan or rdma */
-	set_bit(0, ionic->lifbits);
-	set_bit(0, ionic->ethbits);
-
-	lif = ionic_lif_alloc(ionic, 0);
-	if (lif && !IS_ERR(lif)) {
-		ionic_lif_identify(ionic, IONIC_LIF_TYPE_CLASSIC, lif->identity);
-
-		if (is_master_lif(lif)) {
-			minfs = __le32_to_cpu(lif->identity->eth.min_frame_size);
-			maxfs = __le32_to_cpu(lif->identity->eth.max_frame_size)  - ETH_HLEN - VLAN_HLEN;
-#ifdef HAVE_NETDEVICE_MIN_MAX_MTU
-#ifdef HAVE_RHEL7_EXTENDED_MIN_MAX_MTU
-			lif->netdev->extended->min_mtu = minfs;
-			lif->netdev->extended->max_mtu = maxfs;
-#else
-			lif->netdev->min_mtu = minfs;
-			lif->netdev->max_mtu = maxfs;
-#endif /* HAVE_RHEL7_EXTENDED_MIN_MAX_MTU */
-#endif /* HAVE_NETDEVICE_MIN_MAX_MTU */
-		}
-
-		lif->lif_type = IONIC_LIF_TYPE_CLASSIC;
-		ionic_lif_queue_identify(lif);
-	} else {
-		clear_bit(0, ionic->ethbits);
-		clear_bit(0, ionic->lifbits);
-		return -ENOMEM;
-	}
-
-	return 0;
+	return err;
 }
 
 static void ionic_lif_reset(struct ionic_lif *lif)
@@ -2838,8 +3141,6 @@ static void ionic_lif_reset(struct ionic_lif *lif)
 static void ionic_lif_handle_fw_down(struct ionic_lif *lif)
 {
 	struct ionic *ionic = lif->ionic;
-	struct ionic_lif *slif;
-	unsigned long i;
 
 	if (test_and_set_bit(IONIC_LIF_F_FW_RESET, lif->state))
 		return;
@@ -2850,32 +3151,19 @@ static void ionic_lif_handle_fw_down(struct ionic_lif *lif)
 	netif_device_detach(lif->netdev);
 
 	if (test_bit(IONIC_LIF_F_UP, lif->state)) {
-		dev_info(ionic->dev, "Surprise FW stop, stopping netdev\n");
-
-		for_each_eth_lif(lif->ionic, i, slif)
-			if (!is_master_lif(slif))
-				ionic_stop_queues(slif);
-
+		dev_info(ionic->dev, "Surprise FW stop, stopping queues\n");
+		mutex_lock(&lif->queue_lock);
 		ionic_stop_queues(lif);
+		mutex_unlock(&lif->queue_lock);
 	}
 
 	if (netif_running(lif->netdev)) {
-		for_each_eth_lif(lif->ionic, i, slif)
-			if (!is_master_lif(slif)) {
-				ionic_txrx_deinit(slif);
-				ionic_txrx_free(slif);
-			}
-
 		ionic_txrx_deinit(lif);
 		ionic_txrx_free(lif);
 	}
 
-	ionic_lifs_deinit(ionic);
+	ionic_lif_deinit(lif);
 	ionic_reset(ionic);
-
-	for_each_eth_lif(lif->ionic, i, slif)
-		if (!is_master_lif(slif))
-			ionic_qcqs_free(slif);
 	ionic_qcqs_free(lif);
 
 	dev_info(ionic->dev, "FW Down: LIFs stopped\n");
@@ -2884,8 +3172,6 @@ static void ionic_lif_handle_fw_down(struct ionic_lif *lif)
 static void ionic_lif_handle_fw_up(struct ionic_lif *lif)
 {
 	struct ionic *ionic = lif->ionic;
-	struct ionic_lif *slif;
-	unsigned long i;
 	int err;
 
 	if (!test_bit(IONIC_LIF_F_FW_RESET, lif->state))
@@ -2894,15 +3180,20 @@ static void ionic_lif_handle_fw_up(struct ionic_lif *lif)
 	dev_info(ionic->dev, "FW Up: restarting LIFs\n");
 
 	ionic_init_devinfo(ionic);
-	ionic_port_init(ionic);
+	err = ionic_identify(ionic);
+	if (err)
+		goto err_out;
+	err = ionic_port_identify(ionic);
+	if (err)
+		goto err_out;
+	err = ionic_port_init(ionic);
+	if (err)
+		goto err_out;
 	err = ionic_qcqs_alloc(lif);
 	if (err)
 		goto err_out;
-	for_each_eth_lif(lif->ionic, i, slif)
-		if (!is_master_lif(slif))
-			ionic_qcqs_alloc(slif);
 
-	err = ionic_lifs_init(ionic);
+	err = ionic_lif_init(lif);
 	if (err)
 		goto err_qcqs_free;
 
@@ -2922,7 +3213,7 @@ static void ionic_lif_handle_fw_up(struct ionic_lif *lif)
 	}
 
 	clear_bit(IONIC_LIF_F_FW_RESET, lif->state);
-	ionic_link_status_check_request(lif);
+	ionic_link_status_check_request(lif, CAN_SLEEP);
 	netif_device_attach(lif->netdev);
 	dev_info(ionic->dev, "FW Up: LIFs restarted\n");
 
@@ -2931,17 +3222,18 @@ static void ionic_lif_handle_fw_up(struct ionic_lif *lif)
 err_txrx_free:
 	ionic_txrx_free(lif);
 err_lifs_deinit:
-	ionic_lifs_deinit(ionic);
+	ionic_lif_deinit(lif);
 err_qcqs_free:
 	ionic_qcqs_free(lif);
 err_out:
-	dev_info(ionic->dev, "FW Up: LIFs restart failed\n");
+	dev_err(ionic->dev, "FW Up: LIFs restart failed - err %d\n", err);
 }
 
-static void ionic_lif_free(struct ionic_lif *lif)
+void ionic_lif_free(struct ionic_lif *lif)
 {
 	struct device *dev = lif->ionic->dev;
-	struct ionic *ionic = lif->ionic;
+
+	ionic_lif_free_phc(lif);
 
 	/* free rss indirection table */
 	dma_free_coherent(dev, lif->rss_ind_tbl_sz, lif->rss_ind_tbl,
@@ -2961,52 +3253,31 @@ static void ionic_lif_free(struct ionic_lif *lif)
 	lif->info_pa = 0;
 
 	/* unmap doorbell page */
-	ionic_bus_unmap_dbpage(ionic, lif->kern_dbpage);
+	ionic_bus_unmap_dbpage(lif->ionic, lif->kern_dbpage);
 	lif->kern_dbpage = NULL;
 	kfree(lif->dbid_inuse);
 	lif->dbid_inuse = NULL;
 
 	/* free netdev & lif */
 	ionic_debugfs_del_lif(lif);
-	radix_tree_delete(&ionic->lifs, lif->index);
-	if (is_master_lif(lif)) {
-		lif->ionic->master_lif = NULL;
-		free_netdev(lif->netdev);
-	} else {
-		ionic_slave_free(ionic, lif->index);
-		memset(lif, 0, sizeof(*lif));
-		kfree(lif);
-	}
+	free_netdev(lif->netdev);
 }
 
-void ionic_lifs_free(struct ionic *ionic)
+void ionic_lif_deinit(struct ionic_lif *lif)
 {
-	struct ionic_lif *lif;
-	unsigned long i;
-
-	for_each_eth_lif(ionic, i, lif)
-		ionic_lif_free(lif);
-}
-
-static void ionic_lif_deinit(struct ionic_lif *lif)
-{
-	if (!test_bit(IONIC_LIF_F_INITED, lif->state))
+	if (!test_and_clear_bit(IONIC_LIF_F_INITED, lif->state))
 		return;
-
-	clear_bit(IONIC_LIF_F_INITED, lif->state);
 
 	if (!test_bit(IONIC_LIF_F_FW_RESET, lif->state)) {
 		cancel_work_sync(&lif->deferred.work);
 		cancel_work_sync(&lif->tx_timeout_work);
 		ionic_rx_filters_deinit(lif);
-		if (is_master_lif(lif))
+		if (lif->netdev->features & NETIF_F_RXHASH)
 			ionic_lif_rss_deinit(lif);
 	}
 
-	if (is_master_lif(lif)) {
-		ionic_eqs_deinit(lif->ionic);
-		ionic_eqs_free(lif->ionic);
-	}
+	ionic_eqs_deinit(lif->ionic);
+	ionic_eqs_free(lif->ionic);
 
 	napi_disable(&lif->adminqcq->napi);
 	ionic_lif_qcq_deinit(lif, lif->notifyqcq);
@@ -3015,15 +3286,6 @@ static void ionic_lif_deinit(struct ionic_lif *lif)
 	mutex_destroy(&lif->dbid_inuse_lock);
 	mutex_destroy(&lif->queue_lock);
 	ionic_lif_reset(lif);
-}
-
-void ionic_lifs_deinit(struct ionic *ionic)
-{
-	struct ionic_lif *lif;
-	unsigned long i;
-
-	for_each_eth_lif(ionic, i, lif)
-		ionic_lif_deinit(lif);
 }
 
 static int ionic_lif_adminq_init(struct ionic_lif *lif)
@@ -3064,6 +3326,7 @@ static int ionic_lif_adminq_init(struct ionic_lif *lif)
 	if (qcq->flags & IONIC_QCQ_F_INTR)
 		ionic_intr_mask(idev->intr_ctrl, qcq->intr.index,
 				IONIC_INTR_MASK_CLEAR);
+
 	qcq->flags |= IONIC_QCQ_F_INITED;
 
 	return 0;
@@ -3134,9 +3397,6 @@ static int ionic_station_set(struct ionic_lif *lif)
 	struct sockaddr addr;
 	int err;
 
-	if (!is_master_lif(lif))
-		return 0;
-
 	err = ionic_adminq_post_wait(lif, &ctx);
 	if (err)
 		return err;
@@ -3153,28 +3413,29 @@ static int ionic_station_set(struct ionic_lif *lif)
 		 * sure the netdev mac is in our filter list.
 		 */
 		if (!ether_addr_equal(ctx.comp.lif_getattr.mac, netdev->dev_addr))
-			ionic_lif_addr(lif, netdev->dev_addr, true);
+			ionic_lif_addr(lif, netdev->dev_addr, ADD_ADDR, CAN_SLEEP);
 	} else {
 		/* Update the netdev mac with the device's mac */
 		memcpy(addr.sa_data, ctx.comp.lif_getattr.mac, netdev->addr_len);
 		addr.sa_family = AF_INET;
 		err = eth_prepare_mac_addr_change(netdev, &addr);
 		if (err) {
-			netdev_warn(lif->netdev, "ignoring bad MAC addr from NIC %pM\n",
-				    addr.sa_data);
+			netdev_warn(lif->netdev, "ignoring bad MAC addr from NIC %pM - err %d\n",
+				    addr.sa_data, err);
 			return 0;
 		}
+
 		eth_commit_mac_addr_change(netdev, &addr);
 	}
 
 	netdev_dbg(lif->netdev, "adding station MAC addr %pM\n",
 		   netdev->dev_addr);
-	ionic_lif_addr(lif, netdev->dev_addr, true);
+	ionic_lif_addr(lif, netdev->dev_addr, ADD_ADDR, CAN_SLEEP);
 
 	return 0;
 }
 
-static int ionic_lif_init(struct ionic_lif *lif)
+int ionic_lif_init(struct ionic_lif *lif)
 {
 	struct ionic_dev *idev = &lif->ionic->idev;
 	struct device *dev = lif->ionic->dev;
@@ -3219,7 +3480,7 @@ static int ionic_lif_init(struct ionic_lif *lif)
 		goto err_out_free_dbid;
 	}
 
-	if (is_master_lif(lif) && lif->ionic->neth_eqs) {
+	if (lif->ionic->neth_eqs) {
 		err = ionic_eqs_alloc(lif->ionic);
 		if (err) {
 			dev_err(dev, "Cannot allocate EQs: %d\n", err);
@@ -3238,7 +3499,7 @@ static int ionic_lif_init(struct ionic_lif *lif)
 	if (err)
 		goto err_out_adminq_deinit;
 
-	if (is_master_lif(lif) && lif->ionic->nnqs_per_lif) {
+	if (lif->ionic->nnqs_per_lif) {
 		err = ionic_lif_notifyq_init(lif);
 		if (err)
 			goto err_out_notifyq_deinit;
@@ -3272,6 +3533,9 @@ err_out_adminq_deinit:
 	ionic_lif_qcq_deinit(lif, lif->adminqcq);
 	ionic_eqs_deinit(lif->ionic);
 	ionic_eqs_free(lif->ionic);
+	ionic_lif_reset(lif);
+	ionic_bus_unmap_dbpage(lif->ionic, lif->kern_dbpage);
+	lif->kern_dbpage = NULL;
 err_out_free_dbid:
 	kfree(lif->dbid_inuse);
 	lif->dbid_inuse = NULL;
@@ -3279,26 +3543,11 @@ err_out_free_dbid:
 	return err;
 }
 
-int ionic_lifs_init(struct ionic *ionic)
-{
-	struct ionic_lif *lif;
-	unsigned long i;
-	int err;
-
-	for_each_eth_lif(ionic, i, lif) {
-		err = ionic_lif_init(lif);
-		if (err)
-			return err;
-	}
-
-	return 0;
-}
-
 static void ionic_lif_notify_work(struct work_struct *ws)
 {
 }
 
-static int ionic_lif_set_netdev_info(struct ionic_lif *lif)
+static void ionic_lif_set_netdev_info(struct ionic_lif *lif)
 {
 	struct ionic_admin_ctx ctx = {
 		.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
@@ -3309,14 +3558,10 @@ static int ionic_lif_set_netdev_info(struct ionic_lif *lif)
 		},
 	};
 
-	if (is_master_lif(lif))
-		strlcpy(ctx.cmd.lif_setattr.name, lif->netdev->name,
-			sizeof(ctx.cmd.lif_setattr.name));
-	else
-		strlcpy(ctx.cmd.lif_setattr.name, lif->upper_dev->name,
-			sizeof(ctx.cmd.lif_setattr.name));
+	strlcpy(ctx.cmd.lif_setattr.name, lif->netdev->name,
+		sizeof(ctx.cmd.lif_setattr.name));
 
-	return ionic_adminq_post_wait(lif, &ctx);
+	ionic_adminq_post_wait(lif, &ctx);
 }
 
 struct ionic_lif *ionic_netdev_lif(struct net_device *netdev)
@@ -3346,60 +3591,62 @@ static int ionic_lif_notify(struct notifier_block *nb,
 	return NOTIFY_DONE;
 }
 
-int ionic_lifs_register(struct ionic *ionic)
+int ionic_lif_register(struct ionic_lif *lif)
 {
 	int err;
 
-	INIT_WORK(&ionic->nb_work, ionic_lif_notify_work);
+	ionic_lif_register_phc(lif);
 
-	ionic->nb.notifier_call = ionic_lif_notify;
+	INIT_WORK(&lif->ionic->nb_work, ionic_lif_notify_work);
 
-	err = register_netdevice_notifier(&ionic->nb);
+	lif->ionic->nb.notifier_call = ionic_lif_notify;
+
+	err = register_netdevice_notifier(&lif->ionic->nb);
 	if (err)
-		ionic->nb.notifier_call = NULL;
+		lif->ionic->nb.notifier_call = NULL;
 
 	/* only register LIF0 for now */
-	err = register_netdev(ionic->master_lif->netdev);
+	err = register_netdev(lif->netdev);
 	if (err) {
-		dev_err(ionic->dev, "Cannot register net device, aborting\n");
+		dev_err(lif->ionic->dev, "Cannot register net device, aborting\n");
+		ionic_lif_unregister_phc(lif);
 		return err;
 	}
 
-	ionic_link_status_check_request(ionic->master_lif);
-	ionic->master_lif->registered = true;
+	ionic_link_status_check_request(lif, CAN_SLEEP);
+	lif->registered = true;
 
-	ionic_lif_set_netdev_info(ionic->master_lif);
+	ionic_lif_set_netdev_info(lif);
 
 	return 0;
 }
 
-void ionic_lifs_unregister(struct ionic *ionic)
+void ionic_lif_unregister(struct ionic_lif *lif)
 {
-	if (ionic->nb.notifier_call) {
-		unregister_netdevice_notifier(&ionic->nb);
-		cancel_work_sync(&ionic->nb_work);
-		ionic->nb.notifier_call = NULL;
+	if (lif->ionic->nb.notifier_call) {
+		unregister_netdevice_notifier(&lif->ionic->nb);
+		cancel_work_sync(&lif->ionic->nb_work);
+		lif->ionic->nb.notifier_call = NULL;
 	}
 
-	/* There is only one lif ever registered in the
-	 * current model, so don't bother searching the
-	 * ionic->lif for candidates to unregister
-	 */
-	if (ionic->master_lif &&
-	    ionic->master_lif->netdev->reg_state == NETREG_REGISTERED)
-		unregister_netdev(ionic->master_lif->netdev);
+	if (lif->netdev->reg_state == NETREG_REGISTERED)
+		unregister_netdev(lif->netdev);
+
+	ionic_lif_unregister_phc(lif);
+
+	lif->registered = false;
 }
 
 static void ionic_lif_queue_identify(struct ionic_lif *lif)
 {
+	union ionic_q_identity __iomem *q_ident;
 	struct ionic *ionic = lif->ionic;
-	union ionic_q_identity *q_ident;
 	struct ionic_dev *idev;
 	int qtype;
 	int err;
 
 	idev = &lif->ionic->idev;
-	q_ident = (union ionic_q_identity *)&idev->dev_cmd_regs->data;
+	q_ident = (union ionic_q_identity __iomem *)&idev->dev_cmd_regs->data;
 
 	for (qtype = 0; qtype < ARRAY_SIZE(ionic_qtype_versions); qtype++) {
 		struct ionic_qtype_info *qti = &lif->qtype_info[qtype];
@@ -3422,14 +3669,14 @@ static void ionic_lif_queue_identify(struct ionic_lif *lif)
 					     ionic_qtype_versions[qtype]);
 		err = ionic_dev_cmd_wait(ionic, devcmd_timeout);
 		if (!err) {
-			qti->version   = q_ident->version;
-			qti->supported = q_ident->supported;
-			qti->features  = le64_to_cpu(q_ident->features);
-			qti->desc_sz   = le16_to_cpu(q_ident->desc_sz);
-			qti->comp_sz   = le16_to_cpu(q_ident->comp_sz);
-			qti->sg_desc_sz   = le16_to_cpu(q_ident->sg_desc_sz);
-			qti->max_sg_elems = le16_to_cpu(q_ident->max_sg_elems);
-			qti->sg_desc_stride = le16_to_cpu(q_ident->sg_desc_stride);
+			qti->version   = ioread8(&q_ident->version);
+			qti->supported = ioread8(&q_ident->supported);
+			qti->features  = readq(&q_ident->features);
+			qti->desc_sz   = ioread16(&q_ident->desc_sz);
+			qti->comp_sz   = ioread16(&q_ident->comp_sz);
+			qti->sg_desc_sz   = ioread16(&q_ident->sg_desc_sz);
+			qti->max_sg_elems = ioread16(&q_ident->max_sg_elems);
+			qti->sg_desc_stride = ioread16(&q_ident->sg_desc_stride);
 		}
 		mutex_unlock(&ionic->dev_cmd_lock);
 
@@ -3542,7 +3789,7 @@ int ionic_lif_identify(struct ionic *ionic, u8 lif_type,
 	return 0;
 }
 
-int ionic_lifs_size(struct ionic *ionic)
+int ionic_lif_size(struct ionic *ionic)
 {
 	struct ionic_identity *ident = &ionic->ident;
 	union ionic_lif_config *lc = &ident->lif.eth.config;
@@ -3556,11 +3803,9 @@ int ionic_lifs_size(struct ionic *ionic)
 	unsigned int nrdma_eqs;
 	unsigned int neth_eqs;
 	unsigned int nintrs;
-	unsigned int nlifs;
 	unsigned int nxqs;
 	int err;
 
-	nlifs = le32_to_cpu(ident->dev.nlifs);
 	dev_nintrs = le32_to_cpu(ident->dev.nintrs);
 
 	if (ionic->is_mgmt_nic)
@@ -3574,17 +3819,13 @@ int ionic_lifs_size(struct ionic *ionic)
 	ntxqs_per_lif = le32_to_cpu(lc->queue_count[IONIC_QTYPE_TXQ]);
 	nrxqs_per_lif = le32_to_cpu(lc->queue_count[IONIC_QTYPE_RXQ]);
 
-	if (max_slaves)
-		nlifs = min(nlifs, (max_slaves + 1));
-
 	/* Queue counts are driven by CPU count and interrupt availability.
 	 * In the best case, we'd like to have an individual interrupt
 	 * per CPU and one queuepair per interrupt.  For systems with
 	 * small CPU counts, or when we limit the queues-per-lif, this
 	 * works out pretty easily.  However, this can get out of hand and
 	 * have the driver requesting hundreds of interrupt vectors if we
-	 * allow lots of queues per lif, lots of macvlan offload slaves,
-	 * and lots of RDMA queues.
+	 * allow lots of queues per lif and lots of RDMA queues.
 	 *
 	 * One way of managing this is that when the interrupt count gets
 	 * out of hand we cut down on the number of things that need
@@ -3592,9 +3833,13 @@ int ionic_lifs_size(struct ionic *ionic)
 	 *
 	 * Another way of managing this is by using a smaller number of
 	 * EventQueues on which we can multiplex interrupt events.
-	 * We expect that device configurations supporting macvlan offload
-	 * (aka "scale" profiles) will support EventQueues.
 	 */
+
+	/* reserve last queue id for hardware timestamping */
+	if (lc->features & IONIC_ETH_HW_TIMESTAMP) {
+		ntxqs_per_lif -= 1;
+		nrxqs_per_lif -= 1;
+	}
 
 	/* limit TxRx queuepairs and RDMA event queues to num cpu */
 	nxqs = min(ntxqs_per_lif, nrxqs_per_lif);
@@ -3603,20 +3848,18 @@ int ionic_lifs_size(struct ionic *ionic)
 	neth_eqs = min(dev_neth_eqs, num_online_cpus());
 
 	/* EventQueue interrupt usage: (if eq_count != 0)
-	 *    (1 aq intr * num lifs) + n EQs + m RDMA
+	 *    1 aq intr + n EQs + m RDMA
 	 *
 	 * Default interrupt usage:
 	 *         lif0 has n TxRx queues and 1 Adminq
-	 *         slaves lifs have 1 TxRx queue and 1 Adminq
 	 *    (1 aq interrupt + n TxRx queue interrupts)
-	 *    + ((num lifs - 1) * 2)
 	 *    + whatever's left is for RDMA queues
 	 */
 try_again:
 	if (neth_eqs)
-		nintrs = nlifs + neth_eqs + nrdma_eqs;
+		nintrs = 1 + neth_eqs + nrdma_eqs;
 	else
-		nintrs = (1 + nxqs) + ((nlifs - 1) * 2) + nrdma_eqs;
+		nintrs = 1 + nxqs + nrdma_eqs;
 	min_intrs = 2;  /* adminq + 1 TxRx queue pair */
 
 	if (nintrs > dev_nintrs)
@@ -3639,7 +3882,7 @@ try_again:
 	ionic->ntxqs_per_lif = nxqs;
 	ionic->nrxqs_per_lif = nxqs;
 	ionic->nintrs = nintrs;
-	ionic->nlifs = nlifs;
+	ionic->nlifs = 1;
 	ionic->neth_eqs = neth_eqs;
 
 	ionic_debugfs_add_sizes(ionic);
@@ -3665,11 +3908,6 @@ try_fewer:
 		neth_eqs >>= 1;
 		goto try_again;
 	}
-	/* Cut number of lifs */
-	if (nlifs > 1) {
-		nlifs >>= 1;
-		goto try_again;
-	}
 	/* Cut number of TxRx queuepairs */
 	if (nxqs > 1) {
 		nxqs >>= 1;
@@ -3677,4 +3915,65 @@ try_fewer:
 	}
 	dev_err(ionic->dev, "Can't get minimum %d intrs from OS\n", min_intrs);
 	return -ENOSPC;
+}
+
+void ionic_device_reset(struct ionic_lif *lif)
+{
+	struct ionic *ionic = lif->ionic;
+	int err;
+
+	dev_info(ionic->dev, "Device reset starting\n");
+
+	ionic_stop_queues_reconfig(lif);
+	ionic_txrx_free(lif);
+	mutex_unlock(&lif->queue_lock);
+
+	ionic_lif_deinit(lif);
+	ionic_reset(ionic);
+	ionic_qcqs_free(lif);
+
+	ionic_port_reset(ionic);
+	ionic_reset(ionic);
+
+	ionic_init_devinfo(ionic);
+	err = ionic_identify(ionic);
+	if (err)
+		goto err_out;
+	err = ionic_port_identify(ionic);
+	if (err)
+		goto err_out;
+	err = ionic_port_init(ionic);
+	if (err)
+		goto err_out;
+	err = ionic_qcqs_alloc(lif);
+	if (err)
+		goto err_out;
+
+	err = ionic_lif_init(lif);
+	if (err)
+		goto err_qcqs_free;
+
+	ionic_lif_set_netdev_info(lif);
+	ionic_rx_filter_replay(lif);
+
+	if (netif_running(lif->netdev)) {
+		mutex_lock(&lif->queue_lock);
+		err = ionic_txrx_alloc(lif);
+		if (err)
+			goto err_lifs_deinit;
+
+		ionic_start_queues_reconfig(lif);
+	}
+
+	netif_device_attach(lif->netdev);
+
+	dev_info(ionic->dev, "Device reset done\n");
+	return;
+
+err_lifs_deinit:
+	ionic_lif_deinit(lif);
+err_qcqs_free:
+	ionic_qcqs_free(lif);
+err_out:
+	return;
 }

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -4,6 +4,15 @@
 #ifndef _IONIC_LIF_H_
 #define _IONIC_LIF_H_
 
+#include <linux/ptp_clock_kernel.h>
+#include <linux/timecounter.h>
+
+#ifdef CONFIG_DIMLIB
+#include <linux/dim.h>
+#else
+#include "dim.h"
+#endif
+
 #include "ionic_rx_filter.h"
 
 #define IONIC_ADMINQ_LENGTH	16	/* must be a power of two */
@@ -11,6 +20,11 @@
 
 #define IONIC_MAX_NUM_NAPI_CNTR		(NAPI_POLL_WEIGHT + 1)
 #define IONIC_MAX_NUM_SG_CNTR		(IONIC_TX_MAX_SG_ELEMS + 1)
+
+#define ADD_ADDR	true
+#define DEL_ADDR	false
+#define CAN_SLEEP	true
+#define CAN_NOT_SLEEP	false
 
 /* Tunables */
 #define IONIC_RX_COPYBREAK_DEFAULT	256
@@ -30,6 +44,8 @@ struct ionic_tx_stats {
 	u64 crc32_csum;
 	u64 sg_cntr[IONIC_MAX_NUM_SG_CNTR];
 	u64 dma_map_err;
+	u64 hwstamp_valid;
+	u64 hwstamp_invalid;
 };
 
 struct ionic_rx_stats {
@@ -43,6 +59,8 @@ struct ionic_rx_stats {
 	u64 csum_error;
 	u64 dma_map_err;
 	u64 alloc_err;
+	u64 hwstamp_valid;
+	u64 hwstamp_invalid;
 };
 
 #define IONIC_QCQ_F_INITED		BIT(0)
@@ -57,37 +75,30 @@ struct ionic_napi_stats {
 	u64 work_done_cntr[IONIC_MAX_NUM_NAPI_CNTR];
 };
 
-struct ionic_q_stats {
-	union {
-		struct ionic_tx_stats tx;
-		struct ionic_rx_stats rx;
-	};
-};
-
 struct ionic_qcq {
-	void *base;
-	dma_addr_t base_pa;
-	unsigned int total_size;
+	void *q_base;
+	dma_addr_t q_base_pa;	/* might not be page aligned */
+	u32 q_size;
+	void *cq_base;
+	dma_addr_t cq_base_pa;	/* might not be page aligned */
+	u32 cq_size;
+	void *sg_base;
+	dma_addr_t sg_base_pa;	/* might not be page aligned */
+	u32 sg_size;
 	bool armed;
+	struct dim dim;
 	struct ionic_queue q;
 	struct ionic_cq cq;
 	struct ionic_intr_info intr;
 	struct napi_struct napi;
 	struct ionic_napi_stats napi_stats;
-	struct ionic_q_stats *stats;
 	unsigned int flags;
 	struct dentry *dentry;
-	unsigned int master_slot;
-};
-
-struct ionic_qcqst {
-	struct ionic_qcq *qcq;
-	struct ionic_q_stats *stats;
 };
 
 #define q_to_qcq(q)		container_of(q, struct ionic_qcq, q)
-#define q_to_tx_stats(q)	(&q_to_qcq(q)->stats->tx)
-#define q_to_rx_stats(q)	(&q_to_qcq(q)->stats->rx)
+#define q_to_tx_stats(q)	(&(q)->lif->txqstats[(q)->index])
+#define q_to_rx_stats(q)	(&(q)->lif->rxqstats[(q)->index])
 #define napi_to_qcq(napi)	container_of(napi, struct ionic_qcq, napi)
 #define napi_to_cq(napi)	(&napi_to_qcq(napi)->cq)
 
@@ -127,6 +138,10 @@ struct ionic_lif_sw_stats {
 	u64 rx_csum_none;
 	u64 rx_csum_complete;
 	u64 rx_csum_error;
+	u64 tx_hwstamp_valid;
+	u64 tx_hwstamp_invalid;
+	u64 rx_hwstamp_valid;
+	u64 rx_hwstamp_invalid;
 	u64 hw_tx_dropped;
 	u64 hw_rx_dropped;
 	u64 hw_rx_over_errors;
@@ -142,6 +157,9 @@ enum ionic_lif_state_flags {
 	IONIC_LIF_F_FW_RESET,
 	IONIC_LIF_F_RDMA_SNIFFER,
 	IONIC_LIF_F_SPLIT_INTR,
+	IONIC_LIF_F_BROKEN,
+	IONIC_LIF_F_TX_DIM_INTR,
+	IONIC_LIF_F_RX_DIM_INTR,
 
 	/* leave this as last */
 	IONIC_LIF_F_STATE_SIZE
@@ -166,10 +184,11 @@ struct ionic_qtype_info {
 	u16 sg_desc_stride;
 };
 
+struct ionic_phc;
+
 #define IONIC_LIF_NAME_MAX_SZ		32
 struct ionic_lif {
 	struct net_device *netdev;
-	struct net_device *upper_dev;
 	DECLARE_BITMAP(state, IONIC_LIF_F_STATE_SIZE);
 	struct ionic *ionic;
 	unsigned int index;
@@ -178,8 +197,12 @@ struct ionic_lif {
 	spinlock_t adminq_lock;		/* lock for AdminQ operations */
 	struct ionic_qcq *adminqcq;
 	struct ionic_qcq *notifyqcq;
-	struct ionic_qcqst *txqcqs;
-	struct ionic_qcqst *rxqcqs;
+	struct ionic_qcq **txqcqs;
+	struct ionic_qcq *hwstamp_txq;
+	struct ionic_tx_stats *txqstats;
+	struct ionic_qcq **rxqcqs;
+	struct ionic_qcq *hwstamp_rxq;
+	struct ionic_rx_stats *rxqstats;
 	struct ionic_deferred deferred;
 	struct work_struct tx_timeout_work;
 	u64 last_eid;
@@ -191,6 +214,7 @@ struct ionic_lif {
 	unsigned int ntxq_descs;
 	unsigned int nrxq_descs;
 	u32 rx_copybreak;
+	u64 rxq_features;
 	unsigned int rx_mode;
 	u64 hw_features;
 	bool registered;
@@ -223,19 +247,51 @@ struct ionic_lif {
 	unsigned long *dbid_inuse;
 	unsigned int dbid_count;
 
-	/* TODO: Make this a list if more than one slave is supported */
-	struct ionic_lif_cfg slave_lif_cfg;
+	struct ionic_phc *phc;
+
+	/* TODO: Make this a list if more than one child is supported */
+	struct ionic_lif_cfg child_lif_cfg;
 
 	struct dentry *dentry;
 };
 
-#define lif_to_txqcq(lif, i)	((lif)->txqcqs[i].qcq)
-#define lif_to_rxqcq(lif, i)	((lif)->rxqcqs[i].qcq)
-#define lif_to_txstats(lif, i)	((lif)->txqcqs[i].stats->tx)
-#define lif_to_rxstats(lif, i)	((lif)->rxqcqs[i].stats->rx)
-#define lif_to_txq(lif, i)	(&lif_to_txqcq((lif), i)->q)
-#define lif_to_rxq(lif, i)	(&lif_to_txqcq((lif), i)->q)
-#define is_master_lif(lif)	((lif)->index == 0)
+#if IS_ENABLED(CONFIG_PTP_1588_CLOCK)
+struct ionic_phc {
+	spinlock_t lock; /* lock for cc and tc */
+	struct cyclecounter cc;
+	struct timecounter tc;
+
+	struct mutex config_lock; /* lock for ts_config */
+	struct hwtstamp_config ts_config;
+	u64 ts_config_rx_filt;
+	u32 ts_config_tx_mode;
+
+	u32 init_cc_mult;
+	long aux_work_delay;
+
+	struct ptp_clock_info ptp_info;
+	struct ptp_clock *ptp;
+	struct ionic_lif *lif;
+};
+#endif
+
+struct ionic_queue_params {
+	unsigned int nxqs;
+	unsigned int ntxq_descs;
+	unsigned int nrxq_descs;
+	unsigned int intr_split;
+	u64 rxq_features;
+};
+
+static inline void ionic_init_queue_params(struct ionic_lif *lif,
+					   struct ionic_queue_params *qparam)
+{
+	qparam->nxqs = lif->nxqs;
+	qparam->ntxq_descs = lif->ntxq_descs;
+	qparam->nrxq_descs = lif->nrxq_descs;
+	qparam->intr_split = test_bit(IONIC_LIF_F_SPLIT_INTR, lif->state);
+	qparam->rxq_features = lif->rxq_features;
+}
 
 static inline u32 ionic_coal_usec_to_hw(struct ionic *ionic, u32 usecs)
 {
@@ -253,34 +309,10 @@ static inline u32 ionic_coal_usec_to_hw(struct ionic *ionic, u32 usecs)
 	return (usecs * mult) / div;
 }
 
-static inline u32 ionic_coal_hw_to_usec(struct ionic *ionic, u32 units)
-{
-	u32 mult = le32_to_cpu(ionic->ident.dev.intr_coal_mult);
-	u32 div = le32_to_cpu(ionic->ident.dev.intr_coal_div);
-
-	/* Div-by-zero should never be an issue, but check anyway */
-	if (!div || !mult)
-		return 0;
-
-	/* Convert from device units to usec */
-	return (units * div) / mult;
-}
-
-static inline bool ionic_is_platform_dev(struct ionic *ionic)
-{
-	return !!ionic->pfdev;
-}
-
 static inline bool ionic_is_pf(struct ionic *ionic)
 {
 	return ionic->pdev &&
 	       ionic->pdev->device == PCI_DEVICE_ID_PENSANDO_IONIC_ETH_PF;
-}
-
-static inline bool ionic_is_vf(struct ionic *ionic)
-{
-	return ionic->pdev &&
-	       ionic->pdev->device == PCI_DEVICE_ID_PENSANDO_IONIC_ETH_VF;
 }
 
 static inline bool ionic_use_eqs(struct ionic_lif *lif)
@@ -293,7 +325,7 @@ typedef void (*ionic_reset_cb)(struct ionic_lif *lif, void *arg);
 
 void ionic_lif_deferred_enqueue(struct ionic_deferred *def,
 				struct ionic_deferred_work *work);
-void ionic_link_status_check_request(struct ionic_lif *lif);
+void ionic_link_status_check_request(struct ionic_lif *lif, bool can_sleep);
 #ifdef HAVE_VOID_NDO_GET_STATS64
 void ionic_get_stats64(struct net_device *netdev,
 		       struct rtnl_link_stats64 *ns);
@@ -301,44 +333,78 @@ void ionic_get_stats64(struct net_device *netdev,
 struct rtnl_link_stats64 *ionic_get_stats64(struct net_device *netdev,
 					    struct rtnl_link_stats64 *ns);
 #endif
-int ionic_lifs_alloc(struct ionic *ionic);
-void ionic_lifs_free(struct ionic *ionic);
-void ionic_lifs_deinit(struct ionic *ionic);
-int ionic_lifs_init(struct ionic *ionic);
-int ionic_lifs_register(struct ionic *ionic);
-void ionic_lifs_unregister(struct ionic *ionic);
+int ionic_lif_register(struct ionic_lif *lif);
+void ionic_lif_unregister(struct ionic_lif *lif);
 int ionic_lif_identify(struct ionic *ionic, u8 lif_type,
 		       union ionic_lif_identity *lif_ident);
-int ionic_lifs_size(struct ionic *ionic);
+int ionic_lif_size(struct ionic *ionic);
 
-int ionic_slave_alloc(struct ionic *ionic, enum ionic_api_prsn prsn);
-void ionic_slave_free(struct ionic *ionic, int index);
+#if IS_ENABLED(CONFIG_PTP_1588_CLOCK)
+int ionic_lif_hwstamp_set(struct ionic_lif *lif, struct ifreq *ifr);
+int ionic_lif_hwstamp_get(struct ionic_lif *lif, struct ifreq *ifr);
+ktime_t ionic_lif_phc_ktime(struct ionic_lif *lif, u64 counter);
+void ionic_lif_register_phc(struct ionic_lif *lif);
+void ionic_lif_unregister_phc(struct ionic_lif *lif);
+void ionic_lif_alloc_phc(struct ionic_lif *lif);
+void ionic_lif_free_phc(struct ionic_lif *lif);
+#else
+static inline int ionic_lif_hwstamp_set(struct ionic_lif *lif, struct ifreq *ifr)
+{
+	return -EOPNOTSUPP;
+}
+
+static inline int ionic_lif_hwstamp_get(struct ionic_lif *lif, struct ifreq *ifr)
+{
+	return -EOPNOTSUPP;
+}
+
+static inline ktime_t ionic_lif_phc_ktime(struct ionic_lif *lif, u64 counter)
+{
+	return ns_to_ktime(0);
+}
+
+static inline void ionic_lif_register_phc(struct ionic_lif *lif) {}
+static inline void ionic_lif_unregister_phc(struct ionic_lif *lif) {}
+static inline void ionic_lif_alloc_phc(struct ionic_lif *lif) {}
+static inline void ionic_lif_free_phc(struct ionic_lif *lif) {}
+#endif
+
+int ionic_lif_create_hwstamp_txq(struct ionic_lif *lif);
+int ionic_lif_create_hwstamp_rxq(struct ionic_lif *lif);
+int ionic_lif_config_hwstamp_rxq_all(struct ionic_lif *lif, bool rx_all);
+int ionic_lif_set_hwstamp_txmode(struct ionic_lif *lif, u16 txstamp_mode);
+int ionic_lif_set_hwstamp_rxfilt(struct ionic_lif *lif, u64 pkt_class);
 
 int ionic_lif_rss_config(struct ionic_lif *lif, u16 types,
 			 const u8 *key, const u32 *indir);
 
 int ionic_intr_alloc(struct ionic *ionic, struct ionic_intr_info *intr);
 void ionic_intr_free(struct ionic *ionic, int index);
-int ionic_open(struct net_device *netdev);
-int ionic_stop(struct net_device *netdev);
-void ionic_set_rx_mode(struct net_device *netdev);
+void ionic_set_rx_mode(struct net_device *netdev, bool from_ndo);
+int ionic_reconfigure_queues(struct ionic_lif *lif,
+			     struct ionic_queue_params *qparam);
 int ionic_reset_queues(struct ionic_lif *lif, ionic_reset_cb cb, void *arg);
+int ionic_lif_alloc(struct ionic *ionic);
+int ionic_lif_init(struct ionic_lif *lif);
+void ionic_lif_free(struct ionic_lif *lif);
+void ionic_lif_deinit(struct ionic_lif *lif);
 
 struct ionic_lif *ionic_netdev_lif(struct net_device *netdev);
+void ionic_device_reset(struct ionic_lif *lif);
 
-static inline void debug_stats_txq_post(struct ionic_qcq *qcq, bool dbell)
+static inline void debug_stats_txq_post(struct ionic_queue *q, bool dbell)
 {
-	struct ionic_queue *q = &qcq->q;
 	struct ionic_txq_desc *desc = &q->txq[q->head_idx];
-	u8 num_sg_elems = ((le64_to_cpu(desc->cmd) >> IONIC_TXQ_DESC_NSGE_SHIFT)
-						& IONIC_TXQ_DESC_NSGE_MASK);
+	u8 num_sg_elems;
 
 	q->dbell_count += dbell;
 
+	num_sg_elems = ((le64_to_cpu(desc->cmd) >> IONIC_TXQ_DESC_NSGE_SHIFT)
+						& IONIC_TXQ_DESC_NSGE_MASK);
 	if (num_sg_elems > (IONIC_MAX_NUM_SG_CNTR - 1))
 		num_sg_elems = IONIC_MAX_NUM_SG_CNTR - 1;
 
-	qcq->stats->tx.sg_cntr[num_sg_elems]++;
+	q->lif->txqstats[q->index].sg_cntr[num_sg_elems]++;
 }
 
 static inline void debug_stats_napi_poll(struct ionic_qcq *qcq,
@@ -354,17 +420,15 @@ static inline void debug_stats_napi_poll(struct ionic_qcq *qcq,
 
 #ifdef IONIC_DEBUG_STATS
 #define DEBUG_STATS_CQE_CNT(cq)		((cq)->compl_count++)
-#define DEBUG_STATS_RX_BUFF_CNT(qcq)	((qcq)->stats->rx.buffers_posted++)
-#define DEBUG_STATS_INTR_REARM(intr)	((intr)->rearm_count++)
-#define DEBUG_STATS_TXQ_POST(qcq, dbell) \
-	debug_stats_txq_post(qcq, dbell)
+#define DEBUG_STATS_RX_BUFF_CNT(q)	((q)->lif->rxqstats[q->index].buffers_posted++)
+#define DEBUG_STATS_TXQ_POST(q, dbell) \
+	debug_stats_txq_post(q, dbell)
 #define DEBUG_STATS_NAPI_POLL(qcq, work_done) \
 	debug_stats_napi_poll(qcq, work_done)
 #else
 #define DEBUG_STATS_CQE_CNT(cq)
-#define DEBUG_STATS_RX_BUFF_CNT(qcq)
-#define DEBUG_STATS_INTR_REARM(intr)
-#define DEBUG_STATS_TXQ_POST(qcq, dbell)
+#define DEBUG_STATS_RX_BUFF_CNT(q)
+#define DEBUG_STATS_TXQ_POST(q, dbell)
 #define DEBUG_STATS_NAPI_POLL(qcq, work_done)
 #endif
 

--- a/drivers/linux/eth/ionic/ionic_rx_filter.c
+++ b/drivers/linux/eth/ionic/ionic_rx_filter.c
@@ -28,7 +28,7 @@ void ionic_rx_filter_replay(struct ionic_lif *lif)
 	struct hlist_node *tmp;
 	unsigned int key;
 	unsigned int i;
-	int err = 0;
+	int err;
 
 	INIT_HLIST_HEAD(&new_id_list);
 	ac = &ctx.cmd.rx_filter_add;
@@ -140,6 +140,9 @@ int ionic_rx_filter_save(struct ionic_lif *lif, u32 flow_id, u16 rxq_index,
 	case IONIC_RX_FILTER_MATCH_MAC_VLAN:
 		key = le16_to_cpu(ac->mac_vlan.vlan);
 		break;
+	case IONIC_RX_FILTER_STEER_PKTCLASS:
+		key = 0;
+		break;
 	default:
 		return -EINVAL;
 	}
@@ -206,6 +209,24 @@ struct ionic_rx_filter *ionic_rx_filter_by_addr(struct ionic_lif *lif,
 			continue;
 		if (memcmp(addr, f->cmd.mac.addr, ETH_ALEN) == 0)
 			return f;
+	}
+
+	return NULL;
+}
+
+struct ionic_rx_filter *ionic_rx_filter_rxsteer(struct ionic_lif *lif)
+{
+	struct ionic_rx_filter *f;
+	struct hlist_head *head;
+	unsigned int key;
+
+	key = hash_32(0, IONIC_RX_FILTER_HASH_BITS);
+	head = &lif->rx_filters.by_hash[key];
+
+	hlist_for_each_entry(f, head, by_hash) {
+		if (le16_to_cpu(f->cmd.match) != IONIC_RX_FILTER_STEER_PKTCLASS)
+			continue;
+		return f;
 	}
 
 	return NULL;

--- a/drivers/linux/eth/ionic/ionic_rx_filter.h
+++ b/drivers/linux/eth/ionic/ionic_rx_filter.h
@@ -31,5 +31,6 @@ int ionic_rx_filter_save(struct ionic_lif *lif, u32 flow_id, u16 rxq_index,
 			 u32 hash, struct ionic_admin_ctx *ctx);
 struct ionic_rx_filter *ionic_rx_filter_by_vlan(struct ionic_lif *lif, u16 vid);
 struct ionic_rx_filter *ionic_rx_filter_by_addr(struct ionic_lif *lif, const u8 *addr);
+struct ionic_rx_filter *ionic_rx_filter_rxsteer(struct ionic_lif *lif);
 
 #endif /* _IONIC_RX_FILTER_H_ */

--- a/drivers/linux/eth/ionic/ionic_stats.h
+++ b/drivers/linux/eth/ionic/ionic_stats.h
@@ -52,7 +52,7 @@ extern const int ionic_num_stats_grps;
 	(*((u64 *)(((u8 *)(base_ptr)) + (desc_ptr)->offset)))
 
 #define IONIC_READ_STAT_LE64(base_ptr, desc_ptr) \
-	__le64_to_cpu(*((u64 *)(((u8 *)(base_ptr)) + (desc_ptr)->offset)))
+	__le64_to_cpu(*((__le64 *)(((u8 *)(base_ptr)) + (desc_ptr)->offset)))
 
 struct ionic_stat_desc {
 	char name[ETH_GSTRING_LEN];

--- a/drivers/linux/eth/ionic/ionic_txrx.c
+++ b/drivers/linux/eth/ionic/ionic_txrx.c
@@ -5,7 +5,6 @@
 #include <linux/ipv6.h>
 #include <linux/if_vlan.h>
 #include <net/ip6_checksum.h>
-#include <linux/if_macvlan.h>
 
 #include "ionic.h"
 #include "ionic_lif.h"
@@ -15,15 +14,11 @@ static void ionic_rx_clean(struct ionic_queue *q,
 			   struct ionic_desc_info *desc_info,
 			   struct ionic_cq_info *cq_info,
 			   void *cb_arg);
-static bool ionic_rx_service(struct ionic_cq *cq,
-			     struct ionic_cq_info *cq_info);
-static bool ionic_tx_service(struct ionic_cq *cq,
-			     struct ionic_cq_info *cq_info);
 
 static inline void ionic_txq_post(struct ionic_queue *q, bool ring_dbell,
 				  ionic_desc_cb cb_func, void *cb_arg)
 {
-	DEBUG_STATS_TXQ_POST(q_to_qcq(q), ring_dbell);
+	DEBUG_STATS_TXQ_POST(q, ring_dbell);
 
 	ionic_q_post(q, ring_dbell, cb_func, cb_arg);
 }
@@ -33,7 +28,7 @@ static inline void ionic_rxq_post(struct ionic_queue *q, bool ring_dbell,
 {
 	ionic_q_post(q, ring_dbell, cb_func, cb_arg);
 
-	DEBUG_STATS_RX_BUFF_CNT(q_to_qcq(q));
+	DEBUG_STATS_RX_BUFF_CNT(q);
 }
 
 static inline struct netdev_queue *q_to_ndq(struct ionic_queue *q)
@@ -104,11 +99,8 @@ static inline void ionic_rx_page_free(struct ionic_queue *q,
 		return;
 	}
 
-	if (unlikely(!buf_info->page)) {
-		net_err_ratelimited("%s: %s invalid page in free\n",
-				    netdev->name, q->name);
+	if (!buf_info->page)
 		return;
-	}
 
 	dma_unmap_page(dev, buf_info->dma_addr,
 		IONIC_PAGE_SIZE, DMA_FROM_DEVICE);
@@ -148,9 +140,8 @@ static bool ionic_rx_buf_recycle(struct ionic_queue *q,
 
 static struct sk_buff *ionic_rx_frags(struct ionic_queue *q,
 				      struct ionic_desc_info *desc_info,
-				      struct ionic_cq_info *cq_info)
+				      struct ionic_rxq_comp *comp)
 {
-	struct ionic_rxq_comp *comp = cq_info->cq_desc;
 	struct net_device *netdev = q->lif->netdev;
 	struct ionic_buf_info *buf_info;
 	struct ionic_rx_stats *stats;
@@ -209,9 +200,8 @@ static struct sk_buff *ionic_rx_frags(struct ionic_queue *q,
 
 static struct sk_buff *ionic_rx_copybreak(struct ionic_queue *q,
 					  struct ionic_desc_info *desc_info,
-					  struct ionic_cq_info *cq_info)
+					  struct ionic_rxq_comp *comp)
 {
-	struct ionic_rxq_comp *comp = cq_info->cq_desc;
 	struct net_device *netdev = q->lif->netdev;
 	struct ionic_buf_info *buf_info;
 	struct ionic_rx_stats *stats;
@@ -255,14 +245,16 @@ static void ionic_rx_clean(struct ionic_queue *q,
 			   struct ionic_cq_info *cq_info,
 			   void *cb_arg)
 {
-	struct ionic_rxq_comp *comp = cq_info->cq_desc;
 	struct net_device *netdev = q->lif->netdev;
 	struct ionic_qcq *qcq = q_to_qcq(q);
 	struct ionic_rx_stats *stats;
+	struct ionic_rxq_comp *comp;
 	struct sk_buff *skb;
 #ifdef CSUM_DEBUG
 	__sum16 csum;
 #endif
+
+	comp = cq_info->cq_desc + qcq->cq.desc_size - sizeof(*comp);
 
 	stats = q_to_rx_stats(q);
 
@@ -271,7 +263,7 @@ static void ionic_rx_clean(struct ionic_queue *q,
 		return;
 	}
 
-	if (le16_to_cpu(comp->len) > netdev->mtu + ETH_HLEN) {
+	if (le16_to_cpu(comp->len) > netdev->mtu + ETH_HLEN + VLAN_HLEN) {
 		stats->dropped++;
 		net_warn_ratelimited("%s: RX PKT TOO LARGE! comp->len %d\n",
 				     netdev->name,
@@ -283,9 +275,9 @@ static void ionic_rx_clean(struct ionic_queue *q,
 	stats->bytes += le16_to_cpu(comp->len);
 
 	if (le16_to_cpu(comp->len) <= q->lif->rx_copybreak)
-		skb = ionic_rx_copybreak(q, desc_info, cq_info);
+		skb = ionic_rx_copybreak(q, desc_info, comp);
 	else
-		skb = ionic_rx_frags(q, desc_info, cq_info);
+		skb = ionic_rx_frags(q, desc_info, comp);
 
 	if (unlikely(!skb)) {
 		stats->dropped++;
@@ -296,8 +288,7 @@ static void ionic_rx_clean(struct ionic_queue *q,
 	csum = ip_compute_csum(skb->data, skb->len);
 #endif
 
-	if (is_master_lif(q->lif))
-		skb_record_rx_queue(skb, q->index);
+	skb_record_rx_queue(skb, q->index);
 
 	if (likely(netdev->features & NETIF_F_RXHASH)) {
 		switch (comp->pkt_type_color & IONIC_RXQ_COMP_PKT_TYPE_MASK) {
@@ -319,7 +310,7 @@ static void ionic_rx_clean(struct ionic_queue *q,
 	if (likely(netdev->features & NETIF_F_RXCSUM) &&
 	    (comp->csum_flags & IONIC_RXQ_COMP_CSUM_F_CALC)) {
 		skb->ip_summed = CHECKSUM_COMPLETE;
-		skb->csum = (__wsum)le16_to_cpu(comp->csum);
+		skb->csum = (__force __wsum)le16_to_cpu(comp->csum);
 #ifdef IONIC_DEBUG_STATS
 		stats->csum_complete++;
 #endif
@@ -349,17 +340,39 @@ static void ionic_rx_clean(struct ionic_queue *q,
 #endif
 	}
 
+	if (unlikely(q->features & IONIC_RXQ_F_HWSTAMP)) {
+		__le64 *cq_desc_hwstamp;
+		u64 hwstamp;
+
+		cq_desc_hwstamp =
+			cq_info->cq_desc +
+			qcq->cq.desc_size -
+			sizeof(struct ionic_rxq_comp) -
+			IONIC_HWSTAMP_CQ_NEGOFFSET;
+
+		hwstamp = le64_to_cpu(*cq_desc_hwstamp);
+
+		if (hwstamp != IONIC_HWSTAMP_INVALID) {
+			skb_hwtstamps(skb)->hwtstamp = ionic_lif_phc_ktime(q->lif, hwstamp);
+			stats->hwstamp_valid++;
+		} else {
+			stats->hwstamp_invalid++;
+		}
+	}
+
 	if (le16_to_cpu(comp->len) <= q->lif->rx_copybreak)
 		napi_gro_receive(&qcq->napi, skb);
 	else
 		napi_gro_frags(&qcq->napi);
 }
 
-static bool ionic_rx_service(struct ionic_cq *cq, struct ionic_cq_info *cq_info)
+bool ionic_rx_service(struct ionic_cq *cq, struct ionic_cq_info *cq_info)
 {
-	struct ionic_rxq_comp *comp = cq_info->cq_desc;
 	struct ionic_queue *q = cq->bound_q;
 	struct ionic_desc_info *desc_info;
+	struct ionic_rxq_comp *comp;
+
+	comp = cq_info->cq_desc + cq->desc_size - sizeof(*comp);
 
 	if (!color_match(comp->pkt_type_color, cq->done_color))
 		return false;
@@ -368,10 +381,10 @@ static bool ionic_rx_service(struct ionic_cq *cq, struct ionic_cq_info *cq_info)
 	if (q->tail_idx == q->head_idx)
 		return false;
 
-	desc_info = &q->info[q->tail_idx];
-	if (desc_info->index != le16_to_cpu(comp->comp_index))
+	if (q->tail_idx != le16_to_cpu(comp->comp_index))
 		return false;
 
+	desc_info = &q->info[q->tail_idx];
 	q->tail_idx = (q->tail_idx + 1) & (q->num_descs - 1);
 
 	/* clean the related q entry, only one per qc completion */
@@ -413,7 +426,7 @@ void ionic_rx_fill(struct ionic_queue *q)
 	unsigned int i;
 	unsigned int j;
 
-	len = netdev->mtu + ETH_HLEN;
+	len = netdev->mtu + ETH_HLEN + VLAN_HLEN;
 	align_len = ALIGN(len, IONIC_PAGE_SPLIT_SZ);
 	nsplits = IONIC_PAGE_SIZE / align_len;
 
@@ -465,9 +478,15 @@ void ionic_rx_fill(struct ionic_queue *q)
 			nfrags++;
 		}
 
+		/* clear end sg element as a sentinel */
+		if (j < q->max_sg_elems) {
+			sg_elem = &sg_desc->elems[j];
+			memset(sg_elem, 0, sizeof(*sg_elem));
+		}
+
 		desc->opcode = (nfrags > 1) ? IONIC_RXQ_DESC_OPCODE_SG :
 					      IONIC_RXQ_DESC_OPCODE_SIMPLE;
-		desc_info->npages = nfrags;
+		desc_info->nbufs = nfrags;
 
 		ionic_rxq_post(q, false, ionic_rx_clean, NULL);
 	}
@@ -476,31 +495,51 @@ void ionic_rx_fill(struct ionic_queue *q)
 				q->dbval | q->head_idx);
 }
 
-static void ionic_rx_fill_cb(void *arg)
-{
-	ionic_rx_fill(arg);
-}
-
 void ionic_rx_empty(struct ionic_queue *q)
 {
 	struct ionic_desc_info *desc_info;
-	struct ionic_rxq_desc *desc;
-	unsigned int i;
-	u16 idx;
+	struct ionic_buf_info *buf_info;
+	unsigned int i, j;
 
-	idx = q->tail_idx;
-	while (idx != q->head_idx) {
-		desc_info = &q->info[idx];
-		desc = desc_info->desc;
-		desc->addr = 0;
-		desc->len = 0;
+	for (i = 0; i < q->num_descs; i++) {
+		desc_info = &q->info[i];
+		for (j = 0; j < IONIC_RX_MAX_SG_ELEMS + 1; j++) {
+			buf_info = &desc_info->bufs[j];
+			if (buf_info->page)
+				ionic_rx_page_free(q, buf_info);
+		}
 
-		for (i = 0; i < desc_info->npages; i++)
-			ionic_rx_page_free(q, &desc_info->bufs[i]);
-
+		desc_info->nbufs = 0;
+		desc_info->cb = NULL;
 		desc_info->cb_arg = NULL;
-		idx = (idx + 1) & (q->num_descs - 1);
 	}
+
+	q->head_idx = 0;
+	q->tail_idx = 0;
+}
+
+static void ionic_dim_update(struct ionic_qcq *qcq)
+{
+	struct dim_sample dim_sample;
+	struct ionic_lif *lif;
+	unsigned int qi;
+
+	if (!qcq->intr.dim_coal_hw)
+		return;
+
+	lif = qcq->q.lif;
+	qi = qcq->cq.bound_q->index;
+
+	ionic_intr_coal_init(lif->ionic->idev.intr_ctrl,
+			     lif->rxqcqs[qi]->intr.index,
+			     qcq->intr.dim_coal_hw);
+
+	dim_update_sample(qcq->cq.bound_intr->rearm_count,
+			  lif->txqstats[qi].pkts,
+			  lif->txqstats[qi].bytes,
+			  &dim_sample);
+
+	net_dim(&qcq->dim, dim_sample);
 }
 
 int ionic_tx_napi(struct napi_struct *napi, int budget)
@@ -521,12 +560,14 @@ int ionic_tx_napi(struct napi_struct *napi, int budget)
 
 	if (work_done < budget && napi_complete_done(napi, work_done)) {
 		flags |= IONIC_INTR_CRED_UNMASK;
-		DEBUG_STATS_INTR_REARM(cq->bound_intr);
+		cq->bound_intr->rearm_count++;
 	}
 
 	if (work_done || flags) {
 		flags |= IONIC_INTR_CRED_RESET_COALESCE;
 		if (!lif->ionic->neth_eqs) {
+			if (flags & IONIC_INTR_CRED_UNMASK)
+				ionic_dim_update(qcq);
 			ionic_intr_credits(idev->intr_ctrl,
 					   cq->bound_intr->index,
 					   work_done, flags);
@@ -553,6 +594,7 @@ int ionic_rx_napi(struct napi_struct *napi, int budget)
 	struct ionic_cq *cq = napi_to_cq(napi);
 	struct ionic_dev *idev;
 	struct ionic_lif *lif;
+	u16 rx_fill_threshold;
 	u32 work_done = 0;
 	u32 flags = 0;
 	u64 dbr;
@@ -563,17 +605,20 @@ int ionic_rx_napi(struct napi_struct *napi, int budget)
 	work_done = ionic_cq_service(cq, budget,
 				     ionic_rx_service, NULL, NULL);
 
-	if (work_done)
+	rx_fill_threshold = min_t(u16, IONIC_RX_FILL_THRESHOLD, cq->num_descs / IONIC_RX_FILL_DIV);
+	if (work_done && ionic_q_space_avail(cq->bound_q) >= rx_fill_threshold)
 		ionic_rx_fill(cq->bound_q);
 
 	if (work_done < budget && napi_complete_done(napi, work_done)) {
 		flags |= IONIC_INTR_CRED_UNMASK;
-		DEBUG_STATS_INTR_REARM(cq->bound_intr);
+		cq->bound_intr->rearm_count++;
 	}
 
 	if (work_done || flags) {
 		flags |= IONIC_INTR_CRED_RESET_COALESCE;
 		if (!lif->ionic->neth_eqs) {
+			if (flags & IONIC_INTR_CRED_UNMASK)
+				ionic_dim_update(qcq);
 			ionic_intr_credits(idev->intr_ctrl,
 					   cq->bound_intr->index,
 					   work_done, flags);
@@ -603,31 +648,36 @@ int ionic_txrx_napi(struct napi_struct *napi, int budget)
 	struct ionic_lif *lif;
 	struct ionic_qcq *txqcq;
 	struct ionic_cq *txcq;
+	u16 rx_fill_threshold;
 	u32 tx_work_done = 0;
 	u32 rx_work_done = 0;
 	u32 flags = 0;
 
 	lif = rxcq->bound_q->lif;
 	idev = &lif->ionic->idev;
-	txqcq = lif->txqcqs[qi].qcq;
-	txcq = &lif->txqcqs[qi].qcq->cq;
+	txqcq = lif->txqcqs[qi];
+	txcq = &lif->txqcqs[qi]->cq;
 
 	tx_work_done = ionic_cq_service(txcq, tx_budget,
 					ionic_tx_service, NULL, NULL);
 
 	rx_work_done = ionic_cq_service(rxcq, budget,
 					ionic_rx_service, NULL, NULL);
-	if (rx_work_done)
-		ionic_rx_fill_cb(rxcq->bound_q);
+
+	rx_fill_threshold = min_t(u16, IONIC_RX_FILL_THRESHOLD, rxcq->num_descs / IONIC_RX_FILL_DIV);
+	if (rx_work_done && ionic_q_space_avail(rxcq->bound_q) >= rx_fill_threshold)
+		ionic_rx_fill(rxcq->bound_q);
 
 	if (rx_work_done < budget && napi_complete_done(napi, rx_work_done)) {
 		flags |= IONIC_INTR_CRED_UNMASK;
-		DEBUG_STATS_INTR_REARM(rxcq->bound_intr);
+		rxcq->bound_intr->rearm_count++;
 	}
 
 	if (rx_work_done || flags) {
 		flags |= IONIC_INTR_CRED_RESET_COALESCE;
 		if (!lif->ionic->neth_eqs) {
+			if (flags & IONIC_INTR_CRED_UNMASK)
+				ionic_dim_update(rxqcq);
 			ionic_intr_credits(idev->intr_ctrl,
 					   rxcq->bound_intr->index,
 					   tx_work_done + rx_work_done, flags);
@@ -693,61 +743,121 @@ static dma_addr_t ionic_tx_map_frag(struct ionic_queue *q,
 	return dma_addr;
 }
 
+static int ionic_tx_map_skb(struct ionic_queue *q, struct sk_buff *skb,
+			    struct ionic_desc_info *desc_info)
+{
+	struct ionic_buf_info *buf_info = desc_info->bufs;
+	struct ionic_tx_stats *stats = q_to_tx_stats(q);
+	struct device *dev = q->dev;
+	unsigned int frag_idx;
+	dma_addr_t dma_addr;
+	unsigned int nfrags;
+	skb_frag_t *frag;
+
+	dma_addr = ionic_tx_map_single(q, skb->data, skb_headlen(skb));
+	if (dma_mapping_error(dev, dma_addr)) {
+		stats->dma_map_err++;
+		return -EIO;
+	}
+	buf_info->dma_addr = dma_addr;
+	buf_info->len = skb_headlen(skb);
+	buf_info++;
+
+	frag = skb_shinfo(skb)->frags;
+	nfrags = skb_shinfo(skb)->nr_frags;
+	for (frag_idx = 0; frag_idx < nfrags; frag_idx++, frag++) {
+		dma_addr = ionic_tx_map_frag(q, frag, 0, skb_frag_size(frag));
+		if (dma_mapping_error(dev, dma_addr)) {
+			stats->dma_map_err++;
+			return -EIO;
+		}
+		buf_info->dma_addr = dma_addr;
+		buf_info->len = skb_frag_size(frag);
+		buf_info++;
+	}
+
+	desc_info->nbufs = 1 + nfrags;
+
+	return 0;
+}
+
 static void ionic_tx_clean(struct ionic_queue *q,
 			   struct ionic_desc_info *desc_info,
 			   struct ionic_cq_info *cq_info,
 			   void *cb_arg)
 {
-	struct ionic_txq_sg_desc *sg_desc = desc_info->sg_desc;
-	struct ionic_txq_sg_elem *elem = sg_desc->elems;
+	struct ionic_buf_info *buf_info = desc_info->bufs;
 	struct ionic_tx_stats *stats = q_to_tx_stats(q);
-	struct ionic_txq_desc *desc = desc_info->desc;
+	struct ionic_qcq *qcq = q_to_qcq(q);
 	struct device *dev = q->dev;
-	u8 opcode, flags, nsge;
 	unsigned int i;
-	u64 addr;
 
-	decode_txq_desc_cmd(le64_to_cpu(desc->cmd),
-			    &opcode, &flags, &nsge, &addr);
-
-	/* use unmap_single only if either this is not TSO,
-	 * or this is first descriptor of a TSO
-	 */
-	if (opcode != IONIC_TXQ_DESC_OPCODE_TSO ||
-	    flags & IONIC_TXQ_DESC_FLAG_TSO_SOT)
-		dma_unmap_single(dev, (dma_addr_t)addr,
-				 le16_to_cpu(desc->len), DMA_TO_DEVICE);
-	else
-		dma_unmap_page(dev, (dma_addr_t)addr,
-			       le16_to_cpu(desc->len), DMA_TO_DEVICE);
-
-	for (i = 0; i < nsge; i++, elem++)
-		dma_unmap_page(dev, (dma_addr_t)le64_to_cpu(elem->addr),
-			       le16_to_cpu(elem->len), DMA_TO_DEVICE);
+	if (desc_info->nbufs) {
+		dma_unmap_single(dev, (dma_addr_t)buf_info->dma_addr,
+				 buf_info->len, DMA_TO_DEVICE);
+		buf_info++;
+		for (i = 1; i < desc_info->nbufs; i++, buf_info++)
+			dma_unmap_page(dev, (dma_addr_t)buf_info->dma_addr,
+				       buf_info->len, DMA_TO_DEVICE);
+	}
 
 	if (cb_arg) {
 		struct sk_buff *skb = cb_arg;
 		u16 qi;
 
 		qi = skb_get_queue_mapping(skb);
-		if (unlikely(__netif_subqueue_stopped(q->lif->netdev, qi) &&
-			     cq_info)) {
+
+		if (unlikely(q->features & IONIC_TXQ_F_HWSTAMP)) {
+			struct skb_shared_hwtstamps hwts = {};
+			__le64 *cq_desc_hwstamp;
+			u64 hwstamp;
+
+			cq_desc_hwstamp =
+				cq_info->cq_desc +
+				qcq->cq.desc_size -
+				sizeof(struct ionic_txq_comp) -
+				IONIC_HWSTAMP_CQ_NEGOFFSET;
+
+			hwstamp = le64_to_cpu(*cq_desc_hwstamp);
+
+			if (hwstamp != IONIC_HWSTAMP_INVALID) {
+				hwts.hwtstamp = ionic_lif_phc_ktime(q->lif, hwstamp);
+
+				skb_shinfo(skb)->tx_flags |= SKBTX_IN_PROGRESS;
+				skb_tstamp_tx(skb, &hwts);
+
+				stats->hwstamp_valid++;
+			} else {
+				stats->hwstamp_invalid++;
+			}
+
+			/* do not wake txq, we violated skb queue mapping */
+			qi = U16_MAX;
+		}
+
+		if (likely(cq_info && qi != U16_MAX) &&
+		    unlikely(__netif_subqueue_stopped(q->lif->netdev, qi))) {
 			netif_wake_subqueue(q->lif->netdev, qi);
 			q->wake++;
 		}
+
 		desc_info->bytes = skb->len;
-		dev_kfree_skb_any(skb);
 		stats->clean++;
+
+		dev_consume_skb_any(skb);
 	}
 }
 
-static bool ionic_tx_service(struct ionic_cq *cq, struct ionic_cq_info *cq_info)
+bool ionic_tx_service(struct ionic_cq *cq, struct ionic_cq_info *cq_info)
 {
-	struct ionic_txq_comp *comp = cq_info->cq_desc;
 	struct ionic_queue *q = cq->bound_q;
 	struct ionic_desc_info *desc_info;
+	struct ionic_txq_comp *comp;
 	int bytes = 0;
 	int pkts = 0;
+	u16 index;
+
+	comp = cq_info->cq_desc + cq->desc_size - sizeof(*comp);
 
 	if (!color_match(comp->color, cq->done_color))
 		return false;
@@ -758,6 +868,7 @@ static bool ionic_tx_service(struct ionic_cq *cq, struct ionic_cq_info *cq_info)
 	do {
 		desc_info = &q->info[q->tail_idx];
 		desc_info->bytes = 0;
+		index = q->tail_idx;
 		q->tail_idx = (q->tail_idx + 1) & (q->num_descs - 1);
 		ionic_tx_clean(q, desc_info, cq_info, desc_info->cb_arg);
 		if (desc_info->cb_arg) {
@@ -766,7 +877,7 @@ static bool ionic_tx_service(struct ionic_cq *cq, struct ionic_cq_info *cq_info)
 		}
 		desc_info->cb = NULL;
 		desc_info->cb_arg = NULL;
-	} while (desc_info->index != le16_to_cpu(comp->comp_index));
+	} while (index != le16_to_cpu(comp->comp_index));
 
 #ifdef IONIC_SUPPORTS_BQL
 	if (pkts && bytes)
@@ -889,52 +1000,33 @@ static void ionic_tx_tso_post(struct ionic_queue *q,
 	desc->hdr_len = cpu_to_le16(hdrlen);
 	desc->mss = cpu_to_le16(mss);
 
-	if (done) {
+	if (start) {
 		skb_tx_timestamp(skb);
 #ifdef IONIC_SUPPORTS_BQL
 		netdev_tx_sent_queue(q_to_ndq(q), skb->len);
 #endif
-#ifdef HAVE_SKB_XMIT_MORE
-		ionic_txq_post(q, !netdev_xmit_more(), ionic_tx_clean, skb);
-#else
-		ionic_txq_post(q, true, ionic_tx_clean, skb);
-#endif
+		ionic_txq_post(q, false, ionic_tx_clean, skb);
 	} else {
-		ionic_txq_post(q, false, ionic_tx_clean, NULL);
+		ionic_txq_post(q, done, NULL, NULL);
 	}
-}
-
-static struct ionic_txq_desc *ionic_tx_tso_next(struct ionic_queue *q,
-						struct ionic_txq_sg_elem **elem)
-{
-	struct ionic_txq_sg_desc *sg_desc = q->info[q->head_idx].txq_sg_desc;
-	struct ionic_txq_desc *desc = q->info[q->head_idx].txq_desc;
-
-	*elem = sg_desc->elems;
-	return desc;
 }
 
 static int ionic_tx_tso(struct ionic_queue *q, struct sk_buff *skb)
 {
 	struct ionic_tx_stats *stats = q_to_tx_stats(q);
-	struct device *dev = q->dev;
+	struct ionic_desc_info *desc_info;
+	struct ionic_buf_info *buf_info;
 	struct ionic_txq_sg_elem *elem;
 	struct ionic_txq_desc *desc;
-	unsigned int frag_left = 0;
-	unsigned int offset = 0;
-	u16 abort = q->head_idx;
-	unsigned int len_left;
+	unsigned int chunk_len;
+	unsigned int frag_rem;
+	unsigned int tso_rem;
+	unsigned int seg_rem;
 	dma_addr_t desc_addr;
+	dma_addr_t frag_addr;
 	unsigned int hdrlen;
-	unsigned int nfrags;
-	unsigned int seglen;
-	u64 total_bytes = 0;
-	u64 total_pkts = 0;
-	u16 rewind = abort;
-	unsigned int left;
 	unsigned int len;
 	unsigned int mss;
-	skb_frag_t *frag;
 	bool start, done;
 	bool outer_csum;
 	bool has_vlan;
@@ -943,11 +1035,15 @@ static int ionic_tx_tso(struct ionic_queue *q, struct sk_buff *skb)
 	u16 vlan_tci;
 	bool encap;
 	int err;
-	struct ionic_desc_info *rewind_desc_info;
 
+	desc_info = &q->info[q->head_idx];
+	buf_info = desc_info->bufs;
+
+	if (unlikely(ionic_tx_map_skb(q, skb, desc_info)))
+		return -EIO;
+
+	len = skb->len;
 	mss = skb_shinfo(skb)->gso_size;
-	nfrags = skb_shinfo(skb)->nr_frags;
-	len_left = skb->len - skb_headlen(skb);
 	outer_csum = (skb_shinfo(skb)->gso_type & SKB_GSO_GRE_CSUM) ||
 		     (skb_shinfo(skb)->gso_type & SKB_GSO_UDP_TUNNEL_CSUM);
 	has_vlan = !!skb_vlan_tag_present(skb);
@@ -972,129 +1068,79 @@ static int ionic_tx_tso(struct ionic_queue *q, struct sk_buff *skb)
 	else
 		hdrlen = skb_transport_offset(skb) + tcp_hdrlen(skb);
 
-	seglen = hdrlen + mss;
-	left = skb_headlen(skb);
+	tso_rem = len;
+	seg_rem = min(tso_rem, hdrlen + mss);
 
-	desc = ionic_tx_tso_next(q, &elem);
+	frag_addr = 0;
+	frag_rem = 0;
+
 	start = true;
 
-	/* Chop skb->data up into desc segments */
-
-	while (left > 0) {
-		len = min(seglen, left);
-		frag_left = seglen - len;
-		desc_addr = ionic_tx_map_single(q, skb->data + offset, len);
-		if (dma_mapping_error(dev, desc_addr))
-			goto err_out_abort;
-		desc_len = len;
+	while (tso_rem > 0) {
+		desc = NULL;
+		elem = NULL;
+		desc_addr = 0;
+		desc_len = 0;
 		desc_nsge = 0;
-		left -= len;
-		offset += len;
-		if (nfrags > 0 && frag_left > 0)
-			continue;
-		done = (nfrags == 0 && left == 0);
-		ionic_tx_tso_post(q, desc, skb,
-				  desc_addr, desc_nsge, desc_len,
-				  hdrlen, mss,
-				  outer_csum,
-				  vlan_tci, has_vlan,
-				  start, done);
-		total_pkts++;
-		total_bytes += start ? len : len + hdrlen;
-		desc = ionic_tx_tso_next(q, &elem);
-		start = false;
-		seglen = mss;
-	}
-
-	/* Chop skb frags into desc segments */
-
-	for (frag = skb_shinfo(skb)->frags; len_left; frag++) {
-		offset = 0;
-		left = skb_frag_size(frag);
-		len_left -= left;
-		nfrags--;
-#ifdef IONIC_DEBUG_STATS
-		stats->frags++;
-#endif
-		while (left > 0) {
-			if (frag_left > 0) {
-				len = min(frag_left, left);
-				frag_left -= len;
-				elem->addr =
-				    cpu_to_le64(ionic_tx_map_frag(q, frag,
-								  offset, len));
-				if (dma_mapping_error(dev, elem->addr))
-					goto err_out_abort;
-				elem->len = cpu_to_le16(len);
+		/* use fragments until a we have enough to post a single descriptor */
+		while (seg_rem > 0) {
+			/* if the fragment is exhausted then move to the next one */
+			if (frag_rem == 0) {
+				/* grab the next fragment */
+				frag_addr = buf_info->dma_addr;
+				frag_rem = buf_info->len;
+				buf_info++;
+			}
+			chunk_len = min(frag_rem, seg_rem);
+			if (desc == NULL) {
+				/* fill main descriptor */
+				desc = desc_info->txq_desc;
+				elem = desc_info->txq_sg_desc->elems;
+				desc_addr = frag_addr;
+				desc_len = chunk_len;
+			} else {
+				/* fill sg descriptor */
+				elem->addr = cpu_to_le64(frag_addr);
+				elem->len = cpu_to_le16(chunk_len);
 				elem++;
 				desc_nsge++;
-				left -= len;
-				offset += len;
-				if (nfrags > 0 && frag_left > 0)
-					continue;
-				done = (nfrags == 0 && left == 0);
-				ionic_tx_tso_post(q, desc, skb, desc_addr,
-						  desc_nsge, desc_len,
-						  hdrlen, mss, outer_csum,
-						  vlan_tci, has_vlan,
-						  start, done);
-				total_pkts++;
-				total_bytes += start ? len : len + hdrlen;
-				desc = ionic_tx_tso_next(q, &elem);
-				start = false;
-			} else {
-				len = min(mss, left);
-				frag_left = mss - len;
-				desc_addr = ionic_tx_map_frag(q, frag,
-							      offset, len);
-				if (dma_mapping_error(dev, desc_addr))
-					goto err_out_abort;
-				desc_len = len;
-				desc_nsge = 0;
-				left -= len;
-				offset += len;
-				if (nfrags > 0 && frag_left > 0)
-					continue;
-				done = (nfrags == 0 && left == 0);
-				ionic_tx_tso_post(q, desc, skb, desc_addr,
-						  desc_nsge, desc_len,
-						  hdrlen, mss, outer_csum,
-						  vlan_tci, has_vlan,
-						  start, done);
-				total_pkts++;
-				total_bytes += start ? len : len + hdrlen;
-				desc = ionic_tx_tso_next(q, &elem);
-				start = false;
 			}
+			frag_addr += chunk_len;
+			frag_rem -= chunk_len;
+			tso_rem -= chunk_len;
+			seg_rem -= chunk_len;
 		}
+		seg_rem = min(tso_rem, mss);
+		done = (tso_rem == 0);
+		/* post descriptor */
+		ionic_tx_tso_post(q, desc, skb,
+				desc_addr, desc_nsge, desc_len,
+				hdrlen, mss,
+				outer_csum,
+				vlan_tci, has_vlan,
+				start, done);
+		start = false;
+		/* Buffer information is stored with the first tso descriptor */
+		desc_info = &q->info[q->head_idx];
+		desc_info->nbufs = 0;
 	}
 
-	stats->pkts += total_pkts;
-	stats->bytes += total_bytes;
+	stats->pkts += DIV_ROUND_UP(len - hdrlen, mss);
+	stats->bytes += len;
 	stats->tso++;
-	stats->tso_bytes += total_bytes;
+	stats->tso_bytes = len;
 
 	return 0;
-
-err_out_abort:
-	while (rewind != q->head_idx) {
-		rewind_desc_info = &q->info[rewind];
-		ionic_tx_clean(q, rewind_desc_info, NULL, NULL);
-		rewind = (rewind + 1) & (q->num_descs - 1);
-	}
-	q->head_idx = abort;
-
-	return -ENOMEM;
 }
 
-static int ionic_tx_calc_csum(struct ionic_queue *q, struct sk_buff *skb)
+static int ionic_tx_calc_csum(struct ionic_queue *q, struct sk_buff *skb,
+			      struct ionic_desc_info *desc_info)
 {
-	struct ionic_txq_desc *desc = q->info[q->head_idx].txq_desc;
+	struct ionic_txq_desc *desc = desc_info->txq_desc;
+	struct ionic_buf_info *buf_info = desc_info->bufs;
 #ifdef IONIC_DEBUG_STATS
 	struct ionic_tx_stats *stats = q_to_tx_stats(q);
 #endif
-	struct device *dev = q->dev;
-	dma_addr_t dma_addr;
 	bool has_vlan;
 	u8 flags = 0;
 	bool encap;
@@ -1103,25 +1149,24 @@ static int ionic_tx_calc_csum(struct ionic_queue *q, struct sk_buff *skb)
 	has_vlan = !!skb_vlan_tag_present(skb);
 	encap = skb->encapsulation;
 
-	dma_addr = ionic_tx_map_single(q, skb->data, skb_headlen(skb));
-	if (dma_mapping_error(dev, dma_addr))
-		return -ENOMEM;
-
 	flags |= has_vlan ? IONIC_TXQ_DESC_FLAG_VLAN : 0;
 	flags |= encap ? IONIC_TXQ_DESC_FLAG_ENCAP : 0;
 
 	cmd = encode_txq_desc_cmd(IONIC_TXQ_DESC_OPCODE_CSUM_PARTIAL,
-				  flags, skb_shinfo(skb)->nr_frags, dma_addr);
+				  flags, skb_shinfo(skb)->nr_frags,
+				  buf_info->dma_addr);
 	desc->cmd = cpu_to_le64(cmd);
-	desc->len = cpu_to_le16(skb_headlen(skb));
-	desc->csum_start = cpu_to_le16(skb_checksum_start_offset(skb));
-	desc->csum_offset = cpu_to_le16(skb->csum_offset);
+	desc->len = cpu_to_le16(buf_info->len);
 	if (has_vlan) {
 		desc->vlan_tci = cpu_to_le16(skb_vlan_tag_get(skb));
 #ifdef IONIC_DEBUG_STATS
 		stats->vlan_inserted++;
 #endif
+	} else {
+		desc->vlan_tci = 0;
 	}
+	desc->csum_start = cpu_to_le16(skb_checksum_start_offset(skb));
+	desc->csum_offset = cpu_to_le16(skb->csum_offset);
 
 #ifdef IONIC_DEBUG_STATS
 #ifdef HAVE_CSUM_NOT_INET
@@ -1135,14 +1180,14 @@ static int ionic_tx_calc_csum(struct ionic_queue *q, struct sk_buff *skb)
 	return 0;
 }
 
-static int ionic_tx_calc_no_csum(struct ionic_queue *q, struct sk_buff *skb)
+static int ionic_tx_calc_no_csum(struct ionic_queue *q, struct sk_buff *skb,
+				 struct ionic_desc_info *desc_info)
 {
-	struct ionic_txq_desc *desc = q->info[q->head_idx].txq_desc;
+	struct ionic_txq_desc *desc = desc_info->txq_desc;
+	struct ionic_buf_info *buf_info = desc_info->bufs;
 #ifdef IONIC_DEBUG_STATS
 	struct ionic_tx_stats *stats = q_to_tx_stats(q);
 #endif
-	struct device *dev = q->dev;
-	dma_addr_t dma_addr;
 	bool has_vlan;
 	u8 flags = 0;
 	bool encap;
@@ -1151,23 +1196,24 @@ static int ionic_tx_calc_no_csum(struct ionic_queue *q, struct sk_buff *skb)
 	has_vlan = !!skb_vlan_tag_present(skb);
 	encap = skb->encapsulation;
 
-	dma_addr = ionic_tx_map_single(q, skb->data, skb_headlen(skb));
-	if (dma_mapping_error(dev, dma_addr))
-		return -ENOMEM;
-
 	flags |= has_vlan ? IONIC_TXQ_DESC_FLAG_VLAN : 0;
 	flags |= encap ? IONIC_TXQ_DESC_FLAG_ENCAP : 0;
 
 	cmd = encode_txq_desc_cmd(IONIC_TXQ_DESC_OPCODE_CSUM_NONE,
-				  flags, skb_shinfo(skb)->nr_frags, dma_addr);
+				  flags, skb_shinfo(skb)->nr_frags,
+				  buf_info->dma_addr);
 	desc->cmd = cpu_to_le64(cmd);
-	desc->len = cpu_to_le16(skb_headlen(skb));
+	desc->len = cpu_to_le16(buf_info->len);
 	if (has_vlan) {
 		desc->vlan_tci = cpu_to_le16(skb_vlan_tag_get(skb));
 #ifdef IONIC_DEBUG_STATS
 		stats->vlan_inserted++;
 #endif
+	} else {
+		desc->vlan_tci = 0;
 	}
+	desc->csum_start = 0;
+	desc->csum_offset = 0;
 
 #ifdef IONIC_DEBUG_STATS
 	stats->csum_none++;
@@ -1176,50 +1222,48 @@ static int ionic_tx_calc_no_csum(struct ionic_queue *q, struct sk_buff *skb)
 	return 0;
 }
 
-static int ionic_tx_skb_frags(struct ionic_queue *q, struct sk_buff *skb)
+static int ionic_tx_skb_frags(struct ionic_queue *q, struct sk_buff *skb,
+			      struct ionic_desc_info *desc_info)
 {
-	struct ionic_txq_sg_desc *sg_desc = q->info[q->head_idx].txq_sg_desc;
-	unsigned int len_left = skb->len - skb_headlen(skb);
+	struct ionic_txq_sg_desc *sg_desc = desc_info->txq_sg_desc;
+	struct ionic_buf_info *buf_info = &desc_info->bufs[1];
 	struct ionic_txq_sg_elem *elem = sg_desc->elems;
 #ifdef IONIC_DEBUG_STATS
 	struct ionic_tx_stats *stats = q_to_tx_stats(q);
 #endif
-	struct device *dev = q->dev;
-	dma_addr_t dma_addr;
-	skb_frag_t *frag;
-	u16 len;
+	unsigned int i;
 
-	for (frag = skb_shinfo(skb)->frags; len_left; frag++, elem++) {
-		len = skb_frag_size(frag);
-		elem->len = cpu_to_le16(len);
-		dma_addr = ionic_tx_map_frag(q, frag, 0, len);
-		if (dma_mapping_error(dev, dma_addr))
-			return -ENOMEM;
-		elem->addr = cpu_to_le64(dma_addr);
-		len_left -= len;
-#ifdef IONIC_DEBUG_STATS
-		stats->frags++;
-#endif
+	for (i = 0; i < skb_shinfo(skb)->nr_frags; i++, buf_info++, elem++) {
+		elem->addr = cpu_to_le64(buf_info->dma_addr);
+		elem->len = cpu_to_le16(buf_info->len);
 	}
+
+#ifdef IONIC_DEBUG_STATS
+	stats->frags += skb_shinfo(skb)->nr_frags;
+#endif
 
 	return 0;
 }
 
 static int ionic_tx(struct ionic_queue *q, struct sk_buff *skb)
 {
+	struct ionic_desc_info *desc_info = &q->info[q->head_idx];
 	struct ionic_tx_stats *stats = q_to_tx_stats(q);
 	int err;
 
+	if (unlikely(ionic_tx_map_skb(q, skb, desc_info)))
+		return -EIO;
+
 	/* set up the initial descriptor */
 	if (skb->ip_summed == CHECKSUM_PARTIAL)
-		err = ionic_tx_calc_csum(q, skb);
+		err = ionic_tx_calc_csum(q, skb, desc_info);
 	else
-		err = ionic_tx_calc_no_csum(q, skb);
+		err = ionic_tx_calc_no_csum(q, skb, desc_info);
 	if (err)
 		return err;
 
 	/* add frags */
-	err = ionic_tx_skb_frags(q, skb);
+	err = ionic_tx_skb_frags(q, skb, desc_info);
 	if (err)
 		return err;
 
@@ -1241,25 +1285,27 @@ static int ionic_tx(struct ionic_queue *q, struct sk_buff *skb)
 static int ionic_tx_descs_needed(struct ionic_queue *q, struct sk_buff *skb)
 {
 	struct ionic_tx_stats *stats = q_to_tx_stats(q);
+	int ndescs;
 	int err;
 
-	/* If TSO, need roundup(skb->len/mss) descs */
+	/* If TSO, need roundup(skb->len/mss) descs
+	 * If non-TSO, just need 1 desc and nr_frags sg elems
+	 */
 	if (skb_is_gso(skb))
-		return (skb->len / skb_shinfo(skb)->gso_size) + 1;
+		ndescs = (skb->len / skb_shinfo(skb)->gso_size) + 1;
+	else
+		ndescs = 1;
 
-	/* If non-TSO, just need 1 desc and nr_frags sg elems */
-	if (skb_shinfo(skb)->nr_frags <= q->max_sg_elems)
-		return 1;
+	/* If too many frags, linearize */
+	if (skb_shinfo(skb)->nr_frags > q->max_sg_elems) {
+		err = skb_linearize(skb);
+		if (err)
+			return err;
 
-	/* Too many frags, so linearize */
-	err = skb_linearize(skb);
-	if (err)
-		return err;
+		stats->linearize++;
+	}
 
-	stats->linearize++;
-
-	/* Need 1 desc and zero sg elems */
-	return 1;
+	return ndescs;
 }
 
 static int ionic_maybe_stop_tx(struct ionic_queue *q, int ndescs)
@@ -1282,30 +1328,39 @@ static int ionic_maybe_stop_tx(struct ionic_queue *q, int ndescs)
 	return stopped;
 }
 
-#ifndef HAVE_NDO_SELECT_QUEUE_SB_DEV
-u16 ionic_select_queue(struct net_device *netdev, struct sk_buff *skb,
-			void *accel_priv, select_queue_fallback_t fallback)
+netdev_tx_t ionic_start_hwstamp_xmit(struct sk_buff *skb, struct net_device *netdev)
 {
-	u16 index;
+	struct ionic_lif *lif = netdev_priv(netdev);
+	struct ionic_queue *q = &lif->hwstamp_txq->q;
+	int err, ndescs;
 
-	if (netdev->features & NETIF_F_HW_L2FW_DOFFLOAD) {
-		if (accel_priv) {
-			struct ionic_lif *lif = (struct ionic_lif *)accel_priv;
-			struct ionic_lif *master_lif = lif->ionic->master_lif;
+	/* Does not stop/start txq, because we violate the skb queue mapping by
+	 * posting to a sseparate tx queue for timestamping.  If a packet can't
+	 * be posted immediately to the timestamping queue, it is dropped.
+	 */
 
-			index = master_lif->nxqs + lif->index - 1;
-		} else {
-			struct ionic_lif *lif = netdev_priv(netdev);
+	ndescs = ionic_tx_descs_needed(q, skb);
+	if (unlikely(ndescs < 0))
+		goto err_out_drop;
 
-			index = lif->index;
-		}
-	} else {
-		index = fallback(netdev, skb);
-	}
+	if (unlikely(!ionic_q_has_space(q, ndescs)))
+		goto err_out_drop;
 
-	return index;
+	if (skb_is_gso(skb))
+		err = ionic_tx_tso(q, skb);
+	else
+		err = ionic_tx(q, skb);
+
+	if (err)
+		goto err_out_drop;
+
+	return NETDEV_TX_OK;
+
+err_out_drop:
+	q->drop++;
+	dev_kfree_skb(skb);
+	return NETDEV_TX_OK;
 }
-#endif
 
 netdev_tx_t ionic_start_xmit(struct sk_buff *skb, struct net_device *netdev)
 {
@@ -1320,9 +1375,13 @@ netdev_tx_t ionic_start_xmit(struct sk_buff *skb, struct net_device *netdev)
 		return NETDEV_TX_OK;
 	}
 
-	if (unlikely(!lif_to_txqcq(lif, queue_index)))
+	if (unlikely(skb_shinfo(skb)->tx_flags & SKBTX_HW_TSTAMP))
+		if (lif->hwstamp_txq)
+			return ionic_start_hwstamp_xmit(skb, netdev);
+
+	if (unlikely(queue_index >= lif->nxqs))
 		queue_index = 0;
-	q = lif_to_txq(lif, queue_index);
+	q = &lif->txqcqs[queue_index]->q;
 
 	ndescs = ionic_tx_descs_needed(q, skb);
 	if (ndescs < 0)

--- a/drivers/linux/eth/ionic/ionic_txrx.h
+++ b/drivers/linux/eth/ionic/ionic_txrx.h
@@ -13,10 +13,9 @@ void ionic_tx_empty(struct ionic_queue *q);
 int ionic_rx_napi(struct napi_struct *napi, int budget);
 int ionic_tx_napi(struct napi_struct *napi, int budget);
 int ionic_txrx_napi(struct napi_struct *napi, int budget);
-#ifndef HAVE_NDO_SELECT_QUEUE_SB_DEV
-u16 ionic_select_queue(struct net_device *netdev, struct sk_buff *skb,
-			void *accel_priv, select_queue_fallback_t fallback);
-#endif
 netdev_tx_t ionic_start_xmit(struct sk_buff *skb, struct net_device *netdev);
+
+bool ionic_rx_service(struct ionic_cq *cq, struct ionic_cq_info *cq_info);
+bool ionic_tx_service(struct ionic_cq *cq, struct ionic_cq_info *cq_info);
 
 #endif /* _IONIC_TXRX_H_ */

--- a/drivers/linux/linux_ver.mk
+++ b/drivers/linux/linux_ver.mk
@@ -47,13 +47,13 @@ endif
 
 # Kernel Search Path
 # All the places we look for kernel source
-KSP :=  /lib/modules/${BUILD_KERNEL}/source \
-        /lib/modules/${BUILD_KERNEL}/build \
+KSP :=  /lib/modules/${BUILD_KERNEL}/build \
+	/lib/modules/${BUILD_KERNEL}/source \
         /usr/src/linux-${BUILD_KERNEL} \
-        /usr/src/linux-$(${BUILD_KERNEL} | sed 's/-.*//') \
+        /usr/src/linux-$(shell echo ${BUILD_KERNEL} | sed 's/-.*//') \
         /usr/src/kernel-headers-${BUILD_KERNEL} \
         /usr/src/kernel-source-${BUILD_KERNEL} \
-        /usr/src/linux-$(${BUILD_KERNEL} | sed 's/\([0-9]*\.[0-9]*\)\..*/\1/') \
+        /usr/src/linux-$(shell echo ${BUILD_KERNEL} | sed 's/\([0-9]*\.[0-9]*\)\..*/\1/') \
         /usr/src/linux \
         /usr/src/kernels/${BUILD_KERNEL} \
         /usr/src/kernels
@@ -61,7 +61,7 @@ KSP :=  /lib/modules/${BUILD_KERNEL}/source \
 # prune the list down to only values that exist and have an include/linux
 # sub-directory. We can't use include/config because some older kernels don't
 # have this.
-test_dir = $(shell [ -e ${dir}/include/linux ] && echo ${dir})
+test_dir = $(shell [ -e ${dir}/include/linux -o -e ${dir}/include/generated ] && echo ${dir})
 KSP := $(foreach dir, ${KSP}, ${test_dir})
 
 # we will use this first valid entry in the search path

--- a/drivers/linux/mnet/mnet_drv.c
+++ b/drivers/linux/mnet/mnet_drv.c
@@ -16,6 +16,8 @@
 
 #define DOORBELL_PG_SIZE        0x8
 
+#define TSTAMP_SIZE             0x8
+
 #define MNET_NODE_NAME_LEN      0x8
 
 struct mnet_dev_t {
@@ -72,6 +74,10 @@ struct platform_device *mnet_get_platform_device(struct mnet_dev_t *mnet,
 			.flags    = IORESOURCE_MEM,
 			.start    = req->doorbell_pa,
 			.end      = req->doorbell_pa + DOORBELL_PG_SIZE - 1
+		}, {/*tstamp*/
+			.flags    = IORESOURCE_MEM,
+			.start    = req->tstamp_pa,
+			.end      = req->tstamp_pa + TSTAMP_SIZE - 1
 		}
 	};
 

--- a/drivers/linux/mnet/mnet_drv.h
+++ b/drivers/linux/mnet/mnet_drv.h
@@ -18,6 +18,7 @@ struct mnet_dev_create_req_t {
 	uint64_t drvcfg_pa;
 	uint64_t msixcfg_pa;
 	uint64_t doorbell_pa;
+	uint64_t tstamp_pa;
 	int is_uio_dev;
 	char iface_name[MNIC_NAME_LEN];
 };


### PR DESCRIPTION
Updates include:
 - Added support for PTP
 - Dropped support for macvlan offload
 - Cleaned some 'sparse' complaints
 - Add support for devlink firmware update
 - Dynamic interrupt coalescing
 - Add support for separate Tx interrupts
 - Rework queue reconfiguration for better memory handling
 - Reorder some configuration steps to remove race conditions
 - Changes to napi handling for better performance

Signed-off-by: Shannon Nelson <snelson@pensando.io>