### PR TITLE
drivers: update driver code to 1.15.5-C-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ If the kernel config file doesn't have the Pensando configuration strings
 set in it, you can add them in the make line.
 
 For Naples drivers:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.4.8\\\"" CONFIG_IONIC_MNIC=m CONFIG_MNET=m CONFIG_MNET_UIO_PDRV_GENIRQ=m modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.5.4\\\"" CONFIG_IONIC_MNIC=m CONFIG_MNET=m CONFIG_MNET_UIO_PDRV_GENIRQ=m modules
 
 For the host driver:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.4.8\\\"" CONFIG_IONIC=m modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.5.4\\\"" CONFIG_IONIC=m modules
 
 As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
     make -C <kernel-header-path> M=`pwd` ...
@@ -88,3 +88,10 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - Reorder some configuration steps to remove race conditions
  - Changes to napi handling for better performance
 
+2021-02-24 - driver updates to 1.15.5-C-4
+ - Add weak links for PTP api for compile and load on DSC kernel without PTP support
+ - Don't set up PTP in ionic_mnic if PTP bar is not available
+ - Closed a small window to prevent starting queues when in FW reset
+ - Other small bug fixes to PTP support
+ - Compat fixes for compiling on Linux v5.11
+ - Guard against adminq use after free

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -99,7 +99,7 @@ DVER = $(shell echo $$SW_VERSION)
 ifeq ($(DVER),)
   DVER = $(shell git describe --tags 2>/dev/null)
   ifeq ($(DVER),)
-    DVER = "1.15.4.8"
+    DVER = "1.15.5.4"
   endif
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"

--- a/drivers/linux/eth/ionic/Makefile
+++ b/drivers/linux/eth/ionic/Makefile
@@ -17,4 +17,4 @@ ionic_mnic-y := ionic_main.o ionic_bus_platform.o ionic_dev.o ionic_ethtool.o \
 	        ionic_lif.o ionic_rx_filter.o ionic_txrx.o ionic_debugfs.o \
 	        ionic_api.o ionic_stats.o ionic_devlink.o ionic_fw.o \
 		dim.o net_dim.o
-ionic_mnic-$(CONFIG_PTP_1588_CLOCK) += ionic_phc.o
+ionic_mnic-$(CONFIG_PTP_1588_CLOCK) += ionic_phc.o ionic_phc_weak.o

--- a/drivers/linux/eth/ionic/ionic_dev.c
+++ b/drivers/linux/eth/ionic/ionic_dev.c
@@ -33,7 +33,8 @@ static void ionic_watchdog_cb(struct timer_list *t)
 
 	/* check link if we're waiting for link to come back up */
 	if (hb >= 0 && netif_running(lif->netdev) &&
-	    !test_bit(IONIC_LIF_F_UP, lif->state)) {
+	    !test_bit(IONIC_LIF_F_UP, lif->state) &&
+	    !test_bit(IONIC_LIF_F_FW_RESET, lif->state)) {
 		ionic_link_status_check_request(lif, CAN_NOT_SLEEP);
 	}
 }

--- a/drivers/linux/eth/ionic/ionic_devlink.c
+++ b/drivers/linux/eth/ionic/ionic_devlink.c
@@ -17,7 +17,11 @@ static int ionic_dl_flash_update(struct devlink *dl,
 {
 	struct ionic *ionic = devlink_priv(dl);
 
-	return ionic_firmware_update(ionic->lif, params->file_name);
+#ifdef HAVE_DEVLINK_PREFETCH_FW
+	return ionic_firmware_update(ionic->lif, params->fw);
+#else
+	return ionic_firmware_fetch_and_update(ionic->lif, params->file_name);
+#endif
 }
 #else
 static int ionic_dl_flash_update(struct devlink *dl,
@@ -30,7 +34,7 @@ static int ionic_dl_flash_update(struct devlink *dl,
 	if (component)
 		return -EOPNOTSUPP;
 
-	return ionic_firmware_update(ionic->lif, fwname);
+	return ionic_firmware_fetch_and_update(ionic->lif, fwname);
 }
 #endif /* HAVE_DEVLINK_UPDATE_PARAMS */
 

--- a/drivers/linux/eth/ionic/ionic_devlink.h
+++ b/drivers/linux/eth/ionic/ionic_devlink.h
@@ -4,11 +4,14 @@
 #ifndef _IONIC_DEVLINK_H_
 #define _IONIC_DEVLINK_H_
 
+#include <linux/firmware.h>
+
 #if IS_ENABLED(CONFIG_NET_DEVLINK)
 #include <net/devlink.h>
 #endif
 
-int ionic_firmware_update(struct ionic_lif *lif, const char *fw_name);
+int ionic_firmware_update(struct ionic_lif *lif, const struct firmware *fw);
+int ionic_firmware_fetch_and_update(struct ionic_lif *lif, const char *fw_name);
 
 /* make sure we've got a new-enough devlink support to use dev info */
 #ifdef DEVLINK_INFO_VERSION_GENERIC_BOARD_ID

--- a/drivers/linux/eth/ionic/ionic_ethtool.c
+++ b/drivers/linux/eth/ionic/ionic_ethtool.c
@@ -926,18 +926,13 @@ static int ionic_set_rxfh(struct net_device *netdev, const u32 *indir,
 #endif
 {
 	struct ionic_lif *lif = netdev_priv(netdev);
-	int err;
 
 #ifdef HAVE_RXFH_HASHFUNC
 	if (hfunc != ETH_RSS_HASH_NO_CHANGE && hfunc != ETH_RSS_HASH_TOP)
 		return -EOPNOTSUPP;
 #endif
 
-	err = ionic_lif_rss_config(lif, lif->rss_types, key, indir);
-	if (err)
-		return err;
-
-	return 0;
+	return ionic_lif_rss_config(lif, lif->rss_types, key, indir);
 }
 
 static int ionic_set_tunable(struct net_device *dev,
@@ -1175,7 +1170,7 @@ static int ionic_flash_device(struct net_device *netdev,
 	if (eflash->region)
 		return -EOPNOTSUPP;
 
-	return ionic_firmware_update(lif, eflash->data);
+	return ionic_firmware_fetch_and_update(lif, eflash->data);
 }
 
 static const struct ethtool_ops ionic_ethtool_ops = {

--- a/drivers/linux/eth/ionic/ionic_main.c
+++ b/drivers/linux/eth/ionic/ionic_main.c
@@ -207,10 +207,17 @@ static const char *ionic_opcode_to_str(enum ionic_cmd_opcode opcode)
 
 static void ionic_adminq_flush(struct ionic_lif *lif)
 {
-	struct ionic_queue *q = &lif->adminqcq->q;
 	struct ionic_desc_info *desc_info;
+	unsigned long irqflags;
+	struct ionic_queue *q;
 
-	spin_lock(&lif->adminq_lock);
+	spin_lock_irqsave(&lif->adminq_lock, irqflags);
+	if (!lif->adminqcq) {
+		spin_unlock_irqrestore(&lif->adminq_lock, irqflags);
+		return;
+	}
+
+	q = &lif->adminqcq->q;
 
 	while (q->tail_idx != q->head_idx) {
 		desc_info = &q->info[q->tail_idx];
@@ -219,7 +226,7 @@ static void ionic_adminq_flush(struct ionic_lif *lif)
 		desc_info->cb_arg = NULL;
 		q->tail_idx = (q->tail_idx + 1) & (q->num_descs - 1);
 	}
-	spin_unlock(&lif->adminq_lock);
+	spin_unlock_irqrestore(&lif->adminq_lock, irqflags);
 }
 
 static int ionic_adminq_check_err(struct ionic_lif *lif,
@@ -274,15 +281,18 @@ static void ionic_adminq_cb(struct ionic_queue *q,
 int ionic_adminq_post(struct ionic_lif *lif, struct ionic_admin_ctx *ctx)
 {
 	struct ionic_desc_info *desc_info;
+	unsigned long irqflags;
 	struct ionic_queue *q;
 	int err = 0;
 
-	if (!lif->adminqcq)
+	spin_lock_irqsave(&lif->adminq_lock, irqflags);
+	if (!lif->adminqcq) {
+		spin_unlock_irqrestore(&lif->adminq_lock, irqflags);
 		return -EIO;
+	}
 
 	q = &lif->adminqcq->q;
 
-	spin_lock(&lif->adminq_lock);
 	if (!ionic_q_has_space(q, 1)) {
 		err = -ENOSPC;
 		goto err_out;
@@ -302,7 +312,7 @@ int ionic_adminq_post(struct ionic_lif *lif, struct ionic_admin_ctx *ctx)
 	ionic_q_post(q, true, ionic_adminq_cb, ctx);
 
 err_out:
-	spin_unlock(&lif->adminq_lock);
+	spin_unlock_irqrestore(&lif->adminq_lock, irqflags);
 
 	return err;
 }

--- a/drivers/linux/eth/ionic/ionic_phc.c
+++ b/drivers/linux/eth/ionic/ionic_phc.c
@@ -485,6 +485,9 @@ void ionic_lif_alloc_phc(struct ionic_lif *lif)
 	u64 delay, diff, mult, frac = 0;
 	u32 shift;
 
+	if (!ionic->idev.hwstamp_regs)
+		return;
+
 	if (!(ionic->ident.lif.eth.config.features & IONIC_ETH_HW_TIMESTAMP))
 		return;
 

--- a/drivers/linux/eth/ionic/ionic_phc_weak.c
+++ b/drivers/linux/eth/ionic/ionic_phc_weak.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright(c) 2021 Pensando Systems, Inc */
+
+#include <linux/errno.h>
+#include <linux/kernel.h>
+
+struct device;
+struct ptp_clock;
+struct ptp_clock_event;
+struct ptp_clock_info;
+enum ptp_pin_function { PTP_PIN_DUMMY };
+
+__weak struct ptp_clock *ptp_clock_register(struct ptp_clock_info *info, struct device *parent) { return NULL; }
+__weak int ptp_clock_unregister(struct ptp_clock *ptp) { return 0; }
+__weak void ptp_clock_event(struct ptp_clock *ptp, struct ptp_clock_event *event) { }
+__weak int ptp_clock_index(struct ptp_clock *ptp) { return -1; }
+__weak int ptp_find_pin(struct ptp_clock *ptp, enum ptp_pin_function func, unsigned int chan) { return -1; }
+__weak int ptp_schedule_worker(struct ptp_clock *ptp, unsigned long delay) { return -EOPNOTSUPP; }
+__weak void ptp_cancel_worker_sync(struct ptp_clock *ptp) { }

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -6695,6 +6695,14 @@ _kc_devlink_region_create(struct devlink *devlink,
 #define HAVE_DEVLINK_UPDATE_PARAMS
 #endif /* 5.10.0 */
 
+/*****************************************************************************/
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0))
+#else
+#define HAVE_DEVLINK_PREFETCH_FW
+static inline void devlink_flash_update_begin_notify(struct devlink *dl) { }
+static inline void devlink_flash_update_end_notify(struct devlink *dl) { }
+#endif /* 5.11.0 */
+
 /* we will not support PTP for kernels without HAVE_PTP_CLOCK_DO_AUX_WORK */
 #ifndef HAVE_PTP_CLOCK_DO_AUX_WORK
 #undef CONFIG_PTP_1588_CLOCK

--- a/drivers/linux/mnet/mnet_drv.c
+++ b/drivers/linux/mnet/mnet_drv.c
@@ -98,13 +98,13 @@ struct platform_device *mnet_get_platform_device(struct mnet_dev_t *mnet,
 		return NULL;
 	}
 
-	mnic_name = devm_kzalloc(mnet_device, MNIC_NAME_LEN, GFP_KERNEL);
+	mnic_name = devm_kzalloc(mnet_device, MNIC_NAME_LEN+1, GFP_KERNEL);
 	if (!pdev->name) {
 		dev_err(mnet_device, "Can't allocate memory for mnic_name\n");
 		return NULL;
 	}
 
-	strcpy(mnic_name, req->iface_name);
+	strncpy(mnic_name, req->iface_name, MNIC_NAME_LEN);
 	pdev->name = mnic_name;
 
 	return pdev;
@@ -116,7 +116,7 @@ static long mnet_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 	struct mnet_dev_t *mnet;
 	uint8_t found_dev_node = 0;
 	struct mnet_dev_create_req_t req;
-	char iface_name[MNIC_NAME_LEN] = {0};
+	char iface_name[MNIC_NAME_LEN+1] = {0};
 	void __user *argp = (void __user *)arg;
 
 	switch (cmd) {
@@ -184,7 +184,7 @@ static long mnet_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 
 		list_for_each_entry(mnet, &mnet_list, node) {
 			/* find the mnet device which is bound to this interface */
-			if (!strcmp(mnet->mnic_pdev->name, iface_name)) {
+			if (!strncmp(mnet->mnic_pdev->name, iface_name, MNIC_NAME_LEN)) {
 				found_dev_node = 1;
 				break;
 			}
@@ -230,7 +230,7 @@ static int mnet_probe(struct platform_device *pfdev)
 static int mnet_remove(struct platform_device *pfdev)
 {
 	struct mnet_dev_t *mnet, *tmp;
-	int ret;
+	int ret = 0;
 
     list_for_each_entry_safe(mnet, tmp, &mnet_list, node) {
         if (mnet->mnic_pdev) {


### PR DESCRIPTION
driver updates include:
 - weak links for PTP api for compile and load on DSC kernel without PTP support
 - don't set up PTP in ionic_mnic if PTP bar is not available
 - close a small window to prevent starting queues when in FW reset
 - other small bug fixes to PTP support
 - compat fixes for compiling on Linux v5.11
 - guard against adminq use after free

Signed-off-by: Shannon Nelson <snelson@pensando.io>