### PR TITLE
drivers: updates for 1.15.8.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ we wanted to keep this archive closer to what is used internally.
 
 If the headers for your current Linux kernel are findable under
 /lib/modules with kernel config values defined, this should work:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.7.3\\\"" modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.8.12\\\"" modules
 
 If the kernel config file doesn't have the Pensando configuration strings
 set in it, you can add them in the make line.
 
 For Naples drivers:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.7.3\\\"" CONFIG_IONIC_MNIC=m CONFIG_MDEV=m CONFIG_MNET_UIO_PDRV_GENIRQ=m modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.8.12\\\"" CONFIG_IONIC_MNIC=m CONFIG_MDEV=m CONFIG_MNET_UIO_PDRV_GENIRQ=m modules
 
 For the host driver:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.7.3\\\"" CONFIG_IONIC=m modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.8.12\\\"" CONFIG_IONIC=m modules
 
 As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
     make -C <kernel-header-path> M=`pwd` ...
@@ -107,3 +107,10 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - Minor code cleanups to better match upstream drivers
  - Renamed mnet to mdev to be more generic
  - Added support in mdev for future mcrypt devices
+
+2021-05-19 - driver updates to 1.15.8-C-12
+ - added support for cmb-rings - Tx/Rx descriptor rings allocated in
+   DSC Controller Memory Buffers rather than on host
+ - rx_mode locking to block thread race
+ - struct ionic_lif rework for better cache line layout
+

--- a/drivers/common/ionic_if.h
+++ b/drivers/common/ionic_if.h
@@ -8,11 +8,17 @@
 #define IONIC_DEV_INFO_VERSION			1
 #define IONIC_IFNAMSIZ				16
 
+#ifdef __CHECKER__
+#define IONIC_CHECK_CMD_LENGTH(X)
+#define IONIC_CHECK_COMP_LENGTH(X)
+#define IONIC_CHECK_CMD_DATA_LENGTH(X)
+#else
 #define IONIC_SIZE_CHECK(type, N, X)		enum ionic_static_assert_enum_##X \
 		{ ionic_static_assert_##X = (N) / (sizeof(type X) == (N)) }
 #define IONIC_CHECK_CMD_LENGTH(X)		IONIC_SIZE_CHECK(struct, 64, X)
 #define IONIC_CHECK_COMP_LENGTH(X)  		IONIC_SIZE_CHECK(struct, 16, X)
 #define IONIC_CHECK_CMD_DATA_LENGTH(X)      	IONIC_SIZE_CHECK(union, 1912, X)
+#endif
 
 /**
  * enum ionic_cmd_opcode - Device commands
@@ -3279,9 +3285,11 @@ union ionic_adminq_comp {
 
 #define IONIC_BARS_MAX			6
 #define IONIC_PCI_BAR_DBELL		1
+#define IONIC_PCI_BAR_CMB		2
 
 /* BAR0 */
 #define IONIC_BAR0_SIZE				0x8000
+#define IONIC_BAR2_SIZE				0x800000
 
 #define IONIC_BAR0_DEV_INFO_REGS_OFFSET		0x0000
 #define IONIC_BAR0_DEV_CMD_REGS_OFFSET		0x0800

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -101,7 +101,7 @@ DVER = $(shell echo $$SW_VERSION)
 ifeq ($(DVER),)
   DVER = $(shell git describe --tags 2>/dev/null)
   ifeq ($(DVER),)
-    DVER = "1.15.7.3"
+    DVER = "1.15.8.12"
   endif
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"

--- a/drivers/linux/eth/ionic/ionic.h
+++ b/drivers/linux/eth/ionic/ionic.h
@@ -26,7 +26,7 @@ struct ionic_lif;
 #define SHORT_TIMEOUT   1
 #define MAX_ETH_EQS	64
 
-#define IONIC_PHC_UPDATE_NS	10000000000	    /* 10s in nanoseconds */
+#define IONIC_PHC_UPDATE_NS	10000000000L	    /* 10s in nanoseconds */
 #define NORMAL_PPB		1000000000	    /* one billion parts per billion */
 #define SCALED_PPM		(1000000ull << 16)  /* 2^16 million parts per 2^16 million */
 

--- a/drivers/linux/eth/ionic/ionic_api.c
+++ b/drivers/linux/eth/ionic/ionic_api.c
@@ -181,32 +181,16 @@ EXPORT_SYMBOL_GPL(ionic_api_put_intr);
 int ionic_api_get_cmb(void *handle, u32 *pgid, phys_addr_t *pgaddr, int order)
 {
 	struct ionic_lif *lif = handle;
-	struct ionic_dev *idev = &lif->ionic->idev;
-	int ret;
 
-	mutex_lock(&idev->cmb_inuse_lock);
-	ret = bitmap_find_free_region(idev->cmb_inuse, idev->cmb_npages,
-				      order);
-	mutex_unlock(&idev->cmb_inuse_lock);
-
-	if (ret < 0)
-		return ret;
-
-	*pgid = (u32)ret;
-	*pgaddr = idev->phy_cmb_pages + ret * PAGE_SIZE;
-
-	return 0;
+	return ionic_get_cmb(lif, pgid, pgaddr, order);
 }
 EXPORT_SYMBOL_GPL(ionic_api_get_cmb);
 
 void ionic_api_put_cmb(void *handle, u32 pgid, int order)
 {
 	struct ionic_lif *lif = handle;
-	struct ionic_dev *idev = &lif->ionic->idev;
 
-	mutex_lock(&idev->cmb_inuse_lock);
-	bitmap_release_region(idev->cmb_inuse, pgid, order);
-	mutex_unlock(&idev->cmb_inuse_lock);
+	ionic_put_cmb(lif, pgid, order);
 }
 EXPORT_SYMBOL_GPL(ionic_api_put_cmb);
 

--- a/drivers/linux/eth/ionic/ionic_debugfs.c
+++ b/drivers/linux/eth/ionic/ionic_debugfs.c
@@ -41,10 +41,10 @@ static int bars_show(struct seq_file *seq, void *v)
 	unsigned int i;
 
 	for (i = 0; i < IONIC_BARS_MAX; i++)
-		if (bars[i].vaddr)
-			seq_printf(seq, "BAR%d: len 0x%lx vaddr %pK bus_addr %pad\n",
-				   i, bars[i].len, bars[i].vaddr,
-				   &bars[i].bus_addr);
+		if (bars[i].len)
+			seq_printf(seq, "BAR%d: res %d len 0x%08lx vaddr %pK bus_addr 0x%016llx\n",
+				   i, bars[i].res_index, bars[i].len,
+				   bars[i].vaddr, bars[i].bus_addr);
 
 	return 0;
 }
@@ -229,6 +229,8 @@ void ionic_debugfs_add_qcq(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	debugfs_create_x32("cq_size", 0400, qcq_dentry, &qcq->cq_size);
 	debugfs_create_x64("sg_base_pa", 0400, qcq_dentry, &qcq->sg_base_pa);
 	debugfs_create_x32("sg_size", 0400, qcq_dentry, &qcq->sg_size);
+	debugfs_create_x32("cmb_order", 0400, qcq_dentry, &qcq->cmb_order);
+	debugfs_create_x32("cmb_pgid", 0400, qcq_dentry, &qcq->cmb_pgid);
 
 #if (RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,0)))
 	debugfs_create_u8("armed", 0400, qcq_dentry, (u8 *)&qcq->armed);

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -368,6 +368,9 @@ void ionic_dev_cmd_adminq_init(struct ionic_dev *idev, struct ionic_qcq *qcq,
 
 int ionic_db_page_num(struct ionic_lif *lif, int pid);
 
+int ionic_get_cmb(struct ionic_lif *lif, u32 *pgid, phys_addr_t *pgaddr, int order);
+void ionic_put_cmb(struct ionic_lif *lif, u32 pgid, int order);
+
 int ionic_eqs_alloc(struct ionic *ionic);
 void ionic_eqs_free(struct ionic *ionic);
 void ionic_eqs_deinit(struct ionic *ionic);

--- a/drivers/linux/eth/ionic/kcompat.c
+++ b/drivers/linux/eth/ionic/kcompat.c
@@ -2595,7 +2595,7 @@ void _kc_pcie_print_link_status(struct pci_dev *dev) {
 #endif /* 4.17.0 */
 
 /*****************************************************************************/
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,13,0))
 void _kc_ethtool_sprintf(u8 **data, const char *fmt, ...)
 {
 	va_list args;
@@ -2606,4 +2606,4 @@ void _kc_ethtool_sprintf(u8 **data, const char *fmt, ...)
 
 	*data += ETH_GSTRING_LEN;
 }
-#endif /* 5.12.0 */
+#endif /* 5.13.0 */

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -6753,11 +6753,11 @@ static inline void devlink_flash_update_end_notify(struct devlink *dl) { }
 #endif /* 5.11.0 */
 
 /*****************************************************************************/
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,13,0))
 
 void _kc_ethtool_sprintf(u8 **data, const char *fmt, ...);
 #define ethtool_sprintf _kc_ethtool_sprintf
-#endif /* 5.12.0 */
+#endif /* 5.13.0 */
 
 /* We don't support PTP on older RHEL kernels (needs more compat work) */
 #if (RHEL_RELEASE_CODE && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,4))


### PR DESCRIPTION
Updates include:
 - added support for cmb-rings
 	CMB = Controller Memory Buffers
 - rx_mode locking to block thread race
 - struct ionic_lif rework for better cache line layout

Signed-off-by: Shannon Nelson <snelson@pensando.io>