### PR TITLE
dsc-drivers: update ionic drivers to 23.09.1-001

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,9 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - better error handling for ionic_start_queues_reconfig
  - fix up initial coalesce_usec values
  - various other small updates from upstream
+
+2023-11-10 - driver update for 23.09.1-001
+ - bug fix for copying the page_cache pointer in queue reconfig
+ - some general code and Makefile cleaning
+ - fix 16bit math issue when PAGE_SIZE >= 64KB
+ - restrict page-cache allocation to Rx queues

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -42,8 +42,8 @@ ALL += mnet_uio_pdrv_genirq
 ALL += mdev
 export PATH := $(PATH):$(TOOLCHAIN_DIR)/bin
 
-KSYMS_MNIC = "KBUILD_EXTRA_SYMBOLS=${KMOD_OUT_DIR}/Module.symvers.mnic"
-KSYMS = "${KSYMS_MNIC} ${KMOD_OUT_DIR}/Module.symvers.uio"
+KSYMS_MNIC = $(KMOD_OUT_DIR)/Module.symvers.mnic
+KSYMS_UIO = $(KMOD_OUT_DIR)/Module.symvers.uio
 
 DVER = $(shell cd $(KMOD_SRC_DIR) ; git describe --tags 2>/dev/null)
 
@@ -56,9 +56,8 @@ include linux_ver.mk
 
 KSRC ?= /lib/modules/$(shell uname -r)/build
 ETH_KOPT += CONFIG_IONIC=m
-ETH_KOPT += CONFIG_IONIC_MNIC=_
-ETH_KOPT += CONFIG_MDEV=_
 ETH_KOPT += CONFIG_MNET_UIO_PDRV_GENIRQ=_
+ETH_KOPT += CONFIG_MDEV=_
 KCFLAGS += -DCONFIG_IONIC
 
 KCFLAGS = -Werror
@@ -69,15 +68,15 @@ ALL = eth
 endif
 
 ifeq ($(DVER),)
-    DVER = "23.08.1-001"
+    DVER = "23.09.1-001"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 
-KOPT += KCFLAGS="$(KCFLAGS)"
+KOPT += KCFLAGS="$(KCFLAGS)" KBUILD_EXTRA_SYMBOLS="$(KSYMS)"
 
 all: $(ALL)
 
-KBUILD_RULE = $(MAKE) -C $(KSRC) $(KOPT) M=$(CURDIR)
+KBUILD_RULE = $(MAKE) -C $(KSRC) $(KOPT) M=$(CURDIR) KMOD_SRC_DIR=$(CURDIR)
 
 mnic: KOPT+=$(ETH_KOPT)
 mnic:
@@ -94,17 +93,22 @@ mnet_uio_pdrv_genirq:
 	mv ${KMOD_OUT_DIR}/Module.symvers ${KMOD_OUT_DIR}/Module.symvers.uio
 
 mdev: KOPT+=$(ETH_KOPT)
+mdev: KSYMS+=$(KSYMS_MNIC)
+mdev: KSYMS+=$(KSYMS_UIO)
 mdev:
 	@echo "===> Building MDEV driver "
-	$(MAKE) -C $(KSRC) $(KSYMS) V=1 M=$(KMOD_OUT_DIR) src=$(KMOD_SRC_DIR)/mdev $(KOPT)
+	$(MAKE) -C $(KSRC) V=1 M=$(KMOD_OUT_DIR) src=$(KMOD_SRC_DIR)/mdev $(KOPT)
 
 eth: KOPT+=$(ETH_KOPT)
 eth:
+	@echo "===> Building ETH driver "
 	+$(KBUILD_RULE)
+	mv $(CURDIR)/Module.symvers $(CURDIR)/Module.symvers.ionic
 
 clean: KOPT+=$(ETH_KOPT)
 clean:
 	$(KBUILD_RULE) clean
+	rm -f $(CURDIR)/Module.symvers*
 
 KBUILD_INSTALL_RULE = $(MAKE) -C $(KSRC) $(KOPT) \
 		      $(if ${DISABLE_MODULE_SIGNING},CONFIG_MODULE_SIG=n) \
@@ -118,7 +122,6 @@ modules_install:
 	@$(call warn_signed_modules)
 	$(KBUILD_INSTALL_RULE) modules_install
 	$(call cmd_depmod)
-	$(call cmd_initramfs)
 
 cscope:
 	find $(IONIC_ETH_SRC) -name '*.[ch]' > cscope.files

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -185,7 +185,7 @@ typedef void (*ionic_desc_cb)(struct ionic_queue *q,
 			      struct ionic_desc_info *desc_info,
 			      struct ionic_cq_info *cq_info, void *cb_arg);
 
-
+#define IONIC_MAX_BUF_LEN			((u16)-1)
 #define IONIC_PAGE_ORDER			0
 #define IONIC_PAGE_SIZE				(PAGE_SIZE << IONIC_PAGE_ORDER)
 #define IONIC_PAGE_SPLIT_SZ			(PAGE_SIZE / 4)
@@ -274,7 +274,7 @@ struct ionic_queue {
 	unsigned int desc_size;
 	unsigned int sg_desc_size;
 	unsigned int pid;
-	struct ionic_page_cache page_cache;
+	struct ionic_page_cache *page_cache;
 	char name[IONIC_QUEUE_NAME_MAX_SZ];
 } ____cacheline_aligned_in_smp;
 
@@ -395,7 +395,6 @@ void ionic_q_cmb_map(struct ionic_queue *q, void __iomem *base, dma_addr_t base_
 void ionic_q_sg_map(struct ionic_queue *q, void *base, dma_addr_t base_pa);
 void ionic_q_post(struct ionic_queue *q, bool ring_doorbell, ionic_desc_cb cb,
 		  void *cb_arg);
-void ionic_q_rewind(struct ionic_queue *q, struct ionic_desc_info *start);
 void ionic_q_service(struct ionic_queue *q, struct ionic_cq_info *cq_info,
 		     unsigned int stop_index);
 int ionic_heartbeat_check(struct ionic *ionic);

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -383,6 +383,11 @@ static inline bool ionic_is_pf(struct ionic *ionic)
 	       ionic->pdev->device == PCI_DEVICE_ID_PENSANDO_IONIC_ETH_PF;
 }
 
+static inline bool ionic_txq_hwstamp_enabled(struct ionic_queue *q)
+{
+	return unlikely(q->features & IONIC_TXQ_F_HWSTAMP);
+}
+
 void ionic_lif_deferred_enqueue(struct ionic_deferred *def,
 				struct ionic_deferred_work *work);
 void ionic_link_status_check_request(struct ionic_lif *lif, bool can_sleep);

--- a/drivers/linux/eth/ionic/ionic_rx_filter.h
+++ b/drivers/linux/eth/ionic/ionic_rx_filter.h
@@ -43,7 +43,6 @@ struct ionic_rx_filter *ionic_rx_filter_by_addr(struct ionic_lif *lif, const u8 
 struct ionic_rx_filter *ionic_rx_filter_rxsteer(struct ionic_lif *lif);
 void ionic_rx_filter_sync(struct ionic_lif *lif);
 int ionic_lif_list_addr(struct ionic_lif *lif, const u8 *addr, bool mode);
-int ionic_rx_filters_need_sync(struct ionic_lif *lif);
 int ionic_lif_vlan_add(struct ionic_lif *lif, const u16 vid);
 int ionic_lif_vlan_del(struct ionic_lif *lif, const u16 vid);
 

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -6823,6 +6823,11 @@ static inline struct devlink *_kc_devlink_alloc(const struct devlink_ops *ops,
 #endif /* 5.17 */
 
 /*****************************************************************************/
+#if (KERNEL_VERSION(5, 18, 0) > LINUX_VERSION_CODE)
+#define vcalloc(a, b)	vzalloc((a) * (b))
+#endif /* 5.18 */
+
+/*****************************************************************************/
 #if (KERNEL_VERSION(6, 0, 0) > LINUX_VERSION_CODE && \
 	(!RHEL_RELEASE_CODE || \
 	  RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8, 8) || \


### PR DESCRIPTION
Internal patch list:
    ionic: copy the page_cache pointer in queue reconfig
    ionic: Make the check for Tx HW timestamping more obvious
    ionic: add kcompat for vcalloc
    ionic: fix 16bit math issue when PAGE_SIZE >= 64KB
    ionic: Remove unused declarations
    ionic: use vcalloc rather than vzalloc
    out-of-tree: cleanup and fix symvers issues
    ionic: Only allocate page-cache for Rx queues
    ionic: Don't check null when calling vfree()