### PR TITLE
dsc-drivers: update ionic drivers to 23.12.2-001

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,3 +194,8 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - some general code and Makefile cleaning
  - fix 16bit math issue when PAGE_SIZE >= 64KB
  - restrict page-cache allocation to Rx queues
+
+23-12-14 - driver update for 23.12.2-001
+ - updates from upstream kernel fixes
+ - updates to FLR handling
+ - added AER error handling

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -56,8 +56,9 @@ include linux_ver.mk
 
 KSRC ?= /lib/modules/$(shell uname -r)/build
 ETH_KOPT += CONFIG_IONIC=m
-ETH_KOPT += CONFIG_MNET_UIO_PDRV_GENIRQ=_
+ETH_KOPT += CONFIG_IONIC_MNIC=_
 ETH_KOPT += CONFIG_MDEV=_
+ETH_KOPT += CONFIG_MNET_UIO_PDRV_GENIRQ=_
 KCFLAGS += -DCONFIG_IONIC
 
 KCFLAGS = -Werror
@@ -68,7 +69,7 @@ ALL = eth
 endif
 
 ifeq ($(DVER),)
-    DVER = "23.09.1-001"
+    DVER = "23.12.2-001"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 

--- a/drivers/linux/eth/ionic/Makefile
+++ b/drivers/linux/eth/ionic/Makefile
@@ -4,7 +4,7 @@
 obj-$(CONFIG_IONIC) := ionic.o
 obj-$(CONFIG_IONIC_MNIC) := ionic_mnic.o
 
-ccflags-y := -g -I$(M)/../common
+ccflags-y := -g -I$(M)/../common -I$(src)
 
 ionic-y := ionic_main.o ionic_bus_pci.o ionic_dev.o ionic_ethtool.o \
 	   ionic_lif.o ionic_rx_filter.o ionic_txrx.o ionic_debugfs.o \

--- a/drivers/linux/eth/ionic/ionic.h
+++ b/drivers/linux/eth/ionic/ionic.h
@@ -67,8 +67,6 @@ struct ionic {
 	unsigned int ntxqs_per_lif;
 	unsigned int nrxqs_per_lif;
 	unsigned int nlifs;
-	DECLARE_BITMAP(lifbits, IONIC_LIFS_MAX);
-	DECLARE_BITMAP(ethbits, IONIC_LIFS_MAX);
 	unsigned int nintrs;
 	DECLARE_BITMAP(intrs, IONIC_INTR_CTRL_REGS_MAX);
 #ifndef HAVE_PCI_IRQ_API

--- a/drivers/linux/eth/ionic/ionic_debugfs.c
+++ b/drivers/linux/eth/ionic/ionic_debugfs.c
@@ -541,6 +541,9 @@ void ionic_debugfs_add_lif(struct ionic_lif *lif)
 
 void ionic_debugfs_del_lif(struct ionic_lif *lif)
 {
+	if (!lif->dentry)
+		return;
+
 	debugfs_remove_recursive(lif->dentry);
 	lif->dentry = NULL;
 }

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -149,6 +149,7 @@ struct ionic_dev {
 	bool fw_hb_ready;
 	bool fw_status_ready;
 	u8 fw_generation;
+	u8 opcode;
 
 	u64 __iomem *db_pages;
 	dma_addr_t phy_db_pages;
@@ -229,7 +230,7 @@ struct ionic_desc_info {
 	void *cb_arg;
 };
 
-#define IONIC_QUEUE_NAME_MAX_SZ		32
+#define IONIC_QUEUE_NAME_MAX_SZ		16
 
 struct ionic_queue {
 	struct device *dev;
@@ -283,13 +284,13 @@ struct ionic_queue {
 
 struct ionic_intr_info {
 	char name[IONIC_INTR_NAME_MAX_SZ];
+	u64 rearm_count;
 	unsigned int index;
 	unsigned int vector;
-	u64 rearm_count;
 	unsigned int cpu;
-	cpumask_t affinity_mask;
 	u32 dim_coal_hw;
 	u16 dim_coal_usecs;
+	cpumask_t affinity_mask;
 };
 
 struct ionic_cq {

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -187,6 +187,7 @@ enum ionic_lif_state_flags {
 	IONIC_LIF_F_RX_DIM_INTR,
 	IONIC_LIF_F_CMB_TX_RINGS,
 	IONIC_LIF_F_CMB_RX_RINGS,
+	IONIC_LIF_F_IN_SHUTDOWN,
 
 	/* leave this as last */
 	IONIC_LIF_F_STATE_SIZE

--- a/drivers/linux/eth/ionic/ionic_trace.h
+++ b/drivers/linux/eth/ionic/ionic_trace.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright(c) 2023 Advanced Micro Devices, Inc */
+
+/*
+ * See for references
+ *  https://www.kernel.org/doc/html/latest/trace/tracepoints.html
+ *  http://lwn.net/Articles/379903
+ *  http://lwn.net/Articles/381064
+ *  http://lwn.net/Articles/383362
+ */
+
+#undef TRACE_SYSTEM
+#define TRACE_SYSTEM ionic
+
+#if !defined(_IONIC_TRACE_H) || defined(TRACE_HEADER_MULTI_READ)
+#define _IONIC_TRACE_H
+
+#include <linux/tracepoint.h>
+
+DECLARE_EVENT_CLASS(ionic_q_start_stop_template,
+	TP_PROTO(struct ionic_queue *q),
+
+	TP_ARGS(q),
+
+	TP_STRUCT__entry(__field(unsigned int, index)
+			 __string(devname, q->lif->netdev->name)
+	),
+
+	TP_fast_assign(__entry->index = q->index;
+		       __assign_str(devname, q->lif->netdev->name);
+	),
+
+	TP_printk("%s: queue[%u]", __get_str(devname), __entry->index)
+);
+
+DEFINE_EVENT(ionic_q_start_stop_template, ionic_q_stop,
+	     TP_PROTO(struct ionic_queue *q),
+	     TP_ARGS(q)
+);
+
+DEFINE_EVENT(ionic_q_start_stop_template, ionic_q_start,
+	     TP_PROTO(struct ionic_queue *q),
+	     TP_ARGS(q)
+);
+
+#endif /* _IONIC_TRACE_H */
+
+/* This part must be outside protection */
+#undef TRACE_INCLUDE_PATH
+#define TRACE_INCLUDE_PATH .
+#undef TRACE_INCLUDE_FILE
+#define TRACE_INCLUDE_FILE ionic_trace
+#include <trace/define_trace.h>

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -258,10 +258,6 @@ struct msix_entry {
 #define node_online(node) ((node) == 0)
 #endif
 
-#ifndef cpu_online
-#define cpu_online(cpuid) test_bit((cpuid), &cpu_online_map)
-#endif
-
 #ifndef _LINUX_RANDOM_H
 #include <linux/random.h>
 #endif
@@ -6862,7 +6858,9 @@ static inline int skb_inner_tcp_all_headers(const struct sk_buff *skb)
 #endif /* 6.1 */
 
 /*****************************************************************************/
-#if (KERNEL_VERSION(6, 2, 0) > LINUX_VERSION_CODE)
+#if (KERNEL_VERSION(6, 2, 0) > LINUX_VERSION_CODE && \
+	(!RHEL_RELEASE_CODE || \
+	  RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(9, 2)))
 #define SET_NETDEV_DEVLINK_PORT(dev, port)   devlink_port_type_eth_set(port, dev)
 #else
 #define devlink_info_driver_name_put(x, y)  0


### PR DESCRIPTION
Internal patch list:
    ionic: Fix dim work handling in split interrupt mode
    ionic: Rename dim profile to be more generic
    ionic: remove extra call to ionic_debugfs_add_lif
    ionic: fix snprintf format length warning
    ionic: remove lifbits and ethbits
    ionic: whitespace diffs from upstream
    ionic: add ionic_write_cmb_desc to clean up code
    ionic: no need for pci reset in recovery
    ionic: do full teardown on reset even if fw_down
    ionic: fill out pci error handlers
    ionic: sync up the napi processing on queue stop