### PR TITLE
pciesvc: update to 1.65-C-35

### DIFF
--- a/drivers/linux/pciesvc/Makefile
+++ b/drivers/linux/pciesvc/Makefile
@@ -20,23 +20,37 @@ INCLUDES = -I$(PWD) \
 $(MODNAME)-y := $(kpci) kpcimgr_module.o kpcinterface.o kpci_entry.o \
 		kpci_kexec.o kpci_test.o pciesvc_end.o
 
-
 KDIR := /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)
 UTS := X$(shell grep UTS_RELEASE $(KDIR)/include/generated/utsrelease.h)
 REL := $(shell echo $(UTS) | awk '{ print $$3 }' | sed -e 's/"//g')
 
+# For older toolchains override with "make CC_HAS_NO_STORE_MERGING=0 ..."
+CC_HAS_NO_STORE_MERGING = 1
+
 KCFLAGS = -fno-jump-tables -fno-stack-protector -fno-function-sections
-KCFLAGS += -fno-data-sections -fno-store-merging -mstrict-align
+KCFLAGS += -fno-data-sections -mstrict-align
+ifeq ($(CC_HAS_NO_STORE_MERGING),1)
+KCFLAGS += -fno-store-merging
+endif
 KCFLAGS += $(INCLUDES) -DASIC_ELBA -DPCIESVC_SYSTEM_EXTERN
 KOPT = KCFLAGS="$(KCFLAGS)"
 
-all:
+all: pciesvc.ko pciesvc_upg.ko
+
+buildmod:
 	$(MAKE) -C $(KDIR) M=$(PWD) $(KOPT) modules
 	@mkdir -p $(REL)
 	@mv $(patsubst %.o,%.ko,$(obj-m)) $(REL)
 	@echo Checking for illegal relocations...
 	tools/reloc_check $(REL)/$(MODNAME).ko
 
+pciesvc.ko:
+	$(MAKE) buildmod MODNAME=pciesvc
+
+pciesvc_upg.ko:
+	$(MAKE) buildmod MODNAME=pciesvc_upg
+
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean
+	$(RM) -r $(REL)

--- a/drivers/linux/pciesvc/README.md
+++ b/drivers/linux/pciesvc/README.md
@@ -22,3 +22,5 @@ specify on the make command line with "make KDIR=/path/to/kernel".
 2022-12-02 - initial version
 2023-02-20 - Update to 1.59.0-C-5
 2023-05-08 - Update to 1.63.0-C-8
+2023-06-23 - Update to 1.65-C-6
+2023-09-22 - Update to 1.65-C-35

--- a/drivers/linux/pciesvc/kpci_test.c
+++ b/drivers/linux/pciesvc/kpci_test.c
@@ -174,7 +174,7 @@ void kpcimgr_report_stats(kstate_t *ks, int phase, int always, int rightnow)
 	if (!always && (now - last_call) < 5 * TICKS_PER_SEC)
 		return;
 
-	p = &pshmem->port[0];
+	p = PSHMEM_ADDR_FIELD(pshmem, port[0]);
 	s = &p->stats;
 	cfgrd = s->ind_cfgrd - ks->ind_cfgrd;
 	cfgwr = s->ind_cfgwr - ks->ind_cfgwr;

--- a/drivers/linux/pciesvc/kpcimgr_module.c
+++ b/drivers/linux/pciesvc/kpcimgr_module.c
@@ -14,10 +14,15 @@
 #include <linux/module.h>
 #include <linux/ctype.h>
 
-MODULE_LICENSE("GPL");
-
 #include "kpcimgr_api.h"
+#include "pciesvc.h"
 #include "version.h"
+
+MODULE_LICENSE("GPL");
+MODULE_VERSION(__stringify(PCIESVC_VERSION_MAJ) "."
+	       __stringify(PCIESVC_VERSION_MIN));
+MODULE_INFO(build, PCIESVC_VERSION);
+MODULE_INFO(intree, "Y"); /* no out-of-tree module taints kernel */
 
 static int relocate = 0;
 #ifdef DEBUG_KPCIMGR

--- a/drivers/linux/pciesvc/pciesvc/include/pciehw.h
+++ b/drivers/linux/pciesvc/pciesvc/include/pciehw.h
@@ -14,7 +14,15 @@ extern "C" {
 #endif
 
 #define PCIEHW_NPORTS   8
+/*
+#ifdef SALINA
+#define PCIEHW_NDEVS    4150
+#define PCIEHW_NDEVS_HI 4150
+#else
+*/
 #define PCIEHW_NDEVS    1024
+#define PCIEHW_NDEVS_HI 2080
+/* #endif */
 #define PCIEHW_CFGSHIFT 11
 #define PCIEHW_CFGSZ    (1 << PCIEHW_CFGSHIFT)
 #define PCIEHW_NROMSK   128

--- a/drivers/linux/pciesvc/pciesvc/include/pciehwmem.h
+++ b/drivers/linux/pciesvc/pciesvc/include/pciehwmem.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #define PCIEHW_NOTIFYSZ         (1 * 1024 * 1024)
 
-typedef struct pciehw_mem_s {
+typedef struct pciehw_mem_lo_s {
     u_int8_t notify_area[PCIEHW_NPORTS][PCIEHW_NOTIFYSZ]
                                      __attribute__((aligned(PCIEHW_NOTIFYSZ)));
     /* page of zeros to back cfgspace */
@@ -27,7 +27,37 @@ typedef struct pciehw_mem_s {
     u_int32_t indirect_intr_dest[PCIEHW_NPORTS]; /* indirect intr dest */
     u_int32_t magic;                    /* PCIEHW_MAGIC when initialized */
     u_int32_t version;                  /* PCIEHW_VERSION when initialized */
+} pciehw_mem_lo_t;
+
+typedef struct pciehw_mem_hi_s {
+    u_int8_t notify_area[PCIEHW_NPORTS][PCIEHW_NOTIFYSZ]
+                                     __attribute__((aligned(PCIEHW_NOTIFYSZ)));
+    /* page of zeros to back cfgspace */
+    u_int8_t zeros[4096] __attribute__((aligned(4096)));
+    u_int8_t cfgcur[PCIEHW_NDEVS_HI][PCIEHW_CFGSZ]
+                                     __attribute__((aligned(4096)));
+    u_int32_t notify_intr_dest[PCIEHW_NPORTS];   /* notify   intr dest */
+    u_int32_t indirect_intr_dest[PCIEHW_NPORTS]; /* indirect intr dest */
+    u_int32_t magic;                    /* PCIEHW_MAGIC when initialized */
+    u_int32_t version;                  /* PCIEHW_VERSION when initialized */
+} pciehw_mem_hi_t;
+
+typedef struct pciehw_mem_s {
+    union {
+        pciehw_mem_lo_t lo;
+        pciehw_mem_hi_t hi;
+    };
 } pciehw_mem_t;
+
+#define PHWMEM_DATA_FIELD(H, S, V) (S->lo.hi_ndev ? H->hi.V : H->lo.V)
+#define PHWMEM_ADDR_FIELD(H, S, V) (S->lo.hi_ndev ? &H->hi.V : &H->lo.V)
+#define PHWMEM_ASGN_FIELD(H, S, V, A) (S->lo.hi_ndev ? \
+            (H->hi.V = A) : (H->lo.V = A))
+#define PHWMEM_OFFSETOF(H, S, V) (S->lo.hi_ndev ? \
+            offsetof(pciehw_mem_hi_t, V) : offsetof(pciehw_mem_lo_t, V))
+#define PHWMEM_SIZEOF(H, S, V) (S->lo.hi_ndev ? \
+            sizeof(((pciehw_mem_hi_t *)0L)->V) : \
+            sizeof(((pciehw_mem_lo_t *)0L)->V))
 
 #ifdef __cplusplus
 }

--- a/drivers/linux/pciesvc/pciesvc/include/pciesvc.h
+++ b/drivers/linux/pciesvc/pciesvc/include/pciesvc.h
@@ -22,7 +22,7 @@ extern "C" {
 #include "pciesvc_cmd.h"
 
 #define PCIESVC_VERSION_MAJ     3
-#define PCIESVC_VERSION_MIN     3
+#define PCIESVC_VERSION_MIN     5
 
 typedef struct pciesvc_params_v0_s {
     int         port;                   /* port to config */

--- a/drivers/linux/pciesvc/pciesvc/src/cfg.c
+++ b/drivers/linux/pciesvc/pciesvc/src/cfg.c
@@ -83,7 +83,8 @@ stlp_overlap(const pcie_stlp_t *stlp,
 static pciehwdevh_t
 cfgpa_to_hwdevh(const u_int64_t cfgpa)
 {
-#define CFGCURSZ sizeof(((pciehw_mem_t *)0L)->cfgcur)
+    pciehw_shmem_t *pshmem = pciesvc_shmem_get();
+#define CFGCURSZ PHWMEM_SIZEOF(phwmem, pshmem, cfgcur)
     const u_int64_t cfgcurpa = pciesvc_cfgcur_pa();
 
     if (cfgpa >= cfgcurpa && cfgpa < cfgcurpa + CFGCURSZ) {
@@ -636,7 +637,7 @@ pciehw_sriov_adjust_vf0(pciehwdev_t *vfhwdev, const int numvfs)
         pciehw_spmt_t *spmt, *spmte;
         if (!phwbar->valid) continue;
         do_log = 1; /* log adjust_vf0 for first pmt of bar */
-        spmt = &pshmem->spmt[phwbar->pmtb];
+        spmt = PSHMEM_ADDR_FIELD(pshmem, spmt[phwbar->pmtb]);
         spmte = spmt + phwbar->pmtc;
         for ( ; spmt < spmte; spmt++) {
             if (spmt->vf0) {

--- a/drivers/linux/pciesvc/pciesvc/src/pciesvc_impl.h
+++ b/drivers/linux/pciesvc/pciesvc/src/pciesvc_impl.h
@@ -94,8 +94,9 @@ pciesvc_indirect_intr_dest_pa(const int port)
     pciesvc_assert(port >= 0 && port < PCIEHW_NPORTS);
     if (intr_dest_pa[port] == 0) {
         pciehw_mem_t *phwmem = pciesvc_hwmem_get();
+        pciehw_shmem_t *pshmem = pciesvc_shmem_get();
         intr_dest_pa[port] =
-            pciesvc_vtop(&phwmem->indirect_intr_dest[port]);
+            pciesvc_vtop(PHWMEM_ADDR_FIELD(phwmem, pshmem, indirect_intr_dest[port]));
     }
     return intr_dest_pa[port];
 }
@@ -108,8 +109,9 @@ pciesvc_notify_intr_dest_pa(const int port)
     pciesvc_assert(port >= 0 && port < PCIEHW_NPORTS);
     if (intr_dest_pa[port] == 0) {
         pciehw_mem_t *phwmem = pciesvc_hwmem_get();
+        pciehw_shmem_t *pshmem = pciesvc_shmem_get();
         intr_dest_pa[port] =
-            pciesvc_vtop(&phwmem->notify_intr_dest[port]);
+            pciesvc_vtop(PHWMEM_ADDR_FIELD(phwmem, pshmem, notify_intr_dest[port]));
     }
     return intr_dest_pa[port];
 }
@@ -121,7 +123,8 @@ pciesvc_cfgcur_pa(void)
 
     if (cfgcur_pa == 0) {
         pciehw_mem_t *phwmem = pciesvc_hwmem_get();
-        cfgcur_pa = pciesvc_vtop(phwmem->cfgcur);
+        pciehw_shmem_t *pshmem = pciesvc_shmem_get();
+        cfgcur_pa = pciesvc_vtop(PHWMEM_DATA_FIELD(phwmem, pshmem, cfgcur));
     }
     return cfgcur_pa;
 }
@@ -133,7 +136,7 @@ pciesvc_notify_ring_mask(const int port)
 
     if (ring_mask == 0) {
         pciehw_shmem_t *pshmem = pciesvc_shmem_get();
-        ring_mask = pshmem->notify_ring_mask;
+        ring_mask = PSHMEM_DATA_FIELD(pshmem, notify_ring_mask);
     }
     return ring_mask;
 }
@@ -142,9 +145,10 @@ static inline notify_entry_t *
 pciesvc_notify_ring_get(const int port, const int idx)
 {
     pciehw_mem_t *phwmem = pciesvc_hwmem_get();
+    pciehw_shmem_t *pshmem = pciesvc_shmem_get();
     notify_entry_t *notify_ring;
 
-    notify_ring = (notify_entry_t *)phwmem->notify_area[port];
+    notify_ring = (notify_entry_t *)PHWMEM_ADDR_FIELD(phwmem, pshmem, notify_area[port]);
     return &notify_ring[idx];
 }
 
@@ -160,7 +164,7 @@ pciesvc_port_get(const int port)
     pciehw_shmem_t *pshmem = pciesvc_shmem_get();
 
     pciesvc_assert(port >= 0 && port <= PCIEHW_NPORTS);
-    return &pshmem->port[port];
+    return PSHMEM_ADDR_FIELD(pshmem, port[port]);
 }
 
 static inline void
@@ -173,8 +177,10 @@ static inline pciehwdev_t *
 pciesvc_dev_get(const pciehwdevh_t hwdevh)
 {
     pciehw_shmem_t *pshmem = pciesvc_shmem_get();
+    int ndevs = PSHMEM_NDEVS(pshmem);
 
-    return hwdevh > 0 && hwdevh < PCIEHW_NDEVS ? &pshmem->dev[hwdevh] : NULL;
+    return hwdevh > 0 &&
+        hwdevh < ndevs ? PSHMEM_ADDR_FIELD(pshmem, dev[hwdevh]) : NULL;
 }
 
 static inline void
@@ -189,9 +195,9 @@ pciesvc_cfgspace_get(const pciehwdevh_t hwdevh, cfgspace_t *cs)
     pciehw_mem_t *phwmem = pciesvc_hwmem_get();
     pciehw_shmem_t *pshmem = pciesvc_shmem_get();
 
-    cs->cur = phwmem->cfgcur[hwdevh];
-    cs->msk = pshmem->cfgmsk[hwdevh];
-    cs->rst = pshmem->cfgrst[hwdevh];
+    cs->cur = PHWMEM_DATA_FIELD(phwmem, pshmem, cfgcur[hwdevh]);
+    cs->msk = PSHMEM_DATA_FIELD(pshmem, cfgmsk[hwdevh]);
+    cs->rst = PSHMEM_DATA_FIELD(pshmem, cfgrst[hwdevh]);
     cs->size = PCIEHW_CFGSZ;
 }
 
@@ -206,7 +212,7 @@ pciesvc_spmt_get(const int idx)
 {
     pciehw_shmem_t *pshmem = pciesvc_shmem_get();
 
-    return &pshmem->spmt[idx];
+    return PSHMEM_ADDR_FIELD(pshmem, spmt[idx]);
 }
 
 static inline void
@@ -220,7 +226,7 @@ pciesvc_sprt_get(const int idx)
 {
     pciehw_shmem_t *pshmem = pciesvc_shmem_get();
 
-    return &pshmem->sprt[idx];
+    return PSHMEM_ADDR_FIELD(pshmem, sprt[idx]);
 }
 
 static inline void
@@ -234,7 +240,7 @@ pciesvc_vpd_get(const pciehwdevh_t hwdevh)
 {
     pciehw_shmem_t *pshmem = pciesvc_shmem_get();
 
-    return &pshmem->vpddata[hwdevh];
+    return PSHMEM_ADDR_FIELD(pshmem, vpddata[hwdevh]);
 }
 
 static inline void

--- a/drivers/linux/pciesvc/pciesvc/src/serial.c
+++ b/drivers/linux/pciesvc/pciesvc/src/serial.c
@@ -386,7 +386,8 @@ serial_get(pciehwdev_t *phwdev)
 
     if (!serial.inited) {
         pciehw_shmem_t *pshmem = pciesvc_shmem_get();
-        serial_uart_state_t *su = (serial_uart_state_t *)pshmem->serial[0];
+        serial_uart_state_t *su =
+            (serial_uart_state_t *)PSHMEM_DATA_FIELD(pshmem, serial[0]);
         serial_state_t *st = &su->serial_state;
 
         serial.state = st;


### PR DESCRIPTION
Overview:
Increase scale to 2k vfs.
Add modinfo version=3.5, intree=Y.
Replace gcc-generated reference to memcpy to explicit pciesvc_memcpy. Makefile in module src bundle builds both pciesvc.ko,pciesvc_upg.ko. Bump pciesvc version to 3.5

Internal patch list:

- Pciemgrd: Scale number of devices to 2048 (#69602)
- pciesvc.ko: add module info version, intree=Y (#71131)
- pciesvc: spmt_dup_prts copy all prts (#71821)
- pciesvc.ko: improve Makefile in module src bundle (#71874)