### PR TITLE
dsc-drivers: update drivers for 1.15.9-C-100

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,9 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - update filter management for handling overflow
  - updates for recent upstream kernels and distros
  - better handling of various FW recovery scenarios
+
+2022-06-20 - driver update for 1.15.9-C-100
+ - various code cleanups
+ - add debugfs support to count number of Tx/Rx allocations
+ - better memory handling
+ - minor bug fixes

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -105,7 +105,7 @@ DVER = $(shell echo $$SW_VERSION)
 ifeq ($(DVER),)
   DVER = $(shell git describe --tags 2>/dev/null)
   ifeq ($(DVER),)
-    DVER = "1.15.9.65"
+    DVER = "1.15.9.100"
   endif
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"

--- a/drivers/linux/eth/ionic/ionic.h
+++ b/drivers/linux/eth/ionic/ionic.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #ifndef _IONIC_H_
 #define _IONIC_H_

--- a/drivers/linux/eth/ionic/ionic_api.h
+++ b/drivers/linux/eth/ionic/ionic_api.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright (c) 2017-2021 Pensando Systems, Inc.  All rights reserved. */
+/* Copyright (c) 2017 - 2022 Pensando Systems, Inc.  All rights reserved. */
 
 #ifndef IONIC_API_H
 #define IONIC_API_H

--- a/drivers/linux/eth/ionic/ionic_bus.h
+++ b/drivers/linux/eth/ionic/ionic_bus.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #ifndef _IONIC_BUS_H_
 #define _IONIC_BUS_H_

--- a/drivers/linux/eth/ionic/ionic_bus_pci.c
+++ b/drivers/linux/eth/ionic/ionic_bus_pci.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #include <linux/module.h>
 #include <linux/netdevice.h>

--- a/drivers/linux/eth/ionic/ionic_bus_platform.c
+++ b/drivers/linux/eth/ionic/ionic_bus_platform.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #include <linux/module.h>
 #include <linux/netdevice.h>
@@ -44,7 +44,7 @@ static void ionic_intr_msixcfg(struct device *mnic_dev,
 			       const int intr, const u64 msgaddr,
 			       const u32 msgdata, const int vctrl)
 {
-	volatile void *pa = ionic_intr_msixcfg_addr(mnic_dev, intr);
+	void *pa = ionic_intr_msixcfg_addr(mnic_dev, intr);
 
 	writeq(msgaddr, (pa + offsetof(struct ionic_intr_msixcfg, msgaddr)));
 	writel(msgdata, (pa + offsetof(struct ionic_intr_msixcfg, msgdata)));
@@ -58,7 +58,7 @@ static void ionic_intr_msixcfg(struct device *mnic_dev,
  * when the first device is unregistered, when other devices may still be using
  * it.  ionic_shared_resource just maintains a refcount for mapping a shared
  * resource for use by multiple ionic devices.
-*/
+ */
 struct ionic_shared_resource {
 	struct mutex lock;
 	void __iomem *base;

--- a/drivers/linux/eth/ionic/ionic_debugfs.c
+++ b/drivers/linux/eth/ionic/ionic_debugfs.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #include <linux/netdevice.h>
 
@@ -233,7 +233,7 @@ void ionic_debugfs_add_qcq(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	debugfs_create_x32("cmb_order", 0400, qcq_dentry, &qcq->cmb_order);
 	debugfs_create_x32("cmb_pgid", 0400, qcq_dentry, &qcq->cmb_pgid);
 
-#if (RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,0)))
+#if (RHEL_RELEASE_CODE && (RHEL_RELEASE_VERSION(7, 0) < RHEL_RELEASE_CODE))
 	debugfs_create_u8("armed", 0400, qcq_dentry, (u8 *)&qcq->armed);
 #else
 	debugfs_create_bool("armed", 0400, qcq_dentry, &qcq->armed);
@@ -331,7 +331,7 @@ void ionic_debugfs_add_qcq(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	debugfs_create_u32("num_descs", 0400, cq_dentry, &cq->num_descs);
 	debugfs_create_u32("desc_size", 0400, cq_dentry, &cq->desc_size);
 
-#if (RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,0)))
+#if (RHEL_RELEASE_CODE && (RHEL_RELEASE_VERSION(7, 0) < RHEL_RELEASE_CODE))
 	debugfs_create_u8("done_color", 0400, cq_dentry, (u8 *)&cq->done_color);
 #else
 	debugfs_create_bool("done_color", 0400, cq_dentry, &cq->done_color);
@@ -425,7 +425,7 @@ static int lif_identity_show(struct seq_file *seq, void *v)
 	seq_printf(seq, "eq-count:          %d\n",
 		   lid->eth.config.queue_count[IONIC_QTYPE_EQ]);
 
-	seq_printf(seq, "\n");
+	seq_puts(seq, "\n");
 
 	seq_printf(seq, "rdma_version:        0x%x\n", lid->rdma.version);
 	seq_printf(seq, "rdma_qp_opcodes:     %d\n", lid->rdma.qp_opcodes);
@@ -504,6 +504,16 @@ static int lif_filters_show(struct seq_file *seq, void *v)
 }
 DEFINE_SHOW_ATTRIBUTE(lif_filters);
 
+static int lif_n_txrx_alloc_show(struct seq_file *seq, void *v)
+{
+	struct ionic_lif *lif = seq->private;
+
+	seq_printf(seq, "%llu\n", lif->n_txrx_alloc);
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(lif_n_txrx_alloc);
+
 void ionic_debugfs_add_lif(struct ionic_lif *lif)
 {
 	struct dentry *lif_dentry;
@@ -521,6 +531,8 @@ void ionic_debugfs_add_lif(struct ionic_lif *lif)
 			    lif, &lif_state_fops);
 	debugfs_create_file("filters", 0400, lif->dentry,
 			    lif, &lif_filters_fops);
+	debugfs_create_file("txrx_alloc", 0400, lif->dentry,
+			    lif, &lif_n_txrx_alloc_fops);
 }
 
 void ionic_debugfs_del_lif(struct ionic_lif *lif)

--- a/drivers/linux/eth/ionic/ionic_debugfs.h
+++ b/drivers/linux/eth/ionic/ionic_debugfs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #ifndef _IONIC_DEBUGFS_H_
 #define _IONIC_DEBUGFS_H_

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #ifndef _IONIC_DEV_H_
 #define _IONIC_DEV_H_

--- a/drivers/linux/eth/ionic/ionic_devlink.c
+++ b/drivers/linux/eth/ionic/ionic_devlink.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #include <linux/module.h>
 #include <linux/netdevice.h>

--- a/drivers/linux/eth/ionic/ionic_devlink.h
+++ b/drivers/linux/eth/ionic/ionic_devlink.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #ifndef _IONIC_DEVLINK_H_
 #define _IONIC_DEVLINK_H_

--- a/drivers/linux/eth/ionic/ionic_ethtool.c
+++ b/drivers/linux/eth/ionic/ionic_ethtool.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #include <linux/module.h>
 #include <linux/netdevice.h>
@@ -132,11 +132,11 @@ static void ionic_get_drvinfo(struct net_device *netdev,
 	struct ionic_lif *lif = netdev_priv(netdev);
 	struct ionic *ionic = lif->ionic;
 
-	strlcpy(drvinfo->driver, IONIC_DRV_NAME, sizeof(drvinfo->driver));
-	strlcpy(drvinfo->version, IONIC_DRV_VERSION, sizeof(drvinfo->version));
-	strlcpy(drvinfo->fw_version, ionic->idev.dev_info.fw_version,
+	strscpy(drvinfo->driver, IONIC_DRV_NAME, sizeof(drvinfo->driver));
+	strscpy(drvinfo->version, IONIC_DRV_VERSION, sizeof(drvinfo->version));
+	strscpy(drvinfo->fw_version, ionic->idev.dev_info.fw_version,
 		sizeof(drvinfo->fw_version));
-	strlcpy(drvinfo->bus_info, ionic_bus_info(ionic),
+	strscpy(drvinfo->bus_info, ionic_bus_info(ionic),
 		sizeof(drvinfo->bus_info));
 }
 

--- a/drivers/linux/eth/ionic/ionic_ethtool.h
+++ b/drivers/linux/eth/ionic/ionic_ethtool.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #ifndef _IONIC_ETHTOOL_H_
 #define _IONIC_ETHTOOL_H_

--- a/drivers/linux/eth/ionic/ionic_fw.c
+++ b/drivers/linux/eth/ionic/ionic_fw.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2020 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2020 - 2022 Pensando Systems, Inc */
 
 #include <linux/kernel.h>
 #include <linux/types.h>

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #ifndef _IONIC_LIF_H_
 #define _IONIC_LIF_H_
@@ -276,6 +276,8 @@ struct ionic_lif {
 
 	/* TODO: Make this a list if more than one child is supported */
 	struct ionic_lif_cfg child_lif_cfg;
+
+	u64 n_txrx_alloc;
 
 	struct dentry *dentry;
 };

--- a/drivers/linux/eth/ionic/ionic_main.c
+++ b/drivers/linux/eth/ionic/ionic_main.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #include <linux/module.h>
 #include <linux/version.h>
@@ -462,10 +462,10 @@ int ionic_adminq_post_wait_nomsg(struct ionic_lif *lif, struct ionic_admin_ctx *
 
 static void ionic_dev_cmd_clean(struct ionic *ionic)
 {
-	union __iomem ionic_dev_cmd_regs *regs = ionic->idev.dev_cmd_regs;
+	struct ionic_dev *idev = &ionic->idev;
 
-	iowrite32(0, &regs->doorbell);
-	memset_io(&regs->cmd, 0, sizeof(regs->cmd));
+	iowrite32(0, &idev->dev_cmd_regs->doorbell);
+	memset_io(&idev->dev_cmd_regs->cmd, 0, sizeof(idev->dev_cmd_regs->cmd));
 }
 
 void ionic_dev_cmd_dev_err_print(struct ionic *ionic, u8 opcode, u8 status,

--- a/drivers/linux/eth/ionic/ionic_phc.c
+++ b/drivers/linux/eth/ionic/ionic_phc.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #include <linux/netdevice.h>
 #include <linux/etherdevice.h>

--- a/drivers/linux/eth/ionic/ionic_phc_weak.c
+++ b/drivers/linux/eth/ionic/ionic_phc_weak.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2021 Pensando Systems, Inc */
+/* Copyright(c) 2021 - 2022 Pensando Systems, Inc */
 
 #include <linux/errno.h>
 #include <linux/kernel.h>

--- a/drivers/linux/eth/ionic/ionic_rx_filter.c
+++ b/drivers/linux/eth/ionic/ionic_rx_filter.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #include <linux/netdevice.h>
 #include <linux/dynamic_debug.h>

--- a/drivers/linux/eth/ionic/ionic_rx_filter.h
+++ b/drivers/linux/eth/ionic/ionic_rx_filter.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #ifndef _IONIC_RX_FILTER_H_
 #define _IONIC_RX_FILTER_H_

--- a/drivers/linux/eth/ionic/ionic_stats.c
+++ b/drivers/linux/eth/ionic/ionic_stats.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #include <linux/kernel.h>
 #include <linux/mutex.h>
@@ -287,11 +287,10 @@ static u64 ionic_sw_stats_get_count(struct ionic_lif *lif)
 
 	total += IONIC_NUM_LIF_STATS;
 
-	if (lif->ionic->is_mgmt_nic) {
+	if (lif->ionic->is_mgmt_nic)
 		total += IONIC_NUM_MGMT_PORT_STATS;
-	} else {
+	else
 		total += IONIC_NUM_PORT_STATS;
-	}
 
 	if (lif->hwstamp_txq)
 		tx_queues += 1;

--- a/drivers/linux/eth/ionic/ionic_stats.h
+++ b/drivers/linux/eth/ionic/ionic_stats.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #ifndef _IONIC_STATS_H_
 #define _IONIC_STATS_H_

--- a/drivers/linux/eth/ionic/ionic_txrx.c
+++ b/drivers/linux/eth/ionic/ionic_txrx.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #include <linux/ip.h>
 #include <linux/ipv6.h>
@@ -63,11 +63,10 @@ bool ionic_rxq_poke_doorbell(struct ionic_queue *q)
 {
 	unsigned long now, then, dif;
 
-	// no lock, called from rx napi or txrx napi, nothing else can fill
+	/* no lock, called from rx napi or txrx napi, nothing else can fill */
 
-	if (q->tail_idx == q->head_idx) {
+	if (q->tail_idx == q->head_idx)
 		return false;
-	}
 
 	now = READ_ONCE(jiffies);
 	then = q->dbell_jiffies;
@@ -533,8 +532,7 @@ void ionic_rx_fill(struct ionic_queue *q)
 
 		/* commit descriptor contents in one shot */
 		if (q_to_qcq(q)->flags & IONIC_QCQ_F_CMB_RINGS)
-			memcpy_toio((void volatile __iomem *)desc_info->desc,
-				    &tmp_desc, sizeof(tmp_desc));
+			memcpy_toio(desc_info->desc, &tmp_desc, sizeof(tmp_desc));
 		else
 			memcpy(desc_info->desc, &tmp_desc, sizeof(tmp_desc));
 
@@ -1101,8 +1099,7 @@ static void ionic_tx_tso_post(struct ionic_queue *q,
 
 	/* commit descriptor contents in one shot */
 	if (q_to_qcq(q)->flags & IONIC_QCQ_F_CMB_RINGS)
-		memcpy_toio((void volatile __iomem *)desc,
-			    &tmp_desc, sizeof(tmp_desc));
+		memcpy_toio(desc, &tmp_desc, sizeof(tmp_desc));
 	else
 		memcpy(desc, &tmp_desc, sizeof(tmp_desc));
 
@@ -1276,8 +1273,7 @@ static void ionic_tx_calc_csum(struct ionic_queue *q, struct sk_buff *skb,
 
 	/* commit descriptor contents in one shot */
 	if (q_to_qcq(q)->flags & IONIC_QCQ_F_CMB_RINGS)
-		memcpy_toio((void volatile __iomem *)desc_info->desc,
-			    &tmp_desc, sizeof(tmp_desc));
+		memcpy_toio(desc_info->desc, &tmp_desc, sizeof(tmp_desc));
 	else
 		memcpy(desc_info->desc, &tmp_desc, sizeof(tmp_desc));
 
@@ -1324,8 +1320,7 @@ static void ionic_tx_calc_no_csum(struct ionic_queue *q, struct sk_buff *skb,
 
 	/* commit descriptor contents in one shot */
 	if (q_to_qcq(q)->flags & IONIC_QCQ_F_CMB_RINGS)
-		memcpy_toio((void volatile __iomem *)desc_info->desc,
-			    &tmp_desc, sizeof(tmp_desc));
+		memcpy_toio(desc_info->desc, &tmp_desc, sizeof(tmp_desc));
 	else
 		memcpy(desc_info->desc, &tmp_desc, sizeof(tmp_desc));
 

--- a/drivers/linux/eth/ionic/ionic_txrx.h
+++ b/drivers/linux/eth/ionic/ionic_txrx.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2017 - 2021 Pensando Systems, Inc */
+/* Copyright(c) 2017 - 2022 Pensando Systems, Inc */
 
 #ifndef _IONIC_TXRX_H_
 #define _IONIC_TXRX_H_

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -6764,6 +6764,12 @@ void _kc_ethtool_sprintf(u8 **data, const char *fmt, ...);
 
 /*****************************************************************************/
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5,15,0))
+#if (!RHEL_RELEASE_CODE || (RHEL_RELEASE_CODE && \
+       (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9,0))))
+
+#if (RHEL_RELEASE_CODE && (RHEL_RELEASE_VERSION(8, 6) == RHEL_RELEASE_CODE))
+#define HAVE_COALESCE_EXTACK
+#endif
 
 #define ndo_eth_ioctl ndo_do_ioctl
 
@@ -6779,6 +6785,14 @@ static inline struct devlink *_kc_devlink_alloc(const struct devlink_ops *ops,
 
 #else
 
+#if IS_ENABLED(CONFIG_NET_DEVLINK)
+#define HAVE_VOID_DEVLINK_REGISTER
+#endif /* CONFIG_NET_DEVLINK */
+
+#endif /* not RH or RH < 9.0 */
+
+#else
+
 #define HAVE_COALESCE_EXTACK
 
 #if IS_ENABLED(CONFIG_NET_DEVLINK)
@@ -6788,10 +6802,10 @@ static inline struct devlink *_kc_devlink_alloc(const struct devlink_ops *ops,
 #endif /* 5.15.0 */
 
 /*****************************************************************************/
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,16,0))
+#if (KERNEL_VERSION(5, 17, 0) > LINUX_VERSION_CODE)
 #else
 #define HAVE_RINGPARAM_EXTACK
-#endif /* 5.16 */
+#endif /* 5.17 */
 
 /* We don't support PTP on older RHEL kernels (needs more compat work) */
 #if (RHEL_RELEASE_CODE && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,4))


### PR DESCRIPTION
Overview:
    update to match linux drivers 22.05.1-001

Detailed internal patch list:
    ionic: fix type complaint in ionic_dev_cmd_clean()
    ionic: Add debugfs support to count number of Tx/Rx allocations
    ionic: Use vzalloc for large per-queue related buffers
    ionic: Fix memory leak during surprise FW reset
    ionic: update copyright strings
    ionic: general code fixups
    mdev: quiet a needless irq complaint
    ionic: catch transition back to RUNNING with fw_generation 0
    ionic: kcompat for v5.17, RHEL 9.0, RHEL 8.6
    mdev: ignore request to start existing device
    ionic: clear broken state on generation change

Signed-off-by: Shannon Nelson <snelson@pensando.io>