### PR TITLE
dsc-drivers: update ionic drivers to 23.07.1-001

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,11 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - code cleaning to better match upstream code
  - module parameter to set DMA mask at load time
  - bug fixes
+
+2023-07-25 - driver update for 23.07.1-001
+ - kcompat update for RHEL 8.8
+ - add FLR handling
+ - add new ethtool extended stat link_down_count
+ - add custom Dynamic IRQ Moderation profile
+ - fix a use-after-free issue seen on ARM
+ - replace WARN_ON with dev_warn()

--- a/drivers/common/ionic_if.h
+++ b/drivers/common/ionic_if.h
@@ -9,6 +9,7 @@
 #define IONIC_IFNAMSIZ				16
 
 #ifdef __CHECKER__
+#define IONIC_SIZE_CHECK(type, N, X)
 #define IONIC_CHECK_CMD_LENGTH(X)
 #define IONIC_CHECK_COMP_LENGTH(X)
 #define IONIC_CHECK_CMD_DATA_LENGTH(X)
@@ -280,17 +281,41 @@ struct ionic_dev_identify_comp {
 };
 
 enum ionic_debug_type {
-	IONIC_DEBUG_TYPE_MSG   = 1,
+	IONIC_DEBUG_TYPE_MSG     = 1,
+	IONIC_DEBUG_TYPE_STATS   = 2,
 };
+
+/**
+ * struct ionic_dev_debug_stats - Driver/device debug stats struct
+ * @fld:	A string specifying the field name
+ * @cnt:	Counter value for the field
+ */
+struct ionic_dev_debug_stats {
+	char     fld[56];
+	uint64_t cnt;
+} __attribute__((packed));
+IONIC_SIZE_CHECK(struct, 64, ionic_dev_debug_stats);
+
 /**
  * struct ionic_dev_debug_cmd - Driver/device debug command
- * @opcode:  opcode
- * @type:    debug_type (enum ionic_debug_type)
+ * @opcode:	opcode
+ * @type:	debug_type (enum ionic_debug_type)
+ * @stats:	Debug stats region properties
+ * 		@count:		Number of (field, cnt) pairs
+ * 		@stats_pa:	Physical address of the debug stats region
  */
 struct ionic_dev_debug_cmd {
 	u8 opcode;
 	u8 debug_type;
-	u8 rsvd[62];
+	u8 rsvd[6];
+	union {
+		struct {
+			__le16 count;
+			u8 rsvd2[6];
+			__le64 stats_pa;
+		} stats;
+	};
+	u8 rsvd3[40];
 };
 IONIC_CHECK_CMD_LENGTH(ionic_dev_debug_cmd);
 

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -69,7 +69,7 @@ ALL = eth
 endif
 
 ifeq ($(DVER),)
-    DVER = "23.04.1-001"
+    DVER = "23.07.1-001"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 
@@ -82,6 +82,7 @@ KBUILD_RULE = $(MAKE) -C $(KSRC) $(KOPT) M=$(CURDIR)
 mnic: KOPT+=$(ETH_KOPT)
 mnic:
 	@echo "===> Building MNIC driver "
+	mkdir -p $(KMOD_OUT_DIR)
 	touch $(KMOD_OUT_DIR)/Makefile
 	$(MAKE) -C $(KSRC) V=1 M=$(KMOD_OUT_DIR) src=$(KMOD_SRC_DIR)/eth/ionic $(KOPT)
 	mv ${KMOD_OUT_DIR}/Module.symvers ${KMOD_OUT_DIR}/Module.symvers.mnic
@@ -99,16 +100,25 @@ mdev:
 
 eth: KOPT+=$(ETH_KOPT)
 eth:
-	$(KBUILD_RULE)
+	+$(KBUILD_RULE)
 
 clean: KOPT+=$(ETH_KOPT)
 clean:
 	$(KBUILD_RULE) clean
 
+KBUILD_INSTALL_RULE = $(MAKE) -C $(KSRC) $(KOPT) \
+		      $(if ${DISABLE_MODULE_SIGNING},CONFIG_MODULE_SIG=n) \
+		      $(if ${DISABLE_MODULE_SIGNING},CONFIG_MODULE_SIG_ALL=) \
+		      INSTALL_MOD_DIR=updates \
+		      M=$(CURDIR)
+
 install: modules_install
 modules_install: KOPT+=$(ETH_KOPT)
 modules_install:
-	$(KBUILD_RULE) modules_install
+	@$(call warn_signed_modules)
+	$(KBUILD_INSTALL_RULE) modules_install
+	$(call cmd_depmod)
+	$(call cmd_initramfs)
 
 cscope:
 	find $(IONIC_ETH_SRC) -name '*.[ch]' > cscope.files

--- a/drivers/linux/eth/ionic/ionic_bus.h
+++ b/drivers/linux/eth/ionic/ionic_bus.h
@@ -15,6 +15,9 @@ void __iomem *ionic_bus_map_dbpage(struct ionic *ionic, int page_num);
 void ionic_bus_unmap_dbpage(struct ionic *ionic, void __iomem *page);
 phys_addr_t ionic_bus_phys_dbpage(struct ionic *ionic, int page_num);
 
+void ionic_reset_prepare(struct pci_dev *pdev);
+void ionic_reset_done(struct pci_dev *pdev);
+
 static inline bool ionic_bus_dbpage_per_pid(struct ionic *ionic)
 {
 	return ionic->pdev;

--- a/drivers/linux/eth/ionic/ionic_bus_pci.c
+++ b/drivers/linux/eth/ionic/ionic_bus_pci.c
@@ -272,6 +272,92 @@ out:
 	return ret;
 }
 
+static void ionic_clear_pci(struct ionic *ionic)
+{
+	ionic_unmap_bars(ionic);
+	pci_release_regions(ionic->pdev);
+	pci_disable_device(ionic->pdev);
+}
+
+static int ionic_setup_one(struct ionic *ionic)
+{
+	struct pci_dev *pdev = ionic->pdev;
+	struct device *dev = ionic->dev;
+	int err;
+
+	ionic_debugfs_add_dev(ionic);
+
+	/* Setup PCI device */
+	err = pci_enable_device_mem(pdev);
+	if (err) {
+		dev_err(dev, "Cannot enable PCI device: %d, aborting\n", err);
+		goto err_out_debugfs_del_dev;
+	}
+
+	err = pci_request_regions(pdev, IONIC_DRV_NAME);
+	if (err) {
+		dev_err(dev, "Cannot request PCI regions: %d, aborting\n", err);
+		goto err_out_clear_pci;
+	}
+	pcie_print_link_status(pdev);
+
+	err = ionic_map_bars(ionic);
+	if (err)
+		goto err_out_clear_pci;
+
+	pci_set_master(pdev);
+
+	/* Configure the device */
+	err = ionic_setup(ionic);
+	if (err) {
+		dev_err(dev, "Cannot setup device: %d, aborting\n", err);
+		goto err_out_clear_pci;
+	}
+
+	err = ionic_identify(ionic);
+	if (err) {
+		dev_err(dev, "Cannot identify device: %d, aborting\n", err);
+		goto err_out_teardown;
+	}
+	ionic_debugfs_add_ident(ionic);
+
+	err = ionic_init(ionic);
+	if (err) {
+		dev_err(dev, "Cannot init device: %d, aborting\n", err);
+		goto err_out_teardown;
+	}
+
+	/* Configure the port */
+	ionic_port_reset(ionic);
+	if (err) {
+		dev_err(dev, "Cannot reset port: %d, aborting\n", err);
+		goto err_out_teardown;
+	}
+
+	err = ionic_port_identify(ionic);
+	if (err) {
+		dev_err(dev, "Cannot identify port: %d, aborting\n", err);
+		goto err_out_teardown;
+	}
+
+	err = ionic_port_init(ionic);
+	if (err) {
+		dev_err(dev, "Cannot init port: %d, aborting\n", err);
+		goto err_out_teardown;
+	}
+
+	return 0;
+
+err_out_teardown:
+	ionic_dev_teardown(ionic);
+err_out_clear_pci:
+	ionic_clear_pci(ionic);
+err_out_debugfs_del_dev:
+	ionic_debugfs_del_dev(ionic);
+
+	return err;
+}
+
 static int ionic_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 {
 	struct device *dev = &pdev->dev;
@@ -296,68 +382,20 @@ static int ionic_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 	if (err) {
 		dev_err(dev, "Unable to obtain 64-bit DMA for consistent allocations, aborting.  err=%d\n",
 			err);
-		goto err_out_clear_drvdata;
+		goto err_out;
 	}
 
-	ionic_debugfs_add_dev(ionic);
-
-	/* Setup PCI device */
-	err = pci_enable_device_mem(pdev);
-	if (err) {
-		dev_err(dev, "Cannot enable PCI device: %d, aborting\n", err);
-		goto err_out_debugfs_del_dev;
-	}
-
-	err = pci_request_regions(pdev, IONIC_DRV_NAME);
-	if (err) {
-		dev_err(dev, "Cannot request PCI regions: %d, aborting\n", err);
-		goto err_out_pci_disable_device;
-	}
-	pcie_print_link_status(pdev);
-
-	err = ionic_map_bars(ionic);
+	err = ionic_setup_one(ionic);
 	if (err)
-		goto err_out_pci_release_regions;
+		goto err_out;
 
-	/* Configure the device */
-	err = ionic_setup(ionic);
-	if (err) {
-		dev_err(dev, "Cannot setup device: %d, aborting\n", err);
-		goto err_out_unmap_bars;
-	}
-	pci_set_master(pdev);
-
-	err = ionic_identify(ionic);
-	if (err) {
-		dev_err(dev, "Cannot identify device: %d, aborting\n", err);
-		goto err_out_teardown;
-	}
-	ionic_debugfs_add_ident(ionic);
-
-	err = ionic_init(ionic);
-	if (err) {
-		dev_err(dev, "Cannot init device: %d, aborting\n", err);
-		goto err_out_teardown;
-	}
-
-	/* Configure the ports */
-	err = ionic_port_identify(ionic);
-	if (err) {
-		dev_err(dev, "Cannot identify port: %d, aborting\n", err);
-		goto err_out_reset;
-	}
-
-	err = ionic_port_init(ionic);
-	if (err) {
-		dev_err(dev, "Cannot init port: %d, aborting\n", err);
-		goto err_out_reset;
-	}
+	pci_save_state(pdev);
 
 	/* Allocate and init the LIF */
 	err = ionic_lif_size(ionic);
 	if (err) {
 		dev_err(dev, "Cannot size LIF: %d, aborting\n", err);
-		goto err_out_port_reset;
+		goto err_out_pci;
 	}
 
 	err = ionic_lif_alloc(ionic);
@@ -408,26 +446,9 @@ err_out_free_lifs:
 	ionic->lif = NULL;
 err_out_free_irqs:
 	ionic_bus_free_irq_vectors(ionic);
-err_out_port_reset:
-	ionic_port_reset(ionic);
-err_out_reset:
-	ionic_reset(ionic);
-err_out_teardown:
-	ionic_dev_teardown(ionic);
-	/* Don't fail the probe for these errors, keep
-	 * the hw interface around for inspection
-	 */
-	return 0;
-
-err_out_unmap_bars:
-	ionic_unmap_bars(ionic);
-err_out_pci_release_regions:
-	pci_release_regions(pdev);
-err_out_pci_disable_device:
-	pci_disable_device(pdev);
-err_out_debugfs_del_dev:
-	ionic_debugfs_del_dev(ionic);
-err_out_clear_drvdata:
+err_out_pci:
+	ionic_clear_pci(ionic);
+err_out:
 	mutex_destroy(&ionic->dev_cmd_lock);
 	ionic_devlink_free(ionic);
 	pci_set_drvdata(pdev, NULL);
@@ -456,13 +477,78 @@ static void ionic_remove(struct pci_dev *pdev)
 	ionic_port_reset(ionic);
 	ionic_reset(ionic);
 	ionic_dev_teardown(ionic);
-	ionic_unmap_bars(ionic);
-	pci_release_regions(pdev);
-	pci_disable_device(pdev);
+	ionic_clear_pci(ionic);
 	ionic_debugfs_del_dev(ionic);
 	mutex_destroy(&ionic->dev_cmd_lock);
 	ionic_devlink_free(ionic);
 }
+
+void ionic_reset_prepare(struct pci_dev *pdev)
+{
+	struct ionic *ionic = pci_get_drvdata(pdev);
+	struct ionic_lif *lif = ionic->lif;
+
+	dev_info(ionic->dev, "Device stopping\n");
+
+	/* Stop the timer first so it can't re-schedule more work, but note
+	 * that there is a small chance the device could send an
+	 * IONIC_EVENT_RESET, which could cause another work item to be
+	 * scheduled and render these del/cancel calls useless (i.e. don't mix
+	 * device triggered resets with userspace triggered resets).
+	 */
+	del_timer_sync(&ionic->watchdog_timer);
+	cancel_work_sync(&lif->deferred.work);
+
+	mutex_lock(&lif->queue_lock);
+	ionic_stop_queues_reconfig(lif);
+	ionic_txrx_free(lif);
+	ionic_lif_deinit(lif);
+	ionic_qcqs_free(lif);
+	mutex_unlock(&lif->queue_lock);
+
+	ionic_dev_teardown(ionic);
+	ionic_clear_pci(ionic);
+	ionic_debugfs_del_dev(ionic);
+
+	dev_info(ionic->dev, "Device stopped\n");
+}
+
+void ionic_reset_done(struct pci_dev *pdev)
+{
+	struct ionic *ionic = pci_get_drvdata(pdev);
+	struct ionic_lif *lif = ionic->lif;
+	int err;
+
+	dev_info(ionic->dev, "Device recover started\n");
+
+	err = ionic_setup_one(ionic);
+	if (err)
+		goto err_out;
+
+	pci_restore_state(pdev);
+	pci_save_state(pdev);
+
+	ionic_debugfs_add_sizes(ionic);
+	ionic_debugfs_add_lif(ionic->lif);
+
+	err = ionic_restart_lif(lif);
+	if (err)
+		goto err_out;
+
+	mod_timer(&ionic->watchdog_timer, jiffies + 1);
+
+err_out:
+	dev_info(ionic->dev, "Device recovery %s\n",
+		 err ? "failed" : "done");
+}
+
+#if (KERNEL_VERSION(4, 13, 0) <= LINUX_VERSION_CODE)
+static const struct pci_error_handlers ionic_err_handler = {
+	/* FLR handling */
+	.reset_prepare      = ionic_reset_prepare,
+	.reset_done         = ionic_reset_done,
+};
+#endif
 
 static struct pci_driver ionic_driver = {
 	.name = IONIC_DRV_NAME,
@@ -470,6 +556,9 @@ static struct pci_driver ionic_driver = {
 	.probe = ionic_probe,
 	.remove = ionic_remove,
 	.sriov_configure = ionic_sriov_configure,
+#if (KERNEL_VERSION(4, 13, 0) <= LINUX_VERSION_CODE)
+	.err_handler = &ionic_err_handler
+#endif
 };
 
 int ionic_bus_register_driver(void)

--- a/drivers/linux/eth/ionic/ionic_debugfs.c
+++ b/drivers/linux/eth/ionic/ionic_debugfs.c
@@ -359,6 +359,8 @@ void ionic_debugfs_add_qcq(struct ionic_lif *lif, struct ionic_qcq *qcq)
 				   &intr->vector);
 		debugfs_create_u32("dim_coal_hw", 0400, intr_dentry,
 				   &intr->dim_coal_hw);
+		debugfs_create_u16("dim_coal_usecs", 0400, intr_dentry,
+				   &intr->dim_coal_usecs);
 
 		intr_ctrl_regset = devm_kzalloc(dev, sizeof(*intr_ctrl_regset),
 						GFP_KERNEL);

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -289,6 +289,7 @@ struct ionic_intr_info {
 	unsigned int cpu;
 	cpumask_t affinity_mask;
 	u32 dim_coal_hw;
+	u16 dim_coal_usecs;
 };
 
 struct ionic_cq {

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -250,6 +250,7 @@ struct ionic_lif {
 	u64 hw_features;
 	unsigned int index;
 	unsigned int hw_index;
+	unsigned int link_down_count;
 
 	u8 rss_hash_key[IONIC_RSS_HASH_KEY_SIZE];
 	u8 *rss_ind_tbl;
@@ -456,7 +457,11 @@ int ionic_lif_addr_add(struct ionic_lif *lif, const u8 *addr);
 int ionic_lif_addr_del(struct ionic_lif *lif, const u8 *addr);
 
 struct ionic_lif *ionic_netdev_lif(struct net_device *netdev);
-void ionic_device_reset(struct ionic_lif *lif);
+
+void ionic_stop_queues_reconfig(struct ionic_lif *lif);
+void ionic_txrx_free(struct ionic_lif *lif);
+void ionic_qcqs_free(struct ionic_lif *lif);
+int ionic_restart_lif(struct ionic_lif *lif);
 
 #ifdef IONIC_DEBUG_STATS
 static inline void debug_stats_txq_post(struct ionic_queue *q, bool dbell)

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -36,6 +36,7 @@
 #include <asm/io.h>
 #include <linux/ethtool.h>
 #include <linux/if_vlan.h>
+#include <linux/dynamic_debug.h>
 
 #if IS_ENABLED(CONFIG_NET_DEVLINK)
 #include <net/devlink.h>
@@ -6822,7 +6823,10 @@ static inline struct devlink *_kc_devlink_alloc(const struct devlink_ops *ops,
 #endif /* 5.17 */
 
 /*****************************************************************************/
-#if (KERNEL_VERSION(6, 0, 0) > LINUX_VERSION_CODE)
+#if (KERNEL_VERSION(6, 0, 0) > LINUX_VERSION_CODE && \
+	(!RHEL_RELEASE_CODE || \
+	  RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8, 8) || \
+	 (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 0) && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9, 2))))
 static inline int skb_tcp_all_headers(const struct sk_buff *skb)
 {
 	return skb_transport_offset(skb) + tcp_hdrlen(skb);
@@ -6837,7 +6841,10 @@ static inline int skb_inner_tcp_all_headers(const struct sk_buff *skb)
 #endif /* 6.0 */
 
 /*****************************************************************************/
-#if (KERNEL_VERSION(6, 1, 0) > LINUX_VERSION_CODE)
+#if (KERNEL_VERSION(6, 1, 0) > LINUX_VERSION_CODE && \
+	(!RHEL_RELEASE_CODE || \
+	  RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8, 8) || \
+	 (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 0) && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9, 2))))
 
 #if (RHEL_RELEASE_CODE && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 0) && defined(netif_napi_add))
 #undef netif_napi_add


### PR DESCRIPTION
Update the ionic drivers to match version 23.07.1-001 

Internal patch list:
    ionic: remove noise from ethtool rxnfc error msg
    linux-ionic: Fix multiple defined issue on oot driver
    ionic: add support for ethtool extended stat link_down_count
    ionic: update link down count to exclude VF link state down
    ionic: Add debugfs entry for dim coalesce value in usecs
    ionic: Use a custom dim profile
    ionic: page reuse seems to be causing use-after-free on ARM.
    ionic: extract common bits from probe and remove
    ionic: pull out common bits from fw_up
    ionic: add FLR recovery support
    ionic: kcompat for RHEL 8.8
    ionic: remove WARN_ON
    ionic: Add script to install driver from source