### PR TITLE
dsc-drivers: update ionic drivers to 22.11.1-001

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,14 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - add debugfs support to count number of Tx/Rx allocations
  - better memory handling
  - minor bug fixes
+
+2022-12-05 - driver update for 22.11.1-001
+ - update ionic drivers to 22.11.1-001; version numbers now follow
+   the driver release numbers rather than the DSC firmware release version
+ - enable tunnel offloads
+ - support for changes in MTU, queue count, and ring length while CMB is active
+ - set random VF mac addresses by default
+ - better oprom debugging support
+ - Rx/Tx performance tuning
+ - fixes imported from upstream driver
+ - bug fixes

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -3,11 +3,9 @@ obj-$(CONFIG_IONIC) += eth/ionic/
 obj-$(CONFIG_IONIC_MNIC) += eth/ionic/
 obj-$(CONFIG_MDEV) += mdev/
 obj-$(CONFIG_MNET_UIO_PDRV_GENIRQ) += mnet_uio_pdrv_genirq/
-#obj-$(CONFIG_INFINIBAND_IONIC) += rdma/drv/ionic/
 else
 
 IONIC_ETH_SRC = $(CURDIR)/eth/ionic
-IONIC_RDMA_SRC = $(CURDIR)/rdma/drv/ionic
 
 #KOPT += V=1		# verbose build
 #KOPT += W=1		# extra warnings
@@ -15,33 +13,27 @@ IONIC_RDMA_SRC = $(CURDIR)/rdma/drv/ionic
 #KOPT += CHECK=sparse	# static analysis tool
 #KOPT += CHECK=scripts/coccicheck
 
-ETH_KOPT += CONFIG_INFINIBAND_IONIC=_
-RDMA_KOPT += CONFIG_INFINIBAND_IONIC=m
-
 default: all
 
-# Discover kernel and open fabrics configuration.
+# Discover kernel configuration.
 #
 # Override running kernel with
 # `make KSRC=/path/to/your/sources` or
 # `export KSRC=/path/to/your/sources`
 #
-# Override default open fabrics with
-# `make OFA_KSRC=/path/to/your/sources` or
-# `export OFA_KSRC=/path/to/your/sources`
 
 ifeq ($(ARCH),aarch64)
 
 # Ionic mnic and mdev for drivers ARM
 include ${MKINFRA}/config_${ARCH}.mk
-KSRC ?= ${BRDIR}/output/${ASIC}/linux-headers
+KSRC ?= ${NICDIR}/buildroot/output/${ASIC}/linux-headers
 KMOD_OUT_DIR ?= ${BLD_OUT_DIR}/drivers_submake
-KMOD_SRC_DIR ?= ${TOPDIR}/platform/drivers/linux
+KMOD_SRC_DIR ?= ${TOPDIR}/platform/drivers/linux-ionic
 ETH_KOPT += CONFIG_IONIC_MNIC=m
 ETH_KOPT += CONFIG_MDEV=m
 ETH_KOPT += CONFIG_MNET_UIO_PDRV_GENIRQ=m
-ETH_KOPT += CROSS_COMPILE=aarch64-linux-gnu-
-ETH_KOPT += ARCH=arm64
+KOPT += CROSS_COMPILE=aarch64-linux-gnu-
+KOPT += ARCH=arm64
 KCFLAGS += -DCONFIG_IONIC_MNIC
 KCFLAGS += -DCONFIG_MDEV
 KCFLAGS += -DCONFIG_MNET_UIO_PDRV_GENIRQ
@@ -50,9 +42,14 @@ ALL += mnet_uio_pdrv_genirq
 ALL += mdev
 export PATH := $(PATH):$(TOOLCHAIN_DIR)/bin
 
-KSYMS = "KBUILD_EXTRA_SYMBOLS=${KMOD_OUT_DIR}/Module.symvers.mnic ${KMOD_OUT_DIR}/Module.symvers.uio"
+KSYMS_MNIC = "KBUILD_EXTRA_SYMBOLS=${KMOD_OUT_DIR}/Module.symvers.mnic"
+KSYMS = "${KSYMS_MNIC} ${KMOD_OUT_DIR}/Module.symvers.uio"
+
+DVER = $(shell cd $(KMOD_SRC_DIR) ; git describe --tags 2>/dev/null)
 
 else
+
+DVER = $(shell git describe --tags 2>/dev/null)
 
 # Ionic driver for host
 include linux_ver.mk
@@ -69,44 +66,10 @@ KCFLAGS += $(EXTRA_CFLAGS)
 
 ALL = eth
 
-# Ionic rdma driver, if present
-ifneq ($(wildcard $(IONIC_RDMA_SRC)),)
-ALL += rdma
-
-# Build for OFA rdma stack, if present
-OFA_KSRC ?= /usr/src/ofa_kernel/default
-ifneq ($(wildcard $(OFA_KSRC)),)
-LINUXINCLUDE = $$(UBUNTUINCLUDE) \
-	       -I$(OFA_KSRC)/include \
-	       -I$$(srctree)/arch/$$(SRCARCH)/include \
-	       -I$$(objtree)/arch/$$(SRCARCH)/include/generated \
-	       $$(if $$(KBUILD_SRC), -I$$(srctree)/include) \
-	       -I$$(objtree)/include \
-	       -I$(OFA_KSRC)/include/uapi \
-	       -I$$(srctree)/arch/$$(SRCARCH)/include/uapi \
-	       -I$$(objtree)/arch/$$(SRCARCH)/include/generated/uapi \
-	       -I$$(srctree)/include/uapi \
-	       -I$$(objtree)/include/generated/uapi \
-	       -include $$(srctree)/include/linux/kconfig.h
-OFA_KOPT += LINUXINCLUDE='$(LINUXINCLUDE)'
-OFA_KOPT += KBUILD_EXTRA_SYMBOLS='$(OFA_KSRC)/Module.symvers'
-
-# OFA does not provide semantic versioning for its kernel api.
-# Out-of-tree compatibility is based on hash in compat_version.
-OFA_HASH := $(shell cat '$(OFA_KSRC)/compat_version')
-OFA_KOPT += KCPPFLAGS="-DOFA_KERNEL=$(OFA_HASH)"
-# Relying on undefined macros evaluate to zero, do not warn.
-KCFLAGS += -Wno-undef
-endif
-endif
 endif
 
-DVER = $(shell echo $$SW_VERSION)
 ifeq ($(DVER),)
-  DVER = $(shell git describe --tags 2>/dev/null)
-  ifeq ($(DVER),)
-    DVER = "1.15.9.100"
-  endif
+    DVER = "22.11.1-001"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 
@@ -119,7 +82,7 @@ KBUILD_RULE = $(MAKE) -C $(KSRC) $(KOPT) M=$(CURDIR)
 mnic: KOPT+=$(ETH_KOPT)
 mnic:
 	@echo "===> Building MNIC driver "
-	touch $(BLD_OUT_DIR)/drivers_submake/Makefile
+	touch $(KMOD_OUT_DIR)/Makefile
 	$(MAKE) -C $(KSRC) V=1 M=$(KMOD_OUT_DIR) src=$(KMOD_SRC_DIR)/eth/ionic $(KOPT)
 	mv ${KMOD_OUT_DIR}/Module.symvers ${KMOD_OUT_DIR}/Module.symvers.mnic
 
@@ -138,26 +101,19 @@ eth: KOPT+=$(ETH_KOPT)
 eth:
 	$(KBUILD_RULE)
 
-rdma: eth
-rdma: KOPT+=$(RDMA_KOPT)
-rdma: KOPT+=$(OFA_KOPT)
-rdma:
-	$(KBUILD_RULE)
-
 clean: KOPT+=$(ETH_KOPT)
 clean:
 	$(KBUILD_RULE) clean
 
 install: modules_install
 modules_install: KOPT+=$(ETH_KOPT)
-modules_install: KOPT+=$(RDMA_KOPT)
 modules_install:
 	$(KBUILD_RULE) modules_install
 
 cscope:
-	find $(IONIC_ETH_SRC) $(IONIC_RDMA_SRC) -name '*.[ch]' > cscope.files
+	find $(IONIC_ETH_SRC) -name '*.[ch]' > cscope.files
 	cscope -bkq
 
-.PHONY: default all mnic mdev mnet_uio_pdrv_genirq eth rdma clean install modules_install cscope
+.PHONY: default all mnic mdev mnet_uio_pdrv_genirq eth clean install modules_install cscope
 
 endif

--- a/drivers/linux/eth/ionic/Makefile
+++ b/drivers/linux/eth/ionic/Makefile
@@ -4,7 +4,7 @@
 obj-$(CONFIG_IONIC) := ionic.o
 obj-$(CONFIG_IONIC_MNIC) := ionic_mnic.o
 
-ccflags-y := -g
+ccflags-y := -g -I$(M)/../common
 
 ionic-y := ionic_main.o ionic_bus_pci.o ionic_dev.o ionic_ethtool.o \
 	   ionic_lif.o ionic_rx_filter.o ionic_txrx.o ionic_debugfs.o \

--- a/drivers/linux/eth/ionic/ionic.h
+++ b/drivers/linux/eth/ionic/ionic.h
@@ -33,6 +33,7 @@ struct ionic_lif;
 
 extern bool port_init_up;
 extern unsigned int rx_copybreak;
+extern unsigned int rx_fill_threshold;
 extern unsigned int tx_budget;
 extern unsigned int devcmd_timeout;
 extern unsigned long affinity_mask_override;

--- a/drivers/linux/eth/ionic/ionic_bus_pci.c
+++ b/drivers/linux/eth/ionic/ionic_bus_pci.c
@@ -316,7 +316,7 @@ static int ionic_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 
 	err = ionic_map_bars(ionic);
 	if (err)
-		goto err_out_pci_disable_device;
+		goto err_out_pci_release_regions;
 
 	/* Configure the device */
 	err = ionic_setup(ionic);
@@ -380,16 +380,16 @@ static int ionic_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 			dev_err(dev, "Cannot enable existing VFs: %d\n", err);
 	}
 
-	err = ionic_lif_register(ionic->lif);
-	if (err) {
-		dev_err(dev, "Cannot register LIF: %d, aborting\n", err);
-		goto err_out_deinit_lifs;
-	}
-
 	err = ionic_devlink_register(ionic);
 	if (err) {
 		dev_err(dev, "Cannot register devlink: %d\n", err);
-		goto err_out_deregister_lifs;
+		goto err_out_deinit_lifs;
+	}
+
+	err = ionic_lif_register(ionic->lif);
+	if (err) {
+		dev_err(dev, "Cannot register LIF: %d, aborting\n", err);
+		goto err_out_deregister_devlink;
 	}
 
 	mod_timer(&ionic->watchdog_timer,
@@ -397,8 +397,8 @@ static int ionic_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 
 	return 0;
 
-err_out_deregister_lifs:
-	ionic_lif_unregister(ionic->lif);
+err_out_deregister_devlink:
+	ionic_devlink_unregister(ionic);
 err_out_deinit_lifs:
 	ionic_vf_dealloc(ionic);
 	ionic_lif_deinit(ionic->lif);
@@ -421,6 +421,7 @@ err_out_teardown:
 
 err_out_unmap_bars:
 	ionic_unmap_bars(ionic);
+err_out_pci_release_regions:
 	pci_release_regions(pdev);
 err_out_pci_disable_device:
 	pci_disable_device(pdev);
@@ -444,8 +445,8 @@ static void ionic_remove(struct pci_dev *pdev)
 	del_timer_sync(&ionic->watchdog_timer);
 
 	if (ionic->lif) {
-		ionic_devlink_unregister(ionic);
 		ionic_lif_unregister(ionic->lif);
+		ionic_devlink_unregister(ionic);
 		ionic_lif_deinit(ionic->lif);
 		ionic_lif_free(ionic->lif);
 		ionic->lif = NULL;

--- a/drivers/linux/eth/ionic/ionic_debugfs.c
+++ b/drivers/linux/eth/ionic/ionic_debugfs.c
@@ -6,6 +6,7 @@
 #include "ionic.h"
 #include "ionic_bus.h"
 #include "ionic_lif.h"
+#include "ionic_ethtool.h"
 #include "ionic_debugfs.h"
 #include "kcompat.h"
 
@@ -120,6 +121,7 @@ static int identity_show(struct seq_file *seq, void *v)
 		   ioread8(&idev->dev_info_regs->fw_status));
 	seq_printf(seq, "fw_heartbeat:     0x%x\n",
 		   ioread32(&idev->dev_info_regs->fw_heartbeat));
+	seq_printf(seq, "cmb_pages:        0x%x\n", ionic_cmb_pages_in_use(ionic->lif));
 
 	seq_printf(seq, "nlifs:            %d\n", ident->dev.nlifs);
 	seq_printf(seq, "nintrs:           %d\n", ident->dev.nintrs);

--- a/drivers/linux/eth/ionic/ionic_ethtool.h
+++ b/drivers/linux/eth/ionic/ionic_ethtool.h
@@ -4,6 +4,7 @@
 #ifndef _IONIC_ETHTOOL_H_
 #define _IONIC_ETHTOOL_H_
 
+int ionic_cmb_pages_in_use(struct ionic_lif *lif);
 void ionic_ethtool_set_ops(struct net_device *netdev);
 
 #endif /* _IONIC_ETHTOOL_H_ */

--- a/drivers/linux/eth/ionic/ionic_lif.c
+++ b/drivers/linux/eth/ionic/ionic_lif.c
@@ -406,18 +406,18 @@ static void ionic_qcq_free(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	ionic_debugfs_del_qcq(qcq);
 
 	if (qcq->q_base) {
-		if (qcq->flags & IONIC_QCQ_F_CMB_RINGS) {
-			iounmap(qcq->cmb_q_base);
-			ionic_put_cmb(lif, qcq->cmb_pgid, qcq->cmb_order);
-			qcq->cmb_q_base = NULL;
-			qcq->cmb_pgid = 0;
-			qcq->cmb_order = 0;
-		} else {
-			dma_free_coherent(dev, qcq->q_size,
-					  qcq->q_base, qcq->q_base_pa);
-			qcq->q_base = NULL;
-			qcq->q_base_pa = 0;
-		}
+		dma_free_coherent(dev, qcq->q_size, qcq->q_base, qcq->q_base_pa);
+		qcq->q_base = NULL;
+		qcq->q_base_pa = 0;
+	}
+
+	if (qcq->cmb_q_base) {
+		iounmap(qcq->cmb_q_base);
+		ionic_put_cmb(lif, qcq->cmb_pgid, qcq->cmb_order);
+		qcq->cmb_pgid = 0;
+		qcq->cmb_order = 0;
+		qcq->cmb_q_base = NULL;
+		qcq->cmb_q_base_pa = 0;
 	}
 
 	if (qcq->cq_base) {
@@ -645,45 +645,43 @@ static int ionic_qcq_alloc(struct ionic_lif *lif, unsigned int type,
 		ionic_cq_map(&new->cq, cq_base, cq_base_pa);
 		ionic_cq_bind(&new->cq, &new->q);
 	} else {
+		/* regular DMA q descriptors */
+		new->q_size = PAGE_SIZE + (num_descs * desc_size);
+		new->q_base = dma_alloc_coherent(dev, new->q_size, &new->q_base_pa,
+						 GFP_KERNEL);
+		if (!new->q_base) {
+			netdev_err(lif->netdev, "Cannot allocate queue DMA memory\n");
+			err = -ENOMEM;
+			goto err_out_free_cq_info;
+		}
+		q_base = PTR_ALIGN(new->q_base, PAGE_SIZE);
+		q_base_pa = ALIGN(new->q_base_pa, PAGE_SIZE);
+		ionic_q_map(&new->q, q_base, q_base_pa);
+
 		if (flags & IONIC_QCQ_F_CMB_RINGS) {
 			/* on-chip CMB q descriptors */
-			new->q_size = num_descs * desc_size;
-			new->cmb_order = order_base_2(new->q_size / PAGE_SIZE);
+			new->cmb_q_size = num_descs * desc_size;
+			new->cmb_order = order_base_2(new->cmb_q_size / PAGE_SIZE);
 
-			err = ionic_get_cmb(lif, &new->cmb_pgid, &new->q_base_pa,
+			err = ionic_get_cmb(lif, &new->cmb_pgid, &new->cmb_q_base_pa,
 					    new->cmb_order);
 			if (err) {
 				netdev_err(lif->netdev,
 					   "Cannot allocate queue order %d from cmb: err %d\n",
 					   new->cmb_order, err);
-				goto err_out_free_cq_info;
+				goto err_out_free_q;
 			}
 
-			new->cmb_q_base = ioremap_wc(new->q_base_pa, new->q_size);
+			new->cmb_q_base = ioremap_wc(new->cmb_q_base_pa, new->cmb_q_size);
 			if (!new->cmb_q_base) {
-				netdev_err(lif->netdev,
-					   "Cannot map queue from cmb\n");
+				netdev_err(lif->netdev, "Cannot map queue from cmb\n");
 				ionic_put_cmb(lif, new->cmb_pgid, new->cmb_order);
-				goto err_out_free_cq_info;
+				err = -ENOMEM;
+				goto err_out_free_q;
 			}
 
-			q_base_pa = new->q_base_pa - idev->phy_cmb_pages;
-			ionic_q_map(&new->q, (__force void *)new->cmb_q_base, q_base_pa);
-		} else {
-			/* regular DMA q descriptors */
-			new->q_size = PAGE_SIZE + (num_descs * desc_size);
-			new->q_base = dma_alloc_coherent(dev, new->q_size,
-							 &new->q_base_pa,
-							 GFP_KERNEL);
-			if (!new->q_base) {
-				netdev_err(lif->netdev,
-					   "Cannot allocate queue DMA memory\n");
-				err = -ENOMEM;
-				goto err_out_free_cq_info;
-			}
-			q_base = PTR_ALIGN(new->q_base, PAGE_SIZE);
-			q_base_pa = ALIGN(new->q_base_pa, PAGE_SIZE);
-			ionic_q_map(&new->q, q_base, q_base_pa);
+			new->cmb_q_base_pa -= idev->phy_cmb_pages;
+			ionic_q_cmb_map(&new->q, new->cmb_q_base, new->cmb_q_base_pa);
 		}
 
 		/* cq DMA descriptors */
@@ -725,12 +723,11 @@ static int ionic_qcq_alloc(struct ionic_lif *lif, unsigned int type,
 err_out_free_cq:
 	dma_free_coherent(dev, new->cq_size, new->cq_base, new->cq_base_pa);
 err_out_free_q:
-	if (flags & IONIC_QCQ_F_CMB_RINGS) {
+	if (new->cmb_q_base) {
 		iounmap(new->cmb_q_base);
 		ionic_put_cmb(lif, new->cmb_pgid, new->cmb_order);
-	} else {
-		dma_free_coherent(dev, new->q_size, new->q_base, new->q_base_pa);
 	}
+	dma_free_coherent(dev, new->q_size, new->q_base, new->q_base_pa);
 err_out_free_cq_info:
 	vfree(new->cq.info);
 err_out_free_irq:
@@ -823,10 +820,9 @@ static void ionic_qcq_sanitize(struct ionic_qcq *qcq)
 	qcq->cq.tail_idx = 0;
 	qcq->cq.done_color = 1;
 
-	if (qcq->flags & IONIC_QCQ_F_CMB_RINGS)
-		memset_io(qcq->cmb_q_base, 0, qcq->q_size);
-	else
-		memset(qcq->q_base, 0, qcq->q_size);
+	memset(qcq->q_base, 0, qcq->q_size);
+	if (qcq->cmb_q_base)
+		memset_io(qcq->cmb_q_base, 0, qcq->cmb_q_size);
 	memset(qcq->cq_base, 0, qcq->cq_size);
 	memset(qcq->sg_base, 0, qcq->sg_size);
 }
@@ -871,8 +867,10 @@ static int ionic_lif_txq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 		ctx.cmd.q_init.intr_index = cpu_to_le16(intr_index);
 	}
 
-	if (qcq->flags & IONIC_QCQ_F_CMB_RINGS)
+	if (qcq->flags & IONIC_QCQ_F_CMB_RINGS) {
 		ctx.cmd.q_init.flags |= cpu_to_le16(IONIC_QINIT_F_CMB);
+		ctx.cmd.q_init.ring_base = cpu_to_le64(qcq->cmb_q_base_pa);
+	}
 
 	dev_dbg(dev, "txq_init.pid %d\n", ctx.cmd.q_init.pid);
 	dev_dbg(dev, "txq_init.index %d\n", ctx.cmd.q_init.index);
@@ -901,8 +899,7 @@ static int ionic_lif_txq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	q->dbell_jiffies = jiffies;
 
 	if (test_bit(IONIC_LIF_F_SPLIT_INTR, lif->state)) {
-		netif_napi_add(lif->netdev, &qcq->napi, ionic_tx_napi,
-			       NAPI_POLL_WEIGHT);
+		netif_napi_add(lif->netdev, &qcq->napi, ionic_tx_napi);
 		qcq->napi_qcq = qcq;
 		timer_setup(&qcq->napi_deadline, ionic_napi_deadline, 0);
 	}
@@ -948,8 +945,10 @@ static int ionic_lif_rxq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 		ctx.cmd.q_init.intr_index = cpu_to_le16(cq->bound_intr->index);
 	}
 
-	if (qcq->flags & IONIC_QCQ_F_CMB_RINGS)
+	if (qcq->flags & IONIC_QCQ_F_CMB_RINGS) {
 		ctx.cmd.q_init.flags |= cpu_to_le16(IONIC_QINIT_F_CMB);
+		ctx.cmd.q_init.ring_base = cpu_to_le64(qcq->cmb_q_base_pa);
+	}
 
 	dev_dbg(dev, "rxq_init.pid %d\n", ctx.cmd.q_init.pid);
 	dev_dbg(dev, "rxq_init.index %d\n", ctx.cmd.q_init.index);
@@ -978,11 +977,9 @@ static int ionic_lif_rxq_init(struct ionic_lif *lif, struct ionic_qcq *qcq)
 	q->dbell_jiffies = jiffies;
 
 	if (test_bit(IONIC_LIF_F_SPLIT_INTR, lif->state))
-		netif_napi_add(lif->netdev, &qcq->napi, ionic_rx_napi,
-			       NAPI_POLL_WEIGHT);
+		netif_napi_add(lif->netdev, &qcq->napi, ionic_rx_napi);
 	else
-		netif_napi_add(lif->netdev, &qcq->napi, ionic_txrx_napi,
-			       NAPI_POLL_WEIGHT);
+		netif_napi_add(lif->netdev, &qcq->napi, ionic_txrx_napi);
 
 	qcq->napi_qcq = qcq;
 	timer_setup(&qcq->napi_deadline, ionic_napi_deadline, 0);
@@ -1591,6 +1588,14 @@ static __le64 ionic_netdev_features_to_nic(netdev_features_t features)
 	if (features & NETIF_F_GSO_IPXIP6)
 		wanted |= IONIC_ETH_HW_TSO_IPXIP6;
 #endif
+#ifdef NETIF_F_GSO_IPIP
+	if (features & NETIF_F_GSO_IPIP)
+		wanted |= IONIC_ETH_HW_TSO_IPXIP4;
+#endif
+#ifdef NETIF_F_GSO_SIT
+	if (features & NETIF_F_GSO_SIT)
+		wanted |= IONIC_ETH_HW_TSO_IPXIP4;
+#endif
 	if (features & NETIF_F_GSO_UDP_TUNNEL)
 		wanted |= IONIC_ETH_HW_TSO_UDP;
 	if (features & NETIF_F_GSO_UDP_TUNNEL_CSUM)
@@ -1633,7 +1638,7 @@ static int ionic_set_nic_features(struct ionic_lif *lif,
 	if ((old_hw_features ^ lif->hw_features) & IONIC_ETH_HW_RX_HASH)
 		ionic_lif_rss_config(lif, lif->rss_types, NULL, NULL);
 
-	if ((vlan_flags & features) &&
+	if ((vlan_flags & le64_to_cpu(ctx.cmd.lif_setattr.features)) &&
 	    !(vlan_flags & le64_to_cpu(ctx.comp.lif_setattr.features)))
 		dev_info_once(lif->ionic->dev, "NIC is not supporting vlan offload, likely in SmartNIC mode\n");
 
@@ -1690,7 +1695,23 @@ static int ionic_init_nic_features(struct ionic_lif *lif)
 		   NETIF_F_RXCSUM |
 		   NETIF_F_TSO |
 		   NETIF_F_TSO6 |
-		   NETIF_F_TSO_ECN;
+		   NETIF_F_TSO_ECN |
+		   NETIF_F_GSO_GRE |
+		   NETIF_F_GSO_GRE_CSUM |
+#ifdef NETIF_F_GSO_IPXIP4
+		   NETIF_F_GSO_IPXIP4 |
+#endif
+#ifdef NETIF_F_GSO_IPXIP6
+		   NETIF_F_GSO_IPXIP6 |
+#endif
+#ifdef NETIF_F_GSO_IPIP
+		   NETIF_F_GSO_IPIP |
+#endif
+#ifdef NETIF_F_GSO_SIT
+		   NETIF_F_GSO_SIT |
+#endif
+		   NETIF_F_GSO_UDP_TUNNEL |
+		   NETIF_F_GSO_UDP_TUNNEL_CSUM;
 
 	if (lif->nxqs > 1)
 		features |= NETIF_F_RXHASH;
@@ -1735,6 +1756,10 @@ static int ionic_init_nic_features(struct ionic_lif *lif)
 	if (lif->hw_features & IONIC_ETH_HW_TSO_IPXIP6)
 		netdev->hw_enc_features |= NETIF_F_GSO_IPXIP6;
 #endif
+#ifdef NETIF_F_GSO_IPIP
+	if (lif->hw_features & IONIC_ETH_HW_TSO_IPXIP4)
+		netdev->hw_enc_features |= NETIF_F_GSO_IPIP;
+#endif
 	if (lif->hw_features & IONIC_ETH_HW_TSO_UDP)
 		netdev->hw_enc_features |= NETIF_F_GSO_UDP_TUNNEL;
 	if (lif->hw_features & IONIC_ETH_HW_TSO_UDP_CSUM)
@@ -1770,15 +1795,83 @@ static int ionic_set_features(struct net_device *netdev,
 	return err;
 }
 
+static int ionic_set_attr_mac(struct ionic_lif *lif, u8 *mac)
+{
+	struct ionic_admin_ctx ctx = {
+		.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
+		.cmd.lif_setattr = {
+			.opcode = IONIC_CMD_LIF_SETATTR,
+			.index = cpu_to_le16(lif->index),
+			.attr = IONIC_LIF_ATTR_MAC,
+		},
+	};
+
+	ether_addr_copy(ctx.cmd.lif_setattr.mac, mac);
+	return ionic_adminq_post_wait(lif, &ctx);
+}
+
+static int ionic_get_attr_mac(struct ionic_lif *lif, u8 *mac_addr)
+{
+	struct ionic_admin_ctx ctx = {
+		.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
+		.cmd.lif_getattr = {
+			.opcode = IONIC_CMD_LIF_GETATTR,
+			.index = cpu_to_le16(lif->index),
+			.attr = IONIC_LIF_ATTR_MAC,
+		},
+	};
+	int err;
+
+	err = ionic_adminq_post_wait(lif, &ctx);
+	if (err)
+		return err;
+
+	ether_addr_copy(mac_addr, ctx.comp.lif_getattr.mac);
+	return 0;
+}
+
+static int ionic_program_mac(struct ionic_lif *lif, u8 *mac)
+{
+	u8  get_mac[ETH_ALEN];
+	int err;
+
+	err = ionic_set_attr_mac(lif, mac);
+	if (err)
+		return err;
+
+	err = ionic_get_attr_mac(lif, get_mac);
+	if (err)
+		return err;
+
+	/* To deal with older firmware that silently ignores the set attr mac:
+	 * doesn't actually change the mac and doesn't return an error, so we
+	 * do the get attr to verify whether or not the set actually happened
+	 */
+	if (ether_addr_equal(get_mac, mac))
+		return 0;
+
+	return 1;
+}
+
 static int ionic_set_mac_address(struct net_device *netdev, void *sa)
 {
-	struct sockaddr *addr = sa;
-	u8 *mac;
+	struct ionic_lif *lif = netdev_priv(netdev);
+	struct sockaddr  *addr = sa;
+	u8  *mac;
 	int err;
 
 	mac = (u8 *)addr->sa_data;
+
 	if (ether_addr_equal(netdev->dev_addr, mac))
 		return 0;
+
+	err = ionic_program_mac(lif, mac);
+	if (err < 0)
+		return err;
+
+	if (err > 0)
+		netdev_dbg(netdev, "%s:SET and GET ATTR Mac is not equal-due to old FW running\n",
+			   __func__);
 
 	err = eth_prepare_mac_addr_change(netdev, addr);
 	if (err)
@@ -1837,9 +1930,6 @@ static int ionic_change_mtu(struct net_device *netdev, int new_mtu)
 	};
 	int err;
 	int fs;
-
-	if (test_bit(IONIC_LIF_F_CMB_RINGS, lif->state) && netif_running(netdev))
-		return -EBUSY;
 
 	fs = new_mtu + ETH_HLEN + VLAN_HLEN;
 	if (fs < le32_to_cpu(lif->identity->eth.min_frame_size) ||
@@ -2410,7 +2500,7 @@ static int ionic_eth_ioctl(struct net_device *netdev, struct ifreq *ifr, int cmd
 	}
 }
 
-static int ionic_update_cached_vf_config(struct ionic *ionic, int vf)
+static int ionic_get_fw_vf_config(struct ionic *ionic, int vf, struct ionic_vf *vfdata)
 {
 	struct ionic_vf_getattr_comp comp = { 0 };
 	int err;
@@ -2421,14 +2511,14 @@ static int ionic_update_cached_vf_config(struct ionic *ionic, int vf)
 	if (err && comp.status != IONIC_RC_ENOSUPP)
 		goto err_out;
 	if (!err)
-		ionic->vfs[vf].vlanid = comp.vlanid;
+		vfdata->vlanid = comp.vlanid;
 
 	attr = IONIC_VF_ATTR_SPOOFCHK;
 	err = ionic_dev_cmd_vf_getattr(ionic, vf, attr, &comp);
 	if (err && comp.status != IONIC_RC_ENOSUPP)
 		goto err_out;
 	if (!err)
-		ionic->vfs[vf].spoofchk = comp.spoofchk;
+		vfdata->spoofchk = comp.spoofchk;
 
 	attr = IONIC_VF_ATTR_LINKSTATE;
 	err = ionic_dev_cmd_vf_getattr(ionic, vf, attr, &comp);
@@ -2437,13 +2527,13 @@ static int ionic_update_cached_vf_config(struct ionic *ionic, int vf)
 	if (!err) {
 		switch (comp.linkstate) {
 		case IONIC_VF_LINK_STATUS_UP:
-			ionic->vfs[vf].linkstate = IFLA_VF_LINK_STATE_ENABLE;
+			vfdata->linkstate = IFLA_VF_LINK_STATE_ENABLE;
 			break;
 		case IONIC_VF_LINK_STATUS_DOWN:
-			ionic->vfs[vf].linkstate = IFLA_VF_LINK_STATE_DISABLE;
+			vfdata->linkstate = IFLA_VF_LINK_STATE_DISABLE;
 			break;
 		case IONIC_VF_LINK_STATUS_AUTO:
-			ionic->vfs[vf].linkstate = IFLA_VF_LINK_STATE_AUTO;
+			vfdata->linkstate = IFLA_VF_LINK_STATE_AUTO;
 			break;
 		default:
 			dev_warn(ionic->dev, "Unexpected link state %u\n", comp.linkstate);
@@ -2456,21 +2546,21 @@ static int ionic_update_cached_vf_config(struct ionic *ionic, int vf)
 	if (err && comp.status != IONIC_RC_ENOSUPP)
 		goto err_out;
 	if (!err)
-		ionic->vfs[vf].maxrate = comp.maxrate;
+		vfdata->maxrate = comp.maxrate;
 
 	attr = IONIC_VF_ATTR_TRUST;
 	err = ionic_dev_cmd_vf_getattr(ionic, vf, attr, &comp);
 	if (err && comp.status != IONIC_RC_ENOSUPP)
 		goto err_out;
 	if (!err)
-		ionic->vfs[vf].trusted = comp.trust;
+		vfdata->trusted = comp.trust;
 
 	attr = IONIC_VF_ATTR_MAC;
 	err = ionic_dev_cmd_vf_getattr(ionic, vf, attr, &comp);
 	if (err && comp.status != IONIC_RC_ENOSUPP)
 		goto err_out;
 	if (!err)
-		ether_addr_copy(ionic->vfs[vf].macaddr, comp.macaddr);
+		ether_addr_copy(vfdata->macaddr, comp.macaddr);
 
 err_out:
 	if (err)
@@ -2485,6 +2575,7 @@ static int ionic_get_vf_config(struct net_device *netdev,
 {
 	struct ionic_lif *lif = netdev_priv(netdev);
 	struct ionic *ionic = lif->ionic;
+	struct ionic_vf vfdata = { 0 };
 	int ret = 0;
 
 	if (!netif_device_present(netdev))
@@ -2498,14 +2589,14 @@ static int ionic_get_vf_config(struct net_device *netdev,
 		ivf->vf = vf;
 		ivf->qos = 0;
 
-		ret = ionic_update_cached_vf_config(ionic, vf);
+		ret = ionic_get_fw_vf_config(ionic, vf, &vfdata);
 		if (!ret) {
-			ivf->vlan         = le16_to_cpu(ionic->vfs[vf].vlanid);
-			ivf->spoofchk     = ionic->vfs[vf].spoofchk;
-			ivf->linkstate    = ionic->vfs[vf].linkstate;
-			ivf->max_tx_rate  = le32_to_cpu(ionic->vfs[vf].maxrate);
-			ivf->trusted      = ionic->vfs[vf].trusted;
-			ether_addr_copy(ivf->mac, ionic->vfs[vf].macaddr);
+			ivf->vlan         = le16_to_cpu(vfdata.vlanid);
+			ivf->spoofchk     = vfdata.spoofchk;
+			ivf->linkstate    = vfdata.linkstate;
+			ivf->max_tx_rate  = le32_to_cpu(vfdata.maxrate);
+			ivf->trusted      = vfdata.trusted;
+			ether_addr_copy(ivf->mac, vfdata.macaddr);
 		}
 	}
 
@@ -2764,6 +2855,76 @@ static int ionic_set_vf_link_state(struct net_device *netdev, int vf, int set)
 	return ret;
 }
 
+static void ionic_vf_attr_replay(struct ionic_lif *lif)
+{
+	struct ionic_vf_setattr_cmd vfc = { 0 };
+	struct ionic *ionic = lif->ionic;
+	struct ionic_vf *v;
+	int i;
+
+	if (!ionic->vfs)
+		return;
+
+	down_read(&ionic->vf_op_lock);
+
+	for (i = 0; i < ionic->num_vfs; i++) {
+		v = &ionic->vfs[i];
+
+		if (v->stats_pa) {
+			vfc.attr = IONIC_VF_ATTR_STATSADDR;
+			vfc.stats_pa = cpu_to_le64(v->stats_pa);
+			(void)ionic_set_vf_config(ionic, i, &vfc);
+			vfc.stats_pa = 0;
+		}
+
+		if (!is_zero_ether_addr(v->macaddr)) {
+			vfc.attr = IONIC_VF_ATTR_MAC;
+			ether_addr_copy(vfc.macaddr, v->macaddr);
+			(void)ionic_set_vf_config(ionic, i, &vfc);
+			eth_zero_addr(vfc.macaddr);
+		}
+
+		if (v->vlanid) {
+			vfc.attr = IONIC_VF_ATTR_VLAN;
+			vfc.vlanid = v->vlanid;
+			(void)ionic_set_vf_config(ionic, i, &vfc);
+			vfc.vlanid = 0;
+		}
+
+		if (v->maxrate) {
+			vfc.attr = IONIC_VF_ATTR_RATE;
+			vfc.maxrate = v->maxrate;
+			(void)ionic_set_vf_config(ionic, i, &vfc);
+			vfc.maxrate = 0;
+		}
+
+		if (v->spoofchk) {
+			vfc.attr = IONIC_VF_ATTR_SPOOFCHK;
+			vfc.spoofchk = v->spoofchk;
+			(void)ionic_set_vf_config(ionic, i, &vfc);
+			vfc.spoofchk = 0;
+		}
+
+		if (v->trusted) {
+			vfc.attr = IONIC_VF_ATTR_TRUST;
+			vfc.trust = v->trusted;
+			(void)ionic_set_vf_config(ionic, i, &vfc);
+			vfc.trust = 0;
+		}
+
+		if (v->linkstate) {
+			vfc.attr = IONIC_VF_ATTR_LINKSTATE;
+			vfc.linkstate = v->linkstate;
+			(void)ionic_set_vf_config(ionic, i, &vfc);
+			vfc.linkstate = 0;
+		}
+	}
+
+	up_read(&ionic->vf_op_lock);
+
+	ionic_vf_start(ionic, -1);
+}
+
 static const struct net_device_ops ionic_netdev_ops = {
 	.ndo_open               = ionic_open,
 	.ndo_stop               = ionic_stop,
@@ -2791,7 +2952,9 @@ static const struct net_device_ops ionic_netdev_ops = {
 	.extended.ndo_set_vf_trust	= ionic_set_vf_trust,
 #endif
 #else
+#if (RHEL_RELEASE_CODE == 0 || RHEL_RELEASE_VERSION(8, 0) < RHEL_RELEASE_CODE)
 	.ndo_set_vf_vlan	= ionic_set_vf_vlan,
+#endif
 	.ndo_set_vf_trust	= ionic_set_vf_trust,
 #endif
 	.ndo_set_vf_mac		= ionic_set_vf_mac,
@@ -2840,6 +3003,55 @@ static const struct net_device_ops ionic_mnic_netdev_ops = {
 #endif
 };
 
+static int ionic_cmb_reconfig(struct ionic_lif *lif,
+			      struct ionic_queue_params *qparam)
+{
+	struct ionic_queue_params start_qparams;
+	int err = 0;
+
+	/* When changing CMB queue parameters, we're using limited
+	 * on-device memory and don't have extra memory to use for
+	 * duplicate allocations, so we free it all first then
+	 * re-allocate with the new parameters.
+	 */
+
+	/* Checkpoint for possible unwind */
+	ionic_init_queue_params(lif, &start_qparams);
+
+	/* Stop and free the queues */
+	ionic_stop_queues_reconfig(lif);
+	ionic_txrx_free(lif);
+
+	/* Set up new qparams */
+	ionic_set_queue_params(lif, qparam);
+
+	if (netif_running(lif->netdev)) {
+		/* Alloc and start the new configuration */
+		err = ionic_txrx_alloc(lif);
+		if (err) {
+			dev_warn(lif->ionic->dev,
+				 "CMB reconfig failed, restoring values: %d\n", err);
+
+			/* Back out the changes */
+			ionic_set_queue_params(lif, &start_qparams);
+			err = ionic_txrx_alloc(lif);
+			if (err) {
+				dev_err(lif->ionic->dev,
+					"CMB restore failed: %d\n", err);
+				goto errout;
+			}
+		}
+
+		ionic_start_queues_reconfig(lif);
+	} else {
+		/* This was detached in ionic_stop_queues_reconfig() */
+		netif_device_attach(lif->netdev);
+	}
+
+errout:
+	return err;
+}
+
 static void ionic_swap_queues(struct ionic_qcq *a, struct ionic_qcq *b)
 {
 	/* only swapping the queues, not the napi, flags, or other stuff */
@@ -2882,13 +3094,9 @@ int ionic_reconfigure_queues(struct ionic_lif *lif,
 	unsigned int flags, i;
 	int err = 0;
 
-	if (test_bit(IONIC_LIF_F_CMB_RINGS, lif->state)) {
-		/* Use WARN to trace back where we missed blocking
-		 * a config change.  We should never be here.
-		 */
-		WARN(true, "Reconfigure not allowed in CMB_RING state");
-		return -EBUSY;
-	}
+	/* Are we changing q params while CMB is on */
+	if (test_bit(IONIC_LIF_F_CMB_RINGS, lif->state) && qparam->cmb_enabled)
+		return ionic_cmb_reconfig(lif, qparam);
 
 	/* allocate temporary qcq arrays to hold new queue structs */
 	if (qparam->nxqs != lif->nxqs || qparam->ntxq_descs != lif->ntxq_descs) {
@@ -2926,6 +3134,14 @@ int ionic_reconfigure_queues(struct ionic_lif *lif,
 			sg_desc_sz = sizeof(struct ionic_txq_sg_desc);
 
 		for (i = 0; i < qparam->nxqs; i++) {
+			/* If missing, short placeholder qcq needed for swap */
+			if (!lif->txqcqs[i]) {
+				flags = IONIC_QCQ_F_TX_STATS | IONIC_QCQ_F_SG;
+				err = ionic_qcq_alloc(lif, IONIC_QTYPE_TXQ, i, "tx", flags,
+						      4, desc_sz, comp_sz, sg_desc_sz,
+						      lif->kern_pid, &lif->txqcqs[i]);
+			}
+
 			flags = lif->txqcqs[i]->flags & ~IONIC_QCQ_F_INTR;
 			err = ionic_qcq_alloc(lif, IONIC_QTYPE_TXQ, i, "tx", flags,
 					      num_desc, desc_sz, comp_sz, sg_desc_sz,
@@ -2945,6 +3161,14 @@ int ionic_reconfigure_queues(struct ionic_lif *lif,
 			comp_sz *= 2;
 
 		for (i = 0; i < qparam->nxqs; i++) {
+			/* If missing, short placeholder qcq needed for swap */
+			if (!lif->rxqcqs[i]) {
+				flags = IONIC_QCQ_F_RX_STATS | IONIC_QCQ_F_SG;
+				err = ionic_qcq_alloc(lif, IONIC_QTYPE_RXQ, i, "rx", flags,
+						      4, desc_sz, comp_sz, sg_desc_sz,
+						      lif->kern_pid, &lif->rxqcqs[i]);
+			}
+
 			flags = lif->rxqcqs[i]->flags & ~IONIC_QCQ_F_INTR;
 			err = ionic_qcq_alloc(lif, IONIC_QTYPE_RXQ, i, "rx", flags,
 					      num_desc, desc_sz, comp_sz, sg_desc_sz,
@@ -2994,10 +3218,15 @@ int ionic_reconfigure_queues(struct ionic_lif *lif,
 			lif->tx_coalesce_hw = lif->rx_coalesce_hw;
 		}
 
-		/* clear existing interrupt assignments */
+		/* Clear existing interrupt assignments.  We check for NULL here
+		 * because we're checking the whole array for potential qcqs, not
+		 * just those qcqs that have just been set up.
+		 */
 		for (i = 0; i < lif->ionic->ntxqs_per_lif; i++) {
-			ionic_qcq_intr_free(lif, lif->txqcqs[i]);
-			ionic_qcq_intr_free(lif, lif->rxqcqs[i]);
+			if (lif->txqcqs[i])
+				ionic_qcq_intr_free(lif, lif->txqcqs[i]);
+			if (lif->rxqcqs[i])
+				ionic_qcq_intr_free(lif, lif->rxqcqs[i]);
 		}
 
 		/* re-assign the interrupts */
@@ -3079,11 +3308,15 @@ err_out:
 	 * than the full array, but leave the qcq shells in place
 	 */
 	for (i = lif->nxqs; i < lif->ionic->ntxqs_per_lif; i++) {
-		lif->txqcqs[i]->flags &= ~IONIC_QCQ_F_INTR;
-		ionic_qcq_free(lif, lif->txqcqs[i]);
+		if (lif->txqcqs && lif->txqcqs[i]) {
+			lif->txqcqs[i]->flags &= ~IONIC_QCQ_F_INTR;
+			ionic_qcq_free(lif, lif->txqcqs[i]);
+		}
 
-		lif->rxqcqs[i]->flags &= ~IONIC_QCQ_F_INTR;
-		ionic_qcq_free(lif, lif->rxqcqs[i]);
+		if (lif->rxqcqs && lif->rxqcqs[i]) {
+			lif->rxqcqs[i]->flags &= ~IONIC_QCQ_F_INTR;
+			ionic_qcq_free(lif, lif->rxqcqs[i]);
+		}
 	}
 
 	if (err)
@@ -3311,6 +3544,8 @@ static void ionic_lif_handle_fw_up(struct ionic_lif *lif)
 	if (err)
 		goto err_qcqs_free;
 
+	ionic_vf_attr_replay(lif);
+
 	if (lif->registered)
 		ionic_lif_set_netdev_info(lif);
 
@@ -3453,8 +3688,7 @@ static int ionic_lif_adminq_init(struct ionic_lif *lif)
 	q->dbell_deadline = IONIC_ADMIN_DOORBELL_DEADLINE;
 	q->dbell_jiffies = jiffies;
 
-	netif_napi_add(lif->netdev, &qcq->napi, ionic_adminq_napi,
-		       NAPI_POLL_WEIGHT);
+	netif_napi_add(lif->netdev, &qcq->napi, ionic_adminq_napi);
 
 	qcq->napi_qcq = qcq;
 	timer_setup(&qcq->napi_deadline, ionic_napi_deadline, 0);
@@ -3532,6 +3766,7 @@ static int ionic_station_set(struct ionic_lif *lif)
 			.attr = IONIC_LIF_ATTR_MAC,
 		},
 	};
+	u8  mac_address[ETH_ALEN];
 	struct sockaddr addr;
 	int err;
 
@@ -3540,8 +3775,23 @@ static int ionic_station_set(struct ionic_lif *lif)
 		return err;
 	netdev_dbg(lif->netdev, "found initial MAC addr %pM\n",
 		   ctx.comp.lif_getattr.mac);
-	if (is_zero_ether_addr(ctx.comp.lif_getattr.mac))
-		return 0;
+	ether_addr_copy(mac_address, ctx.comp.lif_getattr.mac);
+
+	if (is_zero_ether_addr(mac_address)) {
+		eth_hw_addr_random(netdev);
+		netdev_dbg(netdev, "Random Mac generated: %pM\n", netdev->dev_addr);
+		ether_addr_copy(mac_address, netdev->dev_addr);
+
+		err = ionic_program_mac(lif, mac_address);
+		if (err < 0)
+			return err;
+
+		if (err > 0) {
+			netdev_dbg(netdev, "%s:SET/GET ATTR Mac is not same-due to old FW running\n",
+				   __func__);
+			return 0;
+		}
+	}
 
 	if (!is_zero_ether_addr(netdev->dev_addr)) {
 		/* If the netdev mac is non-zero and doesn't match the default
@@ -3549,12 +3799,12 @@ static int ionic_station_set(struct ionic_lif *lif)
 		 * likely here again after a fw-upgrade reset.  We need to be
 		 * sure the netdev mac is in our filter list.
 		 */
-		if (!ether_addr_equal(ctx.comp.lif_getattr.mac,
+		if (!ether_addr_equal(mac_address,
 				      netdev->dev_addr))
 			ionic_lif_addr_add(lif, netdev->dev_addr);
 	} else {
 		/* Update the netdev mac with the device's mac */
-		memcpy(addr.sa_data, ctx.comp.lif_getattr.mac, netdev->addr_len);
+		ether_addr_copy(addr.sa_data, mac_address);
 		addr.sa_family = AF_INET;
 		err = eth_prepare_mac_addr_change(netdev, &addr);
 		if (err) {

--- a/drivers/linux/eth/ionic/ionic_phc_weak.c
+++ b/drivers/linux/eth/ionic/ionic_phc_weak.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright(c) 2021 - 2022 Pensando Systems, Inc */
+/* Copyright(c) 2022 Pensando Systems, Inc */
 
 #include <linux/errno.h>
 #include <linux/kernel.h>

--- a/drivers/linux/eth/ionic/ionic_stats.c
+++ b/drivers/linux/eth/ionic/ionic_stats.c
@@ -185,6 +185,14 @@ static const struct ionic_stat_desc ionic_rx_stats_desc[] = {
 	IONIC_RX_STAT_DESC(hwstamp_valid),
 	IONIC_RX_STAT_DESC(hwstamp_invalid),
 	IONIC_RX_STAT_DESC(dropped),
+	IONIC_RX_STAT_DESC(cache_full),
+	IONIC_RX_STAT_DESC(cache_empty),
+	IONIC_RX_STAT_DESC(cache_busy),
+	IONIC_RX_STAT_DESC(cache_get),
+	IONIC_RX_STAT_DESC(cache_put),
+	IONIC_RX_STAT_DESC(buf_exhausted),
+	IONIC_RX_STAT_DESC(buf_not_reusable),
+	IONIC_RX_STAT_DESC(buf_reused),
 };
 
 #ifdef IONIC_DEBUG_STATS

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -6807,6 +6807,34 @@ static inline struct devlink *_kc_devlink_alloc(const struct devlink_ops *ops,
 #define HAVE_RINGPARAM_EXTACK
 #endif /* 5.17 */
 
+/*****************************************************************************/
+#if (KERNEL_VERSION(6, 0, 0) > LINUX_VERSION_CODE)
+static inline int skb_tcp_all_headers(const struct sk_buff *skb)
+{
+	return skb_transport_offset(skb) + tcp_hdrlen(skb);
+}
+
+static inline int skb_inner_tcp_all_headers(const struct sk_buff *skb)
+{
+	return skb_inner_transport_offset(skb) + inner_tcp_hdrlen(skb);
+}
+
+#else
+#endif /* 6.0 */
+
+/*****************************************************************************/
+#if (KERNEL_VERSION(6, 1, 0) > LINUX_VERSION_CODE)
+
+#if (RHEL_RELEASE_CODE && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 0) && defined(netif_napi_add))
+#undef netif_napi_add
+#define netif_napi_add(a, b, c)  _netif_napi_add((a), (b), (c), NAPI_POLL_WEIGHT)
+#else
+#define netif_napi_add(a, b, c)  netif_napi_add((a), (b), (c), NAPI_POLL_WEIGHT)
+#endif
+
+#else
+#endif /* 6.1 */
+
 /* We don't support PTP on older RHEL kernels (needs more compat work) */
 #if (RHEL_RELEASE_CODE && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,4))
 #undef CONFIG_PTP_1588_CLOCK


### PR DESCRIPTION
Update the dsc-drivers to match internal 22.11.1-001 drivers

Internal patch list:
    ionic: VF ethernet interfaces come up with out MAC addresses
    ionic: fix up issues with handling EAGAIN on FW cmds
    ionic: fix vlan feature check
    ionic: eliminate temporary descriptor used for tx posting
    ionic: replay VF attributes after fw crash recovery
    ionic: enable tunnel offloads
    ionic: make rx fill threshold configurable
    ionic: tag all cmb ring & descriptor pointers with __iomem cookie
    ionic: new ionic device identity level and VF start control
    ionic: only save the user set VF attributes
    ionic: page cache for rx buffers
    ionic: Fix crash when reconfiguring queues multiple times
    ionic: memset fix for vf attr replay
    ionic: compat for new netif_napi_add() parameters in v6.1
    ionic: change order of devlink port register and netdev register
    ionic: use the new skb_tcp_all_headers()
    ionic: fix missing pci_release_regions() in probe error path
    ionic: swap the stats_pa value on replay
    ionic: only clean vf attrs when needed during replay
    ionic: Fix tunnel offload #ifdef checks
    ionic: add check for NULL t/rxqcqs in reconfig
    ionic: remove unnecessary CMB reconfig blockers
    ionic: fold CMB check into config check
    ionic: cmb toggle only returns err value
    ionic: allow queue reconfig while running in CMB mode
    ionic: CMB pages count in debugfs

Signed-off-by: Shannon Nelson <shannon.nelson@amd.com>