### PR TITLE
drivers: updates for 1.15.9.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ we wanted to keep this archive closer to what is used internally.
 
 If the headers for your current Linux kernel are findable under
 /lib/modules with kernel config values defined, this should work:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.8.12\\\"" modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.9.7\\\"" modules
 
 If the kernel config file doesn't have the Pensando configuration strings
 set in it, you can add them in the make line.
 
 For Naples drivers:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.8.12\\\"" CONFIG_IONIC_MNIC=m CONFIG_MDEV=m CONFIG_MNET_UIO_PDRV_GENIRQ=m modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.9.7\\\"" CONFIG_IONIC_MNIC=m CONFIG_MDEV=m CONFIG_MNET_UIO_PDRV_GENIRQ=m modules
 
 For the host driver:
-    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.8.12\\\"" CONFIG_IONIC=m modules
+    make M=`pwd` KCFLAGS="-Werror -Ddrv_ver=\\\"1.15.9.7\\\"" CONFIG_IONIC=m modules
 
 As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
     make -C <kernel-header-path> M=`pwd` ...
@@ -114,3 +114,10 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - rx_mode locking to block thread race
  - struct ionic_lif rework for better cache line layout
 
+2021-06-30 - driver updates for 1.15.9-C-7
+ - monitoring fw status generation for fw restart hints
+ - catch lack of PTP support earlier in service routine
+ - makefile fixes for sles 15 sp3
+ - lower page splitting limit to better account for headers
+ - VF stats area fix for PF
+ - better thread-safe rx_mode work

--- a/drivers/common/ionic_if.h
+++ b/drivers/common/ionic_if.h
@@ -3193,6 +3193,8 @@ struct ionic_hwstamp_regs {
  * @asic_type:       Asic type
  * @asic_rev:        Asic revision
  * @fw_status:       Firmware status
+ *			bit 0   - 1 = fw running
+ *			bit 4-7 - 4 bit generation number, changes on fw restart
  * @fw_heartbeat:    Firmware heartbeat counter
  * @serial_num:      Serial number
  * @fw_version:      Firmware version
@@ -3206,7 +3208,8 @@ union ionic_dev_info_regs {
 		u8     version;
 		u8     asic_type;
 		u8     asic_rev;
-#define IONIC_FW_STS_F_RUNNING	0x1
+#define IONIC_FW_STS_F_RUNNING		0x01
+#define IONIC_FW_STS_F_GENERATION	0xF0
 		u8     fw_status;
 		u32    fw_heartbeat;
 		char   fw_version[IONIC_DEVINFO_FWVERS_BUFLEN];

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -101,7 +101,7 @@ DVER = $(shell echo $$SW_VERSION)
 ifeq ($(DVER),)
   DVER = $(shell git describe --tags 2>/dev/null)
   ifeq ($(DVER),)
-    DVER = "1.15.8.12"
+    DVER = "1.15.9.7"
   endif
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"

--- a/drivers/linux/eth/ionic/ionic_bus_pci.c
+++ b/drivers/linux/eth/ionic/ionic_bus_pci.c
@@ -224,10 +224,10 @@ static int ionic_vf_alloc(struct ionic *ionic, int num_vfs)
 			goto out;
 		}
 
+		ionic->num_vfs++;
 		/* ignore failures from older FW, we just won't get stats */
 		(void)ionic_set_vf_config(ionic, i, IONIC_VF_ATTR_STATSADDR,
 					  (u8 *)&v->stats_pa);
-		ionic->num_vfs++;
 	}
 
 out:

--- a/drivers/linux/eth/ionic/ionic_dev.c
+++ b/drivers/linux/eth/ionic/ionic_dev.c
@@ -112,6 +112,8 @@ int ionic_dev_setup(struct ionic *ionic)
 	idev->last_fw_hb = 0;
 	idev->fw_hb_ready = true;
 	idev->fw_status_ready = true;
+	idev->fw_generation = IONIC_FW_STS_F_GENERATION &
+			      ioread8(&idev->dev_info_regs->fw_status);
 
 	mod_timer(&ionic->watchdog_timer,
 		  round_jiffies(jiffies + ionic->watchdog_period));
@@ -158,7 +160,9 @@ int ionic_heartbeat_check(struct ionic *ionic)
 {
 	struct ionic_dev *idev = &ionic->idev;
 	unsigned long check_time, last_check_time;
-	bool fw_status_ready, fw_hb_ready;
+	bool fw_status_ready = true;
+	bool fw_hb_ready;
+	u8 fw_generation;
 	u8 fw_status;
 	u32 fw_hb;
 
@@ -181,9 +185,29 @@ do_check_time:
 
 	/* firmware is useful only if the running bit is set and
 	 * fw_status != 0xff (bad PCI read)
+	 * If fw_status is not ready don't bother with the generation.
 	 */
 	fw_status = ioread8(&idev->dev_info_regs->fw_status);
-	fw_status_ready = (fw_status != 0xff) && (fw_status & IONIC_FW_STS_F_RUNNING);
+
+	if ((fw_status == 0xff) || !(fw_status & IONIC_FW_STS_F_RUNNING)) {
+		fw_status_ready = false;
+	} else {
+		fw_generation = fw_status & IONIC_FW_STS_F_GENERATION;
+		if (idev->fw_generation != fw_generation) {
+			dev_info(ionic->dev, "FW generation 0x%02x -> 0x%02x\n",
+				 idev->fw_generation, fw_generation);
+
+			idev->fw_generation = fw_generation;
+
+			/* If the generation changed, the fw status is not
+			 * ready so we need to trigger a fw-down cycle.  After
+			 * the down, the next watchdog will see the fw is up
+			 * and the generation value stable, so will trigger
+			 * the fw-up activity.
+			 */
+			fw_status_ready = false;
+		}
+	}
 
 	/* is this a transition? */
 	if (fw_status_ready != idev->fw_status_ready) {

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -140,6 +140,7 @@ struct ionic_dev {
 	u32 last_fw_hb;
 	bool fw_hb_ready;
 	bool fw_status_ready;
+	u8 fw_generation;
 
 	u64 __iomem *db_pages;
 	dma_addr_t phy_db_pages;
@@ -180,6 +181,7 @@ typedef void (*ionic_desc_cb)(struct ionic_queue *q,
 #define IONIC_PAGE_ORDER			0
 #define IONIC_PAGE_SIZE				(PAGE_SIZE << IONIC_PAGE_ORDER)
 #define IONIC_PAGE_SPLIT_SZ			(PAGE_SIZE / 2)
+#define IONIC_PAGE_SPLIT_MAX_MTU		1900
 #define IONIC_PAGE_GFP_MASK			(GFP_ATOMIC | __GFP_NOWARN |\
 	__GFP_COMP | __GFP_MEMALLOC)
 

--- a/drivers/linux/eth/ionic/ionic_lif.c
+++ b/drivers/linux/eth/ionic/ionic_lif.c
@@ -30,7 +30,7 @@ static const u8 ionic_qtype_versions[IONIC_QTYPE_MAX] = {
 				      */
 };
 
-static int ionic_lif_rx_mode(struct ionic_lif *lif);
+static void ionic_lif_rx_mode(struct ionic_lif *lif);
 static int ionic_lif_addr_add(struct ionic_lif *lif, const u8 *addr);
 static int ionic_lif_addr_del(struct ionic_lif *lif, const u8 *addr);
 static void ionic_link_status_check(struct ionic_lif *lif);
@@ -1456,10 +1456,8 @@ static int ionic_lif_addr_del(struct ionic_lif *lif, const u8 *addr)
 	return 0;
 }
 
-static int ionic_lif_addr(struct ionic_lif *lif, const u8 *addr, bool add,
-			  bool can_sleep)
+static int ionic_lif_addr(struct ionic_lif *lif, const u8 *addr, bool add)
 {
-	struct ionic_deferred_work *work;
 	unsigned int nmfilters;
 	unsigned int nufilters;
 
@@ -1485,113 +1483,44 @@ static int ionic_lif_addr(struct ionic_lif *lif, const u8 *addr, bool add,
 			lif->nucast--;
 	}
 
-	if (!can_sleep) {
-		work = kzalloc(sizeof(*work), GFP_ATOMIC);
-		if (!work)
-			return -ENOMEM;
-		work->type = add ? IONIC_DW_TYPE_RX_ADDR_ADD :
-				   IONIC_DW_TYPE_RX_ADDR_DEL;
-		memcpy(work->addr, addr, ETH_ALEN);
-		netdev_dbg(lif->netdev, "deferred: rx_filter %s %pM\n",
-			   add ? "add" : "del", addr);
-		ionic_lif_deferred_enqueue(&lif->deferred, work);
-	} else {
-		netdev_dbg(lif->netdev, "rx_filter %s %pM\n",
-			   add ? "add" : "del", addr);
-		if (add)
-			return ionic_lif_addr_add(lif, addr);
-		else
-			return ionic_lif_addr_del(lif, addr);
-	}
-
-	return 0;
+	netdev_dbg(lif->netdev, "rx_filter %s %pM\n",
+		   add ? "add" : "del", addr);
+	if (add)
+		return ionic_lif_addr_add(lif, addr);
+	else
+		return ionic_lif_addr_del(lif, addr);
 }
 
 static int ionic_addr_add(struct net_device *netdev, const u8 *addr)
 {
-	return ionic_lif_addr(netdev_priv(netdev), addr, ADD_ADDR, CAN_SLEEP);
-}
-
-static int ionic_ndo_addr_add(struct net_device *netdev, const u8 *addr)
-{
-	return ionic_lif_addr(netdev_priv(netdev), addr, ADD_ADDR, CAN_NOT_SLEEP);
+	return ionic_lif_addr(netdev_priv(netdev), addr, ADD_ADDR);
 }
 
 static int ionic_addr_del(struct net_device *netdev, const u8 *addr)
 {
-	return ionic_lif_addr(netdev_priv(netdev), addr, DEL_ADDR, CAN_SLEEP);
+	return ionic_lif_addr(netdev_priv(netdev), addr, DEL_ADDR);
 }
 
-static int ionic_ndo_addr_del(struct net_device *netdev, const u8 *addr)
+static void ionic_lif_rx_mode(struct ionic_lif *lif)
 {
-	return ionic_lif_addr(netdev_priv(netdev), addr, DEL_ADDR, CAN_NOT_SLEEP);
-}
-
-static int ionic_lif_rx_mode(struct ionic_lif *lif)
-{
-	struct ionic_admin_ctx ctx = {
-		.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
-		.cmd.rx_mode_set = {
-			.opcode = IONIC_CMD_RX_MODE_SET,
-			.lif_index = cpu_to_le16(lif->index),
-		},
-	};
+	struct net_device *netdev = lif->netdev;
+	unsigned int nfilters;
+	unsigned int nd_flags;
 	char buf[128];
-	int err = 0;
+	u16 rx_mode;
 	int i;
 #define REMAIN(__x) (sizeof(buf) - (__x))
 
-	i = scnprintf(buf, sizeof(buf), "rx_mode 0x%04x -> 0x%04x:",
-		      lif->rx_mode, lif->rx_mode_request);
-	if (lif->rx_mode_request & IONIC_RX_MODE_F_UNICAST)
-		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_UNICAST");
-	if (lif->rx_mode_request & IONIC_RX_MODE_F_MULTICAST)
-		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_MULTICAST");
-	if (lif->rx_mode_request & IONIC_RX_MODE_F_BROADCAST)
-		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_BROADCAST");
-	if (lif->rx_mode_request & IONIC_RX_MODE_F_PROMISC)
-		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_PROMISC");
-	if (lif->rx_mode_request & IONIC_RX_MODE_F_ALLMULTI)
-		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_ALLMULTI");
-	if (lif->rx_mode_request & IONIC_RX_MODE_F_RDMA_SNIFFER)
-		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_RDMA_SNIFFER");
-	netdev_dbg(lif->netdev, "lif%d %s\n", lif->index, buf);
-
 	mutex_lock(&lif->config_lock);
 
-	/* It is possible another request came in on another
-	 * thread that cancels out the request
-	 */
-	if (lif->rx_mode != lif->rx_mode_request) {
-		ctx.cmd.rx_mode_set.rx_mode = cpu_to_le16(lif->rx_mode_request);
-		err = ionic_adminq_post_wait(lif, &ctx);
-		if (err)
-			netdev_warn(lif->netdev, "set rx_mode 0x%04x failed: %d\n",
-				    lif->rx_mode_request, err);
-		else
-			lif->rx_mode = lif->rx_mode_request;
-	} else {
-		netdev_dbg(lif->netdev, "%s: rx_mode change skipped\n", __func__);
-	}
-
-	mutex_unlock(&lif->config_lock);
-
-	return err;
-}
-
-void ionic_set_rx_mode(struct net_device *netdev, bool can_sleep)
-{
-	struct ionic_lif *lif = netdev_priv(netdev);
-	struct ionic_deferred_work *work;
-	bool rx_mode_change = false;
-	unsigned int nfilters;
-	u16 rx_mode;
+	/* grab the flags once for local use */
+	nd_flags = netdev->flags;
 
 	rx_mode = IONIC_RX_MODE_F_UNICAST;
-	rx_mode |= (netdev->flags & IFF_MULTICAST) ? IONIC_RX_MODE_F_MULTICAST : 0;
-	rx_mode |= (netdev->flags & IFF_BROADCAST) ? IONIC_RX_MODE_F_BROADCAST : 0;
-	rx_mode |= (netdev->flags & IFF_PROMISC) ? IONIC_RX_MODE_F_PROMISC : 0;
-	rx_mode |= (netdev->flags & IFF_ALLMULTI) ? IONIC_RX_MODE_F_ALLMULTI : 0;
+	rx_mode |= (nd_flags & IFF_MULTICAST) ? IONIC_RX_MODE_F_MULTICAST : 0;
+	rx_mode |= (nd_flags & IFF_BROADCAST) ? IONIC_RX_MODE_F_BROADCAST : 0;
+	rx_mode |= (nd_flags & IFF_PROMISC) ? IONIC_RX_MODE_F_PROMISC : 0;
+	rx_mode |= (nd_flags & IFF_ALLMULTI) ? IONIC_RX_MODE_F_ALLMULTI : 0;
 
 	if (test_bit(IONIC_LIF_F_RDMA_SNIFFER, lif->state))
 		rx_mode |= IONIC_RX_MODE_F_RDMA_SNIFFER;
@@ -1603,55 +1532,83 @@ void ionic_set_rx_mode(struct net_device *netdev, bool can_sleep)
 	 *       we remove our overflow flag and check the netdev flags
 	 *       to see if we can disable NIC PROMISC
 	 */
-	if (can_sleep)
-		__dev_uc_sync(netdev, ionic_addr_add, ionic_addr_del);
-	else
-		__dev_uc_sync(netdev, ionic_ndo_addr_add, ionic_ndo_addr_del);
+	__dev_uc_sync(netdev, ionic_addr_add, ionic_addr_del);
 	nfilters = le32_to_cpu(lif->identity->eth.max_ucast_filters);
 	if (netdev_uc_count(netdev) + 1 > nfilters) {
 		rx_mode |= IONIC_RX_MODE_F_PROMISC;
 		lif->uc_overflow = true;
 	} else if (lif->uc_overflow) {
 		lif->uc_overflow = false;
-		if (!(netdev->flags & IFF_PROMISC))
+		if (!(nd_flags & IFF_PROMISC))
 			rx_mode &= ~IONIC_RX_MODE_F_PROMISC;
 	}
 
 	/* same for multicast */
-	if (can_sleep)
-		__dev_mc_sync(netdev, ionic_addr_add, ionic_addr_del);
-	else
-		__dev_mc_sync(netdev, ionic_ndo_addr_add, ionic_ndo_addr_del);
+	__dev_mc_sync(netdev, ionic_addr_add, ionic_addr_del);
 	nfilters = le32_to_cpu(lif->identity->eth.max_mcast_filters);
 	if (netdev_mc_count(netdev) > nfilters) {
 		rx_mode |= IONIC_RX_MODE_F_ALLMULTI;
 		lif->mc_overflow = true;
 	} else if (lif->mc_overflow) {
 		lif->mc_overflow = false;
-		if (!(netdev->flags & IFF_ALLMULTI))
+		if (!(nd_flags & IFF_ALLMULTI))
 			rx_mode &= ~IONIC_RX_MODE_F_ALLMULTI;
 	}
 
-	mutex_lock(&lif->config_lock);
-	if (lif->rx_mode != rx_mode || lif->rx_mode_request != rx_mode) {
-		lif->rx_mode_request = rx_mode;
-		rx_mode_change = true;
-	}
-	mutex_unlock(&lif->config_lock);
+	i = scnprintf(buf, sizeof(buf), "rx_mode 0x%04x -> 0x%04x:",
+		      lif->rx_mode, rx_mode);
+	if (rx_mode & IONIC_RX_MODE_F_UNICAST)
+		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_UNICAST");
+	if (rx_mode & IONIC_RX_MODE_F_MULTICAST)
+		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_MULTICAST");
+	if (rx_mode & IONIC_RX_MODE_F_BROADCAST)
+		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_BROADCAST");
+	if (rx_mode & IONIC_RX_MODE_F_PROMISC)
+		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_PROMISC");
+	if (rx_mode & IONIC_RX_MODE_F_ALLMULTI)
+		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_ALLMULTI");
+	if (rx_mode & IONIC_RX_MODE_F_RDMA_SNIFFER)
+		i += scnprintf(&buf[i], REMAIN(i), " RX_MODE_F_RDMA_SNIFFER");
+	netdev_dbg(netdev, "lif%d %s\n", lif->index, buf);
 
-	if (rx_mode_change) {
-		if (!can_sleep) {
-			work = kzalloc(sizeof(*work), GFP_ATOMIC);
-			if (!work) {
-				netdev_err(lif->netdev, "rxmode change dropped\n");
-				return;
-			}
-			work->type = IONIC_DW_TYPE_RX_MODE;
-			netdev_dbg(lif->netdev, "deferred: rx_mode\n");
-			ionic_lif_deferred_enqueue(&lif->deferred, work);
-		} else {
-			ionic_lif_rx_mode(lif);
+	if (lif->rx_mode != rx_mode) {
+		struct ionic_admin_ctx ctx = {
+			.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
+			.cmd.rx_mode_set = {
+				.opcode = IONIC_CMD_RX_MODE_SET,
+				.lif_index = cpu_to_le16(lif->index),
+			},
+		};
+		int err;
+
+		ctx.cmd.rx_mode_set.rx_mode = cpu_to_le16(rx_mode);
+		err = ionic_adminq_post_wait(lif, &ctx);
+		if (err)
+			netdev_warn(netdev, "set rx_mode 0x%04x failed: %d\n",
+				    rx_mode, err);
+		else
+			lif->rx_mode = rx_mode;
+	}
+
+	mutex_unlock(&lif->config_lock);
+}
+
+void ionic_set_rx_mode(struct net_device *netdev, bool can_sleep)
+{
+	struct ionic_lif *lif = netdev_priv(netdev);
+	struct ionic_deferred_work *work;
+
+	if (!can_sleep) {
+		work = kzalloc(sizeof(*work), GFP_ATOMIC);
+		if (!work) {
+			netdev_err(lif->netdev, "rxmode change dropped\n");
+			return;
 		}
+		work->type = IONIC_DW_TYPE_RX_MODE;
+		netdev_dbg(lif->netdev, "deferred: rx_mode\n");
+		ionic_lif_deferred_enqueue(&lif->deferred, work);
+	} else {
+		ionic_lif_rx_mode(lif);
 	}
 }
 
@@ -3524,7 +3481,7 @@ static int ionic_station_set(struct ionic_lif *lif)
 		 */
 		if (!ether_addr_equal(ctx.comp.lif_getattr.mac,
 				      netdev->dev_addr))
-			ionic_lif_addr(lif, netdev->dev_addr, ADD_ADDR, CAN_SLEEP);
+			ionic_lif_addr(lif, netdev->dev_addr, ADD_ADDR);
 	} else {
 		/* Update the netdev mac with the device's mac */
 		memcpy(addr.sa_data, ctx.comp.lif_getattr.mac, netdev->addr_len);
@@ -3541,7 +3498,7 @@ static int ionic_station_set(struct ionic_lif *lif)
 
 	netdev_dbg(lif->netdev, "adding station MAC addr %pM\n",
 		   netdev->dev_addr);
-	ionic_lif_addr(lif, netdev->dev_addr, ADD_ADDR, CAN_SLEEP);
+	ionic_lif_addr(lif, netdev->dev_addr, ADD_ADDR);
 
 	return 0;
 }

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -225,7 +225,6 @@ struct ionic_lif {
 	unsigned int nrxq_descs;
 	u64 rxq_features;
 	u16 rx_mode;
-	u16 rx_mode_request;
 	bool registered;
 	bool mc_overflow;
 	bool uc_overflow;

--- a/drivers/linux/eth/ionic/ionic_phc.c
+++ b/drivers/linux/eth/ionic/ionic_phc.c
@@ -194,6 +194,9 @@ int ionic_lif_hwstamp_set(struct ionic_lif *lif, struct ifreq *ifr)
 	struct hwtstamp_config config;
 	int err;
 
+	if (!lif->phc || !lif->phc->ptp)
+		return -EOPNOTSUPP;
+
 	if (copy_from_user(&config, ifr->ifr_data, sizeof(config)))
 		return -EFAULT;
 

--- a/drivers/linux/eth/ionic/ionic_txrx.c
+++ b/drivers/linux/eth/ionic/ionic_txrx.c
@@ -102,6 +102,7 @@ static inline void ionic_rx_page_free(struct ionic_queue *q,
 static bool ionic_rx_buf_recycle(struct ionic_queue *q,
 				 struct ionic_buf_info *buf_info, u32 used)
 {
+	struct net_device *netdev = q->lif->netdev;
 	u32 size;
 
 	/* don't re-use pages allocated in low-mem condition */
@@ -110,6 +111,9 @@ static bool ionic_rx_buf_recycle(struct ionic_queue *q,
 
 	/* don't re-use buffers from non-local numa nodes */
 	if (page_to_nid(buf_info->page) != numa_mem_id())
+		return false;
+
+	if (netdev->mtu > IONIC_PAGE_SPLIT_MAX_MTU)
 		return false;
 
 	size = ALIGN(used, IONIC_PAGE_SPLIT_SZ);

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -920,9 +920,17 @@ struct _kc_ethtool_pauseparam {
        SLE_LOCALVERSION_CODE >= KERNEL_VERSION(25,23,0))
 /* SLES15 SP1 Beta1 is 4.12.14-25.23 */
 #define SLE_VERSION_CODE SLE_VERSION(15,1,0)
-#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,13))
+#elif (LINUX_VERSION_CODE == KERNEL_VERSION(5,3,13))
 /* SLES15 SP2 Beta1 is 5.3.13 */
 #define SLE_VERSION_CODE SLE_VERSION(15,2,0)
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,18))
+#if (SLE_LOCALVERSION_CODE < KERNEL_VERSION(47,0,0))
+/* SLES15 SP2 Beta1 is 5.3.18 */
+#define SLE_VERSION_CODE SLE_VERSION(15,2,0)
+#else /* local version >= 47 */
+/* SLES15 SP3 Beta1 is 5.3.18 */
+#define SLE_VERSION_CODE SLE_VERSION(15,3,0)
+#endif
 
 /* new SLES kernels must be added here with >= based on kernel
  * the idea is to order from newest to oldest and just catch all
@@ -6691,7 +6699,8 @@ devlink_flash_update_status_notify(struct devlink __always_unused *devlink,
 /*****************************************************************************/
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0))
 
-#if (RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,3)))
+#if ((RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,3))) || \
+     (SLE_VERSION_CODE && (SLE_VERSION_CODE >= SLE_VERSION(15,3,0))))
 #define HAVE_TX_TIMEOUT_TXQUEUE
 #endif
 
@@ -6708,29 +6717,6 @@ devlink_flash_update_status_notify(struct devlink __always_unused *devlink,
 #endif
 
 #ifdef HAVE_DEVLINK_REGIONS
-#if IS_ENABLED(CONFIG_NET_DEVLINK)
-#if (!RHEL_RELEASE_CODE || (RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8,3))))
-#include <net/devlink.h>
-
-struct devlink_region_ops {
-	const char *name;
-	void (*destructor)(const void *data);
-};
-
-#ifndef devlink_region_create
-static inline struct devlink_region *
-_kc_devlink_region_create(struct devlink *devlink,
-			  const struct devlink_region_ops *ops,
-			  u32 region_max_snapshots, u64 region_size)
-{
-	return devlink_region_create(devlink, ops->name, region_max_snapshots,
-				     region_size);
-}
-
-#define devlink_region_create _kc_devlink_region_create
-#endif /* devlink_region_create */
-#endif /* RHEL_RELEASE_CODE */
-#endif /* CONFIG_NET_DEVLINK */
 #define HAVE_DEVLINK_SNAPSHOT_CREATE_DESTRUCTOR
 #endif /* HAVE_DEVLINK_REGIONS */
 #else /* >= 5.7.0 */
@@ -6739,7 +6725,8 @@ _kc_devlink_region_create(struct devlink *devlink,
 #endif /* 5.7.0 */
 
 /*****************************************************************************/
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0))
+#if ((LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)) && \
+     !(SLE_VERSION_CODE && (SLE_VERSION_CODE >= SLE_VERSION(15,3,0))))
 #else
 #define HAVE_DEVLINK_UPDATE_PARAMS
 #endif /* 5.10.0 */


### PR DESCRIPTION
Updates include:
 - monitoring fw status generation for fw restart hints
 - catch lack of PTP support earlier in service routine
 - makefile fixes for sles 15 sp3
 - lower page splitting limit to better account for headers
 - VF stats area fix for PF
 - better thread-safe rx_mode work

Signed-off-by: Shannon Nelson <snelson@pensando.io>