### PR TITLE
Update pciesvc to 1.63.0-C-8

### DIFF
--- a/drivers/linux/pciesvc/README.md
+++ b/drivers/linux/pciesvc/README.md
@@ -21,3 +21,4 @@ specify on the make command line with "make KDIR=/path/to/kernel".
 
 2022-12-02 - initial version
 2023-02-20 - Update to 1.59.0-C-5
+2023-05-08 - Update to 1.63.0-C-8

--- a/drivers/linux/pciesvc/pciesvc/include/pcieshmem.h
+++ b/drivers/linux/pciesvc/pciesvc/include/pcieshmem.h
@@ -94,6 +94,7 @@ typedef union pciehwdev_u {
         u_int16_t pf:1;                 /* is pf */
         u_int16_t vf:1;                 /* is vf */
         u_int16_t flexvf:1;             /* is flexvf */
+        u_int16_t msix_en:1;            /* msix enabled for this dev */
         u_int16_t totalvfs;             /* totalvfs provisioned */
         u_int16_t numvfs;               /* current numvfs */
         u_int16_t vfidx;                /* if is vf, vf position */

--- a/drivers/linux/pciesvc/pciesvc/include/pciesvc.h
+++ b/drivers/linux/pciesvc/pciesvc/include/pciesvc.h
@@ -22,7 +22,7 @@ extern "C" {
 #include "pciesvc_cmd.h"
 
 #define PCIESVC_VERSION_MAJ     3
-#define PCIESVC_VERSION_MIN     1
+#define PCIESVC_VERSION_MIN     2
 
 typedef struct pciesvc_params_v0_s {
     int         port;                   /* port to config */

--- a/drivers/linux/pciesvc/pciesvc/src/bar.c
+++ b/drivers/linux/pciesvc/pciesvc/src/bar.c
@@ -109,7 +109,7 @@ pciehw_barrd_notify(const int port, notify_entry_t *nentry)
 {
     const tlpauxinfo_t *info = &nentry->info;
     const pciehw_spmt_t *spmt = pciesvc_spmt_get(info->pmti);
-    pciehwdev_t *phwdev = pciehwdev_get(spmt->owner);
+    pciehwdev_t *phwdev = pciehwdev_get(spmt->owner + info->vfid);
     pcie_stlp_t stlpbuf, *stlp = &stlpbuf;
 
     pcietlp_decode(stlp, nentry->rtlp, sizeof(nentry->rtlp));
@@ -126,7 +126,7 @@ pciehw_barwr_notify(const int port, notify_entry_t *nentry)
 {
     const tlpauxinfo_t *info = &nentry->info;
     const pciehw_spmt_t *spmt = pciesvc_spmt_get(info->pmti);
-    pciehwdev_t *phwdev = pciehwdev_get(spmt->owner);
+    pciehwdev_t *phwdev = pciehwdev_get(spmt->owner + info->vfid);
     pcie_stlp_t stlpbuf, *stlp = &stlpbuf;
 
     pcietlp_decode(stlp, nentry->rtlp, sizeof(nentry->rtlp));
@@ -143,7 +143,7 @@ pciehw_barrd_indirect(const int port, indirect_entry_t *ientry)
 {
     const tlpauxinfo_t *info = &ientry->info;
     const pciehw_spmt_t *spmt = pciesvc_spmt_get(info->pmti);
-    pciehwdev_t *phwdev = pciehwdev_get(spmt->owner);
+    pciehwdev_t *phwdev = pciehwdev_get(spmt->owner + info->vfid);
     const pciehwbar_t *phwbar = pciehw_bar_get(phwdev, spmt->cfgidx);
 
     switch (phwbar->hnd) {
@@ -197,7 +197,7 @@ pciehw_barwr_indirect(const int port, indirect_entry_t *ientry)
 {
     const tlpauxinfo_t *info = &ientry->info;
     const pciehw_spmt_t *spmt = pciesvc_spmt_get(info->pmti);
-    pciehwdev_t *phwdev = pciehwdev_get(spmt->owner);
+    pciehwdev_t *phwdev = pciehwdev_get(spmt->owner + info->vfid);
     const pciehwbar_t *phwbar = pciehw_bar_get(phwdev, spmt->cfgidx);
     pcie_stlp_t stlpbuf, *stlp = &stlpbuf;
 

--- a/drivers/linux/pciesvc/pciesvc/src/cfg.c
+++ b/drivers/linux/pciesvc/pciesvc/src/cfg.c
@@ -531,6 +531,7 @@ pciehw_cfgwr_msix(const handler_ctx_t *hctx)
     msix_mask = (msixctl & PCI_MSIX_FLAGS_MASKALL) != 0;
 
     phwdev = pciehwdev_get(hctx->hwdevh);
+    phwdev->msix_en = msix_en;
 
     if (msix_en) {
         /* msix mode */

--- a/drivers/linux/pciesvc/pciesvc/src/pciesvc_impl.h
+++ b/drivers/linux/pciesvc/pciesvc/src/pciesvc_impl.h
@@ -304,6 +304,12 @@ rounddn_power2(u_int64_t n)
     return roundup_power2(n + 1) >> 1;
 }
 
+static inline u_int64_t
+align_to(u_int64_t n, u_int64_t align)
+{
+	return (n + align - 1) & ~(align - 1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/linux/pciesvc/pciesvc/src/prt.c
+++ b/drivers/linux/pciesvc/pciesvc/src/prt.c
@@ -57,9 +57,13 @@ prt_alloc(const int n)
 void
 prt_free(const int prtb, const int prtc)
 {
+    pciehw_shmem_t *pshmem = pciesvc_shmem_get();
+
     assert_prts_in_range(prtb, prtc);
 
-    if (prtc == PRT_SLAB_SIZE) {
+    if ((prtb + prtc) ==  pshmem->allocprt) {
+        pshmem->allocprt -= prtc;
+    } else if (prtc == PRT_SLAB_SIZE) {
         pciehw_shmem_t *pshmem = pciesvc_shmem_get();
         pciehw_sprt_t *sprt;
 
@@ -68,7 +72,8 @@ prt_free(const int prtb, const int prtc)
         pciesvc_sprt_put(sprt, DIRTY);
         pshmem->freeprt_slab = prtb;
     } else {
-        /* XXX */
+        pciesvc_logerror("prt_free: leak prt %d (%d), allocprt %d\n",
+                          prtb, prtc, pshmem->allocprt);
     }
 }
 


### PR DESCRIPTION
Overview
Improved error handling during resource allocation. Virtio enhancements, preliminary legacy device support. Bump pciesvc version to 3.2 (was 3.1).

Internal patch list:
- Handle the device, PMT and PRT alloc error in finalize (#61332)
- virtio: Updates for PCI, OPROM, CVQ, crash recovery (#62484)
- virtio: CVQ queue id, crash recovery support (#63210)
- pciemgrd: virtio sriov scale (#63779)
- pciemgrd: fix pmt leak in pmt_free (#63911)
- virtio: Logging levels, edmaq return codes (#64053)
- virtio: Partial legacy device support (#64431)
- Salina athena (#64820)
- Eth and Virtio devices recovery support, istate implementation (#64739)
- virtio: move cvq crash recovery data from common regs to istate (#65304)
- pciesvc: version to 3.2 (#66013)