### PR TITLE
dsc-drivers: update for 1.15.9-C-64

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,6 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
 
 2021-08-25 - driver update for 1.15.9-C-32
  - added use of reserved memory region for dma
+
+2022-02-02 - driver update for 1.15.9-C-64
+ - Remove an unnecessary kcompat macro

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -34,7 +34,7 @@ ifeq ($(ARCH),aarch64)
 
 # Ionic mnic and mdev for drivers ARM
 include ${MKINFRA}/config_${ARCH}.mk
-KSRC ?= ${NICDIR}/buildroot/output/${ASIC}/linux-headers
+KSRC ?= ${BRDIR}/output/${ASIC}/linux-headers
 KMOD_OUT_DIR ?= ${BLD_OUT_DIR}/drivers_submake
 KMOD_SRC_DIR ?= ${TOPDIR}/platform/drivers/linux
 ETH_KOPT += CONFIG_IONIC_MNIC=m
@@ -101,7 +101,7 @@ DVER = $(shell echo $$SW_VERSION)
 ifeq ($(DVER),)
   DVER = $(shell git describe --tags 2>/dev/null)
   ifeq ($(DVER),)
-    DVER = "1.15.9.32"
+    DVER = "1.15.9.64"
   endif
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -6656,14 +6656,6 @@ _kc_devlink_port_attrs_set(struct devlink_port *devlink_port,
  /*****************************************************************************/
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5,3,0))
 
-static inline s32 scaled_ppm_to_ppb(long ppm)
-{
-	s64 ppb = 1 + ppm;
-	ppb *= 125;
-	ppb >>= 13;
-	return (s32) ppb;
-}
-
 #if (!RHEL_RELEASE_CODE || \
      (RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8,2))))
 #if IS_ENABLED(CONFIG_NET_DEVLINK)


### PR DESCRIPTION
Remove an unnecessary kcompat macro

Signed-off-by: Shannon Nelson <snelson@pensando.io>