### PR TITLE
drivers: add new Makefile for mdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ we wanted to keep this archive closer to what is used internally.
 
 If the headers for your current Linux kernel are findable under
 /lib/modules with kernel config values defined, this should work:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.4.8\\\"" modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.7.3\\\"" modules
 
 If the kernel config file doesn't have the Pensando configuration strings
 set in it, you can add them in the make line.
 
 For Naples drivers:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.5.4\\\"" CONFIG_IONIC_MNIC=m CONFIG_MNET=m CONFIG_MNET_UIO_PDRV_GENIRQ=m modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.7.3\\\"" CONFIG_IONIC_MNIC=m CONFIG_MDEV=m CONFIG_MNET_UIO_PDRV_GENIRQ=m modules
 
 For the host driver:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.5.4\\\"" CONFIG_IONIC=m modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.7.3\\\"" CONFIG_IONIC=m modules
 
 As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
     make -C <kernel-header-path> M=`pwd` ...

--- a/drivers/linux/mdev/Makefile
+++ b/drivers/linux/mdev/Makefile
@@ -1,0 +1,3 @@
+obj-$(CONFIG_MDEV) := mdev.o
+
+mdev-y := mdev_drv.o


### PR DESCRIPTION
The Makefile got lost in the driver name change, so add it
back into the release.  Also updating the example make lines
in the README.

Signed-off-by: Shannon Nelson <snelson@pensando.io>