### PR TITLE
Update to 1.59.0-C-5

### DIFF
--- a/drivers/linux/pciesvc/README.md
+++ b/drivers/linux/pciesvc/README.md
@@ -20,3 +20,4 @@ specify on the make command line with "make KDIR=/path/to/kernel".
 ## History
 
 2022-12-02 - initial version
+2023-02-20 - Update to 1.59.0-C-5

--- a/drivers/linux/pciesvc/pciesvc/include/virtio_spec.h
+++ b/drivers/linux/pciesvc/pciesvc/include/virtio_spec.h
@@ -69,6 +69,8 @@ typedef struct virtio_pci_common_cfg {
             virtio_pci_feature_cfg_t driver_feature_cfg[VIRTIO_PCI_FEATURE_SELECT_COUNT];
             /* pciemgr observed device status nonzero -> zero */
             uint8_t need_reset;
+	    /* for checking status transitions */
+	    uint8_t device_status_prev;
         };
     };
 } __attribute__((packed)) virtio_pci_common_cfg_t;
@@ -151,6 +153,11 @@ enum {
     VIRTIO_NET_F_RSS_EXT                = (1ull << 61),
     VIRTIO_NET_F_STANDBY                = (1ull << 62),
     VIRTIO_NET_F_SPEED_DUPLEX           = (1ull << 63),
+};
+
+enum {
+    VIRTIO_NET_S_LINK_UP                = 1,  // e.g. BIT(0)
+    VIRTIO_NET_S_ANNOUNCE               = 2,  // e.g. BIT(1)
 };
 
 /* 6 - reserved feature bits */

--- a/drivers/linux/pciesvc/pciesvc/src/virtio.c
+++ b/drivers/linux/pciesvc/pciesvc/src/virtio.c
@@ -50,15 +50,6 @@
         pciesvc_mem_wr(addr, &val, VIRTIO_DEV_REG_SZ(fld));             \
         break;
 
-#define VIRTIO_DEV_REG_WR_COND(fld, cond)                               \
-        case VIRTIO_DEV_REG_OFF(fld):                                              \
-            pciesvc_logdebug("%s: write %s addr "FMT64X" off "FMT64U" size "FMT64S" val "FMT64X" cond %u", \
-                pciehwdev_get_name(phwdev), #fld, addr, baroff, size, val, cond);  \
-            if (cond) {                                                            \
-                pciesvc_mem_wr(addr, &val, VIRTIO_DEV_REG_SZ(fld));                \
-            }                                                                      \
-            break;
-
 #define VIRTIO_DEV_REG_WR_PROC(fld, proc)                               \
         case VIRTIO_DEV_REG_OFF(fld):                                              \
             pciesvc_logdebug("%s: write %s addr "FMT64X" off "FMT64U" size "FMT64S" val "FMT64X" proc %s", \
@@ -100,8 +91,6 @@
                              pciehwdev_get_name(phwdev), #fld, idx,     \
                              VIRTIO_DEV_REG_ADDR(base, arr_fld),        \
                              baroff, size, val);                        \
-            pciesvc_mem_wr(VIRTIO_DEV_REG_ADDR(base, arr_fld),          \
-                           &val, VIRTIO_DEV_REG_SZ(arr_fld));           \
         } else {                                                        \
             pciesvc_logerror("%s: write %s["FMT64U"] addr "FMT64X" off "FMT64U" size "FMT64S" val "FMT64X" ignore (out of bounds)",\
                              pciehwdev_get_name(phwdev), #fld, idx,     \


### PR DESCRIPTION
Overview
virtio register improvements for features, status
preserve MaxPayload setting across FLR resets

Internal patch list:
- vdpa: fix up use of virtio BAR config for device_status and virtio_net_config
- virtio: Fixes around features and status bits
- pciesvc: preserve MaxPayload setting across FLR resets