### PR TITLE
drivers: updates for 1.15.9-C-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - Fixed dynamic interrupt management accounting
  - Fixes for mac filter management
 
-2021-08-16 - driver updated for 1.15.9-C-26
+2021-08-16 - driver updates for 1.15.9-C-26
  - Add work-around for Elba doorbell issue
 
+2021-08-19 - driver updates for 1.15.9-C-28
+ - Additional queue config locking for stress timing issue
+ - Suppressed unnecessary log message

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -101,7 +101,7 @@ DVER = $(shell echo $$SW_VERSION)
 ifeq ($(DVER),)
   DVER = $(shell git describe --tags 2>/dev/null)
   ifeq ($(DVER),)
-    DVER = "1.15.9.26"
+    DVER = "1.15.9.28"
   endif
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"

--- a/drivers/linux/eth/ionic/ionic_lif.c
+++ b/drivers/linux/eth/ionic/ionic_lif.c
@@ -2500,9 +2500,11 @@ static int ionic_open(struct net_device *netdev)
 	if (test_and_clear_bit(IONIC_LIF_F_BROKEN, lif->state))
 		netdev_info(netdev, "clearing broken state\n");
 
+	mutex_lock(&lif->queue_lock);
+
 	err = ionic_txrx_alloc(lif);
 	if (err)
-		return err;
+		goto err_unlock;
 
 	err = ionic_txrx_init(lif);
 	if (err)
@@ -2523,12 +2525,15 @@ static int ionic_open(struct net_device *netdev)
 			goto err_txrx_deinit;
 	}
 
+	mutex_unlock(&lif->queue_lock);
 	return 0;
 
 err_txrx_deinit:
 	ionic_txrx_deinit(lif);
 err_txrx_free:
 	ionic_txrx_free(lif);
+err_unlock:
+	mutex_unlock(&lif->queue_lock);
 	return err;
 }
 
@@ -2548,9 +2553,11 @@ static int ionic_stop(struct net_device *netdev)
 	if (test_bit(IONIC_LIF_F_FW_RESET, lif->state))
 		return 0;
 
+	mutex_lock(&lif->queue_lock);
 	ionic_stop_queues(lif);
 	ionic_txrx_deinit(lif);
 	ionic_txrx_free(lif);
+	mutex_unlock(&lif->queue_lock);
 
 	return 0;
 }

--- a/drivers/linux/eth/ionic/ionic_main.c
+++ b/drivers/linux/eth/ionic/ionic_main.c
@@ -432,7 +432,7 @@ try_again:
 		 * heartbeat check but is still alive and will process this
 		 * request, so don't clean the dev_cmd in this case.
 		 */
-		dev_warn(ionic->dev, "DEVCMD %s (%d) failed - FW halted\n",
+		dev_dbg(ionic->dev, "DEVCMD %s (%d) failed - FW halted\n",
 			 ionic_opcode_to_str(opcode), opcode);
 		return -ENXIO;
 	}


### PR DESCRIPTION
Updates include:
 - Additional queue config locking for stress timing issue
 - Suppressed unnecessary log message

Signed-off-by: Shannon Nelson <snelson@pensando.io>