### PR TITLE
dsc-drivers: update ionic drivers to 23.08.1-001

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,10 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - add custom Dynamic IRQ Moderation profile
  - fix a use-after-free issue seen on ARM
  - replace WARN_ON with dev_warn()
+
+2023-08-29 - driver update for 23.08.1-001
+ - updates to FLR handling
+ - improved handling of scatter-gather with TSO
+ - better error handling for ionic_start_queues_reconfig
+ - fix up initial coalesce_usec values
+ - various other small updates from upstream

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -69,7 +69,7 @@ ALL = eth
 endif
 
 ifeq ($(DVER),)
-    DVER = "23.07.1-001"
+    DVER = "23.08.1-001"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 

--- a/drivers/linux/eth/ionic/ionic_dev.c
+++ b/drivers/linux/eth/ionic/ionic_dev.c
@@ -487,22 +487,16 @@ int ionic_set_vf_config(struct ionic *ionic, int vf,
 	return err;
 }
 
-void ionic_vf_start(struct ionic *ionic, int vf)
+void ionic_vf_start(struct ionic *ionic)
 {
 #ifdef IONIC_DEV_IDENTITY_VERSION_2
 	union ionic_dev_cmd cmd = {
 		.vf_ctrl.opcode = IONIC_CMD_VF_CTRL,
+		.vf_ctrl.ctrl_opcode = IONIC_VF_CTRL_START_ALL,
 	};
 
 	if (!(ionic->ident.dev.capabilities & cpu_to_le64(IONIC_DEV_CAP_VF_CTRL)))
 		return;
-
-	if (vf == -1) {
-		cmd.vf_ctrl.ctrl_opcode = IONIC_VF_CTRL_START_ALL;
-	} else {
-		cmd.vf_ctrl.ctrl_opcode = IONIC_VF_CTRL_START;
-		cmd.vf_ctrl.vf_index = cpu_to_le16(vf);
-	}
 
 	ionic_dev_cmd_go(&ionic->idev, &cmd);
 	ionic_dev_cmd_wait(ionic, DEVCMD_TIMEOUT);

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -224,7 +224,7 @@ struct ionic_desc_info {
 	};
 	unsigned int bytes;
 	unsigned int nbufs;
-	struct ionic_buf_info bufs[IONIC_MAX_FRAGS];
+	struct ionic_buf_info bufs[MAX_SKB_FRAGS + 1];
 	ionic_desc_cb cb;
 	void *cb_arg;
 };
@@ -362,7 +362,7 @@ int ionic_set_vf_config(struct ionic *ionic, int vf,
 
 void ionic_dev_cmd_queue_identify(struct ionic_dev *idev,
 				  u16 lif_type, u8 qtype, u8 qver);
-void ionic_vf_start(struct ionic *ionic, int vf);
+void ionic_vf_start(struct ionic *ionic);
 void ionic_dev_cmd_lif_identify(struct ionic_dev *idev, u8 type, u8 ver);
 void ionic_dev_cmd_lif_init(struct ionic_dev *idev, u16 lif_index,
 			    dma_addr_t addr);

--- a/drivers/linux/eth/ionic/ionic_ethtool.c
+++ b/drivers/linux/eth/ionic/ionic_ethtool.c
@@ -640,7 +640,7 @@ static int ionic_set_coalesce(struct net_device *netdev,
 						     lif->rx_coalesce_hw);
 				lif->rxqcqs[i]->intr.dim_coal_hw = rx_dim;
 				lif->rxqcqs[i]->intr.dim_coal_usecs =
-					coalesce->rx_coalesce_usecs;
+							lif->rx_coalesce_usecs;
 			}
 
 			if (lif->txqcqs[i]->flags & IONIC_QCQ_F_INTR) {
@@ -649,7 +649,7 @@ static int ionic_set_coalesce(struct net_device *netdev,
 						     lif->tx_coalesce_hw);
 				lif->txqcqs[i]->intr.dim_coal_hw = tx_dim;
 				lif->txqcqs[i]->intr.dim_coal_usecs =
-					coalesce->tx_coalesce_usecs;
+							lif->tx_coalesce_usecs;
 			}
 		}
 	}
@@ -693,7 +693,8 @@ static int ionic_validate_cmb_config(struct ionic_lif *lif,
 
 	pages_have = lif->ionic->bars[IONIC_PCI_BAR_CMB].len / PAGE_SIZE;
 	if (pages_required > pages_have) {
-		netdev_info(lif->netdev, "Not enough CMB pages for number of queues and size of descriptor rings, need %d have %d",
+		netdev_info(lif->netdev,
+			    "Not enough CMB pages for number of queues and size of descriptor rings, need %d have %d",
 			    pages_required, pages_have);
 		return -ENOMEM;
 	}

--- a/drivers/linux/eth/ionic/ionic_lif.c
+++ b/drivers/linux/eth/ionic/ionic_lif.c
@@ -179,7 +179,7 @@ static void ionic_link_status_check(struct ionic_lif *lif)
 				netdev_err(netdev,
 					   "Failed to start queues: %d\n", err);
 				set_bit(IONIC_LIF_F_BROKEN, lif->state);
-				netif_carrier_off(netdev);
+				netif_carrier_off(lif->netdev);
 			}
 			mutex_unlock(&lif->queue_lock);
 		}
@@ -1864,7 +1864,7 @@ static int ionic_set_mac_address(struct net_device *netdev, void *sa)
 		return err;
 
 	if (err > 0)
-		netdev_dbg(netdev, "%s: SET and GET ATTR Mac is not equal-due to old FW running\n",
+		netdev_dbg(netdev, "%s: SET and GET ATTR Mac are not equal-due to old FW running\n",
 			   __func__);
 
 	err = eth_prepare_mac_addr_change(netdev, addr);
@@ -1910,6 +1910,20 @@ static int ionic_start_queues_reconfig(struct ionic_lif *lif)
 	return err;
 }
 
+static int ionic_check_valid_mtu(struct ionic_lif *lif, int new_mtu)
+{
+	int fs;
+
+	fs = new_mtu + ETH_HLEN + VLAN_HLEN;
+	if (fs < le32_to_cpu(lif->identity->eth.min_frame_size) ||
+	    fs > le32_to_cpu(lif->identity->eth.max_frame_size)) {
+		netdev_err(lif->netdev, "Invalid MTU %d\n", new_mtu);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int ionic_change_mtu(struct net_device *netdev, int new_mtu)
 {
 	struct ionic_lif *lif = netdev_priv(netdev);
@@ -1923,14 +1937,10 @@ static int ionic_change_mtu(struct net_device *netdev, int new_mtu)
 		},
 	};
 	int err;
-	int fs;
 
-	fs = new_mtu + ETH_HLEN + VLAN_HLEN;
-	if (fs < le32_to_cpu(lif->identity->eth.min_frame_size) ||
-	    fs > le32_to_cpu(lif->identity->eth.max_frame_size)) {
-		netdev_err(netdev, "Invalid MTU %d\n", new_mtu);
-		return -EINVAL;
-	}
+	err = ionic_check_valid_mtu(lif, new_mtu);
+	if (err)
+		return err;
 
 	err = ionic_adminq_post_wait(lif, &ctx);
 	if (err)
@@ -1957,6 +1967,7 @@ static int ionic_change_mtu(struct net_device *netdev, int new_mtu)
 static void ionic_tx_timeout_work(struct work_struct *ws)
 {
 	struct ionic_lif *lif = container_of(ws, struct ionic_lif, tx_timeout_work);
+	int err;
 
 	if (test_bit(IONIC_LIF_F_FW_RESET, lif->state))
 		return;
@@ -1969,8 +1980,11 @@ static void ionic_tx_timeout_work(struct work_struct *ws)
 
 	mutex_lock(&lif->queue_lock);
 	ionic_stop_queues_reconfig(lif);
-	ionic_start_queues_reconfig(lif);
+	err = ionic_start_queues_reconfig(lif);
 	mutex_unlock(&lif->queue_lock);
+
+	if (err)
+		dev_err(lif->ionic->dev, "%s: Restarting queues failed\n", __func__);
 }
 
 #ifdef HAVE_TX_TIMEOUT_TXQUEUE
@@ -2830,7 +2844,7 @@ static void ionic_vf_attr_replay(struct ionic_lif *lif)
 
 	up_read(&ionic->vf_op_lock);
 
-	ionic_vf_start(ionic, -1);
+	ionic_vf_start(ionic);
 }
 
 static const struct net_device_ops ionic_netdev_ops = {
@@ -2946,17 +2960,22 @@ static int ionic_cmb_reconfig(struct ionic_lif *lif,
 			if (err) {
 				dev_err(lif->ionic->dev,
 					"CMB restore failed: %d\n", err);
-				goto errout;
+				goto err_out;
 			}
 		}
 
-		ionic_start_queues_reconfig(lif);
-	} else {
-		/* This was detached in ionic_stop_queues_reconfig() */
-		netif_device_attach(lif->netdev);
+		err = ionic_start_queues_reconfig(lif);
+		if (err) {
+			dev_err(lif->ionic->dev,
+				"CMB reconfig failed: %d\n", err);
+			goto err_out;
+		}
 	}
 
-errout:
+err_out:
+	/* This was detached in ionic_stop_queues_reconfig() */
+	netif_device_attach(lif->netdev);
+
 	return err;
 }
 
@@ -3458,9 +3477,9 @@ int ionic_restart_lif(struct ionic_lif *lif)
 			goto err_txrx_free;
 	}
 
-	clear_bit(IONIC_LIF_F_FW_RESET, lif->state);
 	mutex_unlock(&lif->queue_lock);
 
+	clear_bit(IONIC_LIF_F_FW_RESET, lif->state);
 	ionic_link_status_check_request(lif, CAN_SLEEP);
 	netif_device_attach(lif->netdev);
 
@@ -4008,6 +4027,18 @@ static void ionic_lif_queue_identify(struct ionic_lif *lif)
 			qtype, qti->max_sg_elems);
 		dev_dbg(ionic->dev, " qtype[%d].sg_desc_stride = %d\n",
 			qtype, qti->sg_desc_stride);
+
+		if (qti->max_sg_elems >= IONIC_MAX_FRAGS) {
+			qti->max_sg_elems = IONIC_MAX_FRAGS - 1;
+			dev_dbg(ionic->dev, "limiting qtype %d max_sg_elems to IONIC_MAX_FRAGS-1 %d\n",
+				qtype, qti->max_sg_elems);
+		}
+
+		if (qti->max_sg_elems > MAX_SKB_FRAGS) {
+			qti->max_sg_elems = MAX_SKB_FRAGS;
+			dev_dbg(ionic->dev, "limiting qtype %d max_sg_elems to MAX_SKB_FRAGS %d\n",
+				qtype, qti->max_sg_elems);
+		}
 	}
 }
 

--- a/drivers/linux/eth/ionic/ionic_txrx.c
+++ b/drivers/linux/eth/ionic/ionic_txrx.c
@@ -180,9 +180,38 @@ static void ionic_rx_cache_drain(struct ionic_queue *q)
 	stats->cache_full = 0;
 }
 
+static bool ionic_rx_buf_reuse(struct ionic_queue *q,
+			       struct ionic_buf_info *buf_info, u32 used)
+{
+	struct ionic_rx_stats *stats = q_to_rx_stats(q);
+	u32 size;
+
+	if (!dev_page_is_reusable(buf_info->page)) {
+		stats->buf_not_reusable++;
+		return false;
+	}
+
+	size = ALIGN(used, IONIC_PAGE_SPLIT_SZ);
+	buf_info->page_offset += size;
+	if (buf_info->page_offset >= IONIC_PAGE_SIZE) {
+		buf_info->page_offset = 0;
+		stats->buf_exhausted++;
+		return false;
+	}
+
+	stats->buf_reused++;
+
+	get_page(buf_info->page);
+
+	return true;
+}
+
 static void ionic_rx_buf_complete(struct ionic_queue *q,
 				  struct ionic_buf_info *buf_info, u32 used)
 {
+	if (ionic_rx_buf_reuse(q, buf_info, used))
+		return;
+
 	if (!ionic_rx_cache_put(q, buf_info)) {
 #ifndef HAVE_STRUCT_DMA_ATTRS
 		dma_unmap_page_attrs(q->dev, buf_info->dma_addr, IONIC_PAGE_SIZE,
@@ -1383,25 +1412,84 @@ static int ionic_tx(struct ionic_queue *q, struct sk_buff *skb)
 static int ionic_tx_descs_needed(struct ionic_queue *q, struct sk_buff *skb)
 {
 	struct ionic_tx_stats *stats = q_to_tx_stats(q);
+	bool too_many_frags = false;
+	skb_frag_t *frag;
+	int desc_bufs;
+	int chunk_len;
+	int frag_rem;
+	int tso_rem;
+	int seg_rem;
+	bool encap;
+	int hdrlen;
 	int ndescs;
 	int err;
 
 	/* Each desc is mss long max, so a descriptor for each gso_seg */
-	if (skb_is_gso(skb))
+	if (skb_is_gso(skb)) {
 		ndescs = skb_shinfo(skb)->gso_segs;
-	else
+	} else {
 		ndescs = 1;
+		if (skb_shinfo(skb)->nr_frags > q->max_sg_elems) {
+			too_many_frags = true;
+			goto linearize;
+		}
+	}
 
-	/* If non-TSO, just need 1 desc and nr_frags sg elems */
-	if (skb_shinfo(skb)->nr_frags <= q->max_sg_elems)
+	/* If non-TSO, or no frags to check, we're done */
+	if (!skb_is_gso(skb) || !skb_shinfo(skb)->nr_frags)
 		return ndescs;
 
-	/* Too many frags, so linearize */
-	err = skb_linearize(skb);
-	if (err)
-		return err;
+	/* We need to scan the skb to be sure that none of the MTU sized
+	 * packets in the TSO will require more sgs per descriptor than we
+	 * can support.  We loop through the frags, add up the lengths for
+	 * a packet, and count the number of sgs used per packet.
+	 */
+	tso_rem = skb->len;
+	frag = skb_shinfo(skb)->frags;
+	encap = skb->encapsulation;
 
-	stats->linearize++;
+	/* start with just hdr in first part of first descriptor */
+	if (encap)
+		hdrlen = skb_inner_tcp_all_headers(skb);
+	else
+		hdrlen = skb_tcp_all_headers(skb);
+	seg_rem = min_t(int, tso_rem, hdrlen + skb_shinfo(skb)->gso_size);
+	frag_rem = hdrlen;
+
+	while (tso_rem > 0) {
+		desc_bufs = 0;
+		while (seg_rem > 0) {
+			desc_bufs++;
+
+			/* We add the +1 because we can take buffers for one
+			 * more than we have SGs: one for the initial desc data
+			 * in addition to the SG segments that might follow.
+			 */
+			if (desc_bufs > q->max_sg_elems + 1) {
+				too_many_frags = true;
+				goto linearize;
+			}
+
+			if (frag_rem == 0) {
+				frag_rem = skb_frag_size(frag);
+				frag++;
+			}
+			chunk_len = min(frag_rem, seg_rem);
+			frag_rem -= chunk_len;
+			tso_rem -= chunk_len;
+			seg_rem -= chunk_len;
+		}
+
+		seg_rem = min_t(int, tso_rem, skb_shinfo(skb)->gso_size);
+	}
+
+linearize:
+	if (too_many_frags) {
+		err = skb_linearize(skb);
+		if (err)
+			return err;
+		stats->linearize++;
+	}
 
 	return ndescs;
 }


### PR DESCRIPTION
Update the drivers to match 23.08.1-001
Internal patch list:
    ionic: update FLR handling from upstream comments
    ionic: other upstream diffs to catch up to
    ionic: fix up initial coalesce_usec values
    ionic: more FLR catchup from upstream comments
    ionic: count SGs in packet to minimize linearize
    ionic: add a check for max SGs and SKB frags
    ionic: expand the descriptor bufs array
    ionic: Add function ionic_check_valid_mtu
    ionic: Add missing err handling for ionic_start_queues_reconfig
    Revert "ionic: page reuse seems to be causing use-after-free on ARM."