### PR TITLE
pciesvc: update to 1.65-C-69

### DIFF
--- a/drivers/linux/pciesvc/Makefile
+++ b/drivers/linux/pciesvc/Makefile
@@ -17,26 +17,40 @@ INCLUDES = -I$(PWD) \
 	   -I$(PWD)/pciesvc/include \
 	   -I$(PWD)/pciesvc/src
 
-$(MODNAME)-y := $(kpci) kpcimgr_module.o kpcinterface.o kpci_entry.o \
-		kpci_kexec.o kpci_test.o pciesvc_end.o
+$(MODNAME)-y := $(kpci) kpci_get_entry.o kpcimgr_module.o kpcinterface.o \
+	     kpci_entry.o kpci_kexec.o kpci_test.o pciesvc_end.o
 
 KDIR := /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)
 UTS := X$(shell grep UTS_RELEASE $(KDIR)/include/generated/utsrelease.h)
 REL := $(shell echo $(UTS) | awk '{ print $$3 }' | sed -e 's/"//g')
 
-# For older toolchains override with "make CC_HAS_NO_STORE_MERGING=0 ..."
-CC_HAS_NO_STORE_MERGING = 1
+# find CC like the kernel build does
+ifneq ($(LLVM),)
+CC = clang
+else
+CC = $(CROSS_COMPILE)gcc
+endif
+
+# Check for cc flag support, if yes emit the flag else alternate (or null)
+# Usage: CFLAGS += $(call cc-option,-fno-store-merging,)
+cc-option = $(shell set -e;		\
+	TMPO=/tmp/cc-option-$$$$-tmp.o;	\
+	trap "rm -rf $$TMPO" EXIT;	\
+	if ($(CC) -Werror $(1) -c -x c /dev/null -o $$TMPO) >/dev/null 2>&1; \
+	then echo "$(1)";		\
+	else echo "$(2)";		\
+	fi)
 
 KCFLAGS = -fno-jump-tables -fno-stack-protector -fno-function-sections
 KCFLAGS += -fno-data-sections -mstrict-align
-ifeq ($(CC_HAS_NO_STORE_MERGING),1)
-KCFLAGS += -fno-store-merging
-endif
+KCFLAGS += $(call cc-option,-fno-store-merging,)
 KCFLAGS += $(INCLUDES) -DASIC_ELBA -DPCIESVC_SYSTEM_EXTERN
 KOPT = KCFLAGS="$(KCFLAGS)"
 
-all: pciesvc.ko pciesvc_upg.ko
+all:
+	make pciesvc.ko
+	make pciesvc_upg.ko
 
 buildmod:
 	$(MAKE) -C $(KDIR) M=$(PWD) $(KOPT) modules

--- a/drivers/linux/pciesvc/kpci_constants.h
+++ b/drivers/linux/pciesvc/kpci_constants.h
@@ -5,18 +5,18 @@
 /*
  * Layout of non-Linux Memory:
  *  (base address provided in device tree and may change)
- *  C500 0000  SHMEM segment (pciehw_shmem_t) [0x942440 bytes ~9.25Mb]
- *  C5F0 0000  kpcimgr state (kstate_t)       [3 * 64k]
- *  C5F3 0000  relocated code                 [Allow 256k]
- *  C5F7 0000  available for stack when in nommu mode (64k)
- *  C5F8 0000  top of stack
- *  C5FF FFFF  end of 1M allotted range
+ *  C5F8 D000  kpcimgr state (kstate_t)       [3 * 64k]
+ *  C5FB D000  relocated code                 [Allow 256k]
+ *       ....  code can grow upwards and stack downwards
+ *  C5FF D000  top of stack
+ *  C5FF FFE0  fake efi.mem area for LPI
+ *  C5FF FFFF  end of HWMEM range
  */
-#define SHMEM_KSTATE_OFFSET       0xF00000
+#define COMPAT_SHMEM_KSTATE_OFFSET 0xF00000
 #define SHMEM_KSTATE_SIZE          0x30000
-#define KSTATE_STACK_OFFSET        0x80000
-#define KSTATE_CODE_OFFSET      (SHMEM_KSTATE_OFFSET + SHMEM_KSTATE_SIZE)
+#define KSTATE_CODE_OFFSET      SHMEM_KSTATE_SIZE
 #define KSTATE_CODE_SIZE        (256 * 1024)
+#define KSTATE_STACK_OFFSET     SHMEM_KSTATE_SIZE+KSTATE_CODE_SIZE
 #define KSTATE_MAGIC            0x1743BA1F
 
 /* size of trace data arrays */

--- a/drivers/linux/pciesvc/kpci_entry.S
+++ b/drivers/linux/pciesvc/kpci_entry.S
@@ -9,11 +9,17 @@
  *  Author: rob.gardner@oracle.com
  */
 	
-#include <linux/linkage.h>
-#include <asm/assembler.h>
-#include <asm/sysreg.h>
 #include "kpci_constants.h"
 	
+#ifndef SYM_CODE_START
+#define SYM_CODE_START(name) \
+	.globl name		;\
+        name:			;
+
+#define SYM_CODE_END(name) \
+	.size name, .-name
+#endif
+
 /* Calling conventions for printl: */
 /* We use x12 as the branch link register and x13 as the first function arg */
 #define	return_addr 	x12

--- a/drivers/linux/pciesvc/kpci_get_entry.c
+++ b/drivers/linux/pciesvc/kpci_get_entry.c
@@ -1,0 +1,50 @@
+#include <stddef.h>
+#include "kpcimgr_api.h"
+
+extern char pciesvc_end;
+extern void kpcimgr_init_intr(void *);
+extern void kpcimgr_init_fn(void *);
+extern void kpcimgr_version_fn(char **);
+extern void kpcimgr_init_poll(void *);
+extern void pciesvc_shut(int);
+extern void kpcimgr_poll(kstate_t *, int, int);
+extern unsigned long kpcimgr_get_holding_pen(unsigned long, unsigned int);
+extern int kpcimgr_ind_intr(void *, int);
+extern int kpcimgr_not_intr(void *, int);
+extern void kpcimgr_undefined_entry(void);
+extern int pciesvc_sysfs_cmd_read(void *, char *, int *);
+extern int pciesvc_sysfs_cmd_write(void *, char *, size_t, int *);
+
+extern int pciesvc_version_major;
+extern int pciesvc_version_minor;
+
+struct kpcimgr_entry_points_t ep;
+
+struct kpcimgr_entry_points_t *kpci_get_entry_points(void)
+{
+	int i;
+
+	/* initialize entry_points struct via executable code so that
+	 * PC relative relocations are generated */
+	ep.expected_mgr_version = 3;
+	ep.lib_version_major = pciesvc_version_major;
+	ep.lib_version_minor = pciesvc_version_minor;
+	ep.code_end = &pciesvc_end;
+
+	for (i=0; i<K_NUM_ENTRIES; i++)
+		ep.entry_point[i] = kpcimgr_undefined_entry;
+
+	ep.entry_point[K_ENTRY_INIT_INTR] = kpcimgr_init_intr;
+	ep.entry_point[K_ENTRY_INIT_POLL] = kpcimgr_init_poll;
+	ep.entry_point[K_ENTRY_SHUT] = pciesvc_shut;
+	ep.entry_point[K_ENTRY_POLL] = kpcimgr_poll;
+	ep.entry_point[K_ENTRY_HOLDING_PEN] = kpcimgr_get_holding_pen;
+	ep.entry_point[K_ENTRY_INDIRECT_INTR] = kpcimgr_ind_intr;
+	ep.entry_point[K_ENTRY_NOTIFY_INTR] = kpcimgr_not_intr;
+	ep.entry_point[K_ENTRY_INIT_FN] = kpcimgr_init_fn;
+	ep.entry_point[K_ENTRY_CMD_READ] = pciesvc_sysfs_cmd_read;
+	ep.entry_point[K_ENTRY_CMD_WRITE] = pciesvc_sysfs_cmd_write;
+	ep.entry_point[K_ENTRY_GET_VERSION] = kpcimgr_version_fn;
+
+	return &ep;
+}

--- a/drivers/linux/pciesvc/kpci_test.c
+++ b/drivers/linux/pciesvc/kpci_test.c
@@ -9,9 +9,7 @@
  * Author: rob.gardner@oracle.com
  */
 
-#include "kpcimgr_api.h"
-#include "pciesvc.h"
-#include "pciesvc_system.h"
+#include "pciesvc_impl.h"
 
 #define TICKS_PER_US 200
 #define TICKS_PER_MS  (1000*TICKS_PER_US)

--- a/drivers/linux/pciesvc/kpcimgr_api.h
+++ b/drivers/linux/pciesvc/kpcimgr_api.h
@@ -22,6 +22,7 @@
 #include <linux/moduleloader.h>
 #include <linux/set_memory.h>
 #include <asm/insn.h>
+#include <asm/cacheflush.h>
 #endif
 
 #include "kpci_constants.h"

--- a/drivers/linux/pciesvc/kpcimgr_module.c
+++ b/drivers/linux/pciesvc/kpcimgr_module.c
@@ -20,7 +20,7 @@
 
 MODULE_LICENSE("GPL");
 MODULE_VERSION(__stringify(PCIESVC_VERSION_MAJ) "."
-	       __stringify(PCIESVC_VERSION_MIN));
+		__stringify(PCIESVC_VERSION_MIN));
 MODULE_INFO(build, PCIESVC_VERSION);
 MODULE_INFO(intree, "Y"); /* no out-of-tree module taints kernel */
 
@@ -30,57 +30,21 @@ module_param(relocate, int, 0600);
 MODULE_PARM_DESC(relocate, "specifies whether or not to relocate module");
 #endif
 
-extern char pciesvc_end;
-extern void kpcimgr_init_intr(void *);
-extern void kpcimgr_init_fn(void *);
-extern void kpcimgr_version_fn(char **);
-extern void kpcimgr_init_poll(void *);
-extern void pciesvc_shut(int);
-extern void kpcimgr_poll(kstate_t *, int, int);
-extern unsigned long kpcimgr_get_holding_pen(unsigned long, unsigned int);
-extern int kpcimgr_ind_intr(void *, int);
-extern int kpcimgr_not_intr(void *, int);
-extern void kpcimgr_undefined_entry(void);
-extern int pciesvc_sysfs_cmd_read(void *, char *, int *);
-extern int pciesvc_sysfs_cmd_write(void *, char *, size_t, int *);
-
-extern int pciesvc_version_major;
-extern int pciesvc_version_minor;
-
 static int __init pciesvc_dev_init(void)
 {
-	struct kpcimgr_entry_points_t ep;
-	int i, ret = 0;
+	struct kpcimgr_entry_points_t *kpci_get_entry_points(void);
+	struct kpcimgr_entry_points_t *ep;
+	int ret;
 
-	/* initialize entry_points struct via executable code so that
-	 * PC relative relocations are generated */
-	ep.expected_mgr_version = 3;
-	ep.lib_version_major = pciesvc_version_major;
-	ep.lib_version_minor = pciesvc_version_minor;
-	ep.code_end = &pciesvc_end;
-
-	for (i=0; i<K_NUM_ENTRIES; i++)
-		ep.entry_point[i] = kpcimgr_undefined_entry;
-
-	ep.entry_point[K_ENTRY_INIT_INTR] = kpcimgr_init_intr;
-	ep.entry_point[K_ENTRY_INIT_POLL] = kpcimgr_init_poll;
-	ep.entry_point[K_ENTRY_SHUT] = pciesvc_shut;
-	ep.entry_point[K_ENTRY_POLL] = kpcimgr_poll;
-	ep.entry_point[K_ENTRY_HOLDING_PEN] = kpcimgr_get_holding_pen;
-	ep.entry_point[K_ENTRY_INDIRECT_INTR] = kpcimgr_ind_intr;
-	ep.entry_point[K_ENTRY_NOTIFY_INTR] = kpcimgr_not_intr;
-	ep.entry_point[K_ENTRY_INIT_FN] = kpcimgr_init_fn;
-	ep.entry_point[K_ENTRY_CMD_READ] = pciesvc_sysfs_cmd_read;
-	ep.entry_point[K_ENTRY_CMD_WRITE] = pciesvc_sysfs_cmd_write;
-	ep.entry_point[K_ENTRY_GET_VERSION] = kpcimgr_version_fn;
+	ep = kpci_get_entry_points();
 
 	/* call to Pensando SOC driver to copy the code to persistent memory */
-	ret = kpcimgr_module_register(THIS_MODULE, &ep, relocate);
+	ret = kpcimgr_module_register(THIS_MODULE, ep, relocate);
 #ifdef PEN_COMPAT_V2
 	if (ret < 0) {
 		/* attempt compat registration, some entry_point[] unused */
-		ep.expected_mgr_version = 2;
-		ret = kpcimgr_module_register(THIS_MODULE, &ep, relocate);
+		ep->expected_mgr_version = 2;
+		ret = kpcimgr_module_register(THIS_MODULE, ep, relocate);
 	}
 #endif
 

--- a/drivers/linux/pciesvc/kpcinterface.c
+++ b/drivers/linux/pciesvc/kpcinterface.c
@@ -9,9 +9,7 @@
  * Author: rob.gardner@oracle.com
  */
 
-#include "kpcimgr_api.h"
-#include "pciesvc.h"
-#include "pciesvc_system.h"
+#include "pciesvc_impl.h"
 #include "version.h"
 
 /*
@@ -251,16 +249,6 @@ pciesvc_reg_rd32(const uint64_t pa)
     return val;
 }
 
-static inline void
-pciesvc_reg_rd32w(const uint64_t pa, uint32_t *w, const uint32_t nw)
-{
-    int i;
-
-    for (i = 0; i < nw; i++) {
-        w[i] = pciesvc_reg_rd32(pa + (i * 4));
-    }
-}
-
 void
 pciesvc_pciepreg_rd32(const uint64_t pa, uint32_t *dest)
 {
@@ -284,16 +272,6 @@ pciesvc_reg_wr32(const uint64_t pa, const uint32_t val)
 
     pciesvc_assert((pa & 0x3) == 0);
     writel(val, va);
-}
-
-static inline void
-pciesvc_reg_wr32w(const uint64_t pa, const uint32_t *w, const uint32_t nw)
-{
-    int i;
-
-    for (i = 0; i < nw; i++) {
-        pciesvc_reg_wr32(pa + (i * 4), w[i]);
-    }
 }
 
 /*

--- a/drivers/linux/pciesvc/pciesvc_end.c
+++ b/drivers/linux/pciesvc/pciesvc_end.c
@@ -19,6 +19,6 @@
  *
  * Author: rob.gardner@oracle.com
  */
-noinline void pciesvc_end(void)
+__attribute__((__noinline__)) void pciesvc_end(void)
 {
 }

--- a/drivers/linux/pciesvc/pciesvc_loader/Makefile
+++ b/drivers/linux/pciesvc/pciesvc_loader/Makefile
@@ -1,0 +1,25 @@
+#
+# usage: make KDIR=/path/to/kernel/build/area DRIVER=driver_name
+#
+
+DRIVER=pciesvc_loader
+
+$(shell echo '#define PCIESVC_VERSION "'`date`'"' >version.h)
+
+obj-m := $(DRIVER).o
+KDIR := /lib/modules/$(shell uname -r)/build
+PWD := $(shell pwd)
+UTS := X$(shell grep UTS_RELEASE $(KDIR)/include/generated/utsrelease.h)
+REL := $(shell echo $(UTS) | awk '{ print $$3 }' | sed -e 's/"//g')
+INCLUDES = -I$(PWD) -I$(PWD)/..
+KCFLAGS = $(INCLUDES)
+KOPT = KCFLAGS="$(KCFLAGS)"
+
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) $(KOPT) modules
+	@mkdir -p $(REL)
+	@mv $(PWD)/$(patsubst %.o,%.ko,$(obj-m)) $(REL)
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean
+

--- a/drivers/linux/pciesvc/pciesvc_loader/pciesvc_loader.c
+++ b/drivers/linux/pciesvc/pciesvc_loader/pciesvc_loader.c
@@ -1,0 +1,445 @@
+/*
+ * Simple Elf loader for pciesvc library code
+ *
+ * Authors: Rob Gardner, Joseph Dobosenski
+ *
+ */
+
+#include "kpcimgr_api.h"
+#include <linux/elf.h>
+#include <linux/reboot.h>
+#include <linux/stacktrace.h>
+#include <linux/of.h>
+#include "version.h"
+
+MODULE_LICENSE("GPL");
+MODULE_VERSION("OLdev-1.0");
+MODULE_INFO(build, PCIESVC_VERSION);
+MODULE_INFO(intree, "Y"); /* no out-of-tree module taints kernel */
+
+int kpcimgr_module_register(struct module *mod,
+			    struct kpcimgr_entry_points_t *ep, int relocate);
+
+/* loaded elf data, code, symtab, etc */
+static void *elfdata, *bin_image;
+static int elf_valid_bytes, bin_valid_bytes, start_offset;
+static char *strtbl;
+static Elf64_Sym *symtbl, *symtbl_end;
+
+/*
+ * Retrieve kstate_t from kpcimgr via device tree
+ */
+kstate_t *get_kpci_state(void)
+{
+	static kstate_t *kstate = NULL;
+	struct device_node *dn;
+	u32 kstate_idx;
+	int err;
+
+	if (kstate != NULL)
+		return kstate;
+
+	dn = of_find_compatible_node(NULL, NULL, "pensando,kpcimgr");
+	if (dn == NULL) {
+		pr_err("pciesvc_loader: no compatible device found in dtree\n");
+		return NULL;
+	}
+
+	err = of_property_read_u32(dn, "kstate-index", &kstate_idx);
+	if (err) {
+		pr_err("pciesvc_loader: please upgrade to new kstate-index dtree\n");
+		return NULL;
+	}
+
+	kstate = (kstate_t *) of_iomap(dn, kstate_idx);
+	if (kstate == NULL) {
+		pr_err("pciesvc_loader: failed to map kstate\n");
+		return NULL;
+	}
+
+	return kstate;
+}
+
+/*
+ * Allocate executable memory
+ */
+void *vmalloc_exec(unsigned long size)
+{
+	pgprot_t prot = PAGE_KERNEL_EXEC;
+
+	return __vmalloc(size, GFP_KERNEL, prot);
+}
+
+/*
+ * Simple Elf Loader
+ */
+int load_elf(void)
+{
+	Elf64_Ehdr *h = elfdata;
+	Elf64_Shdr *sh;
+	size_t length;
+	char *sh_strtbl;
+	int i;
+
+	strtbl = NULL;
+	symtbl = NULL;
+
+	if (h == NULL)
+		return -ENOENT;
+
+	if (strncmp(h->e_ident, ELFMAG, SELFMAG))
+		return -EINVAL;
+
+	if (h->e_machine != EM_AARCH64)
+		return -ENOTTY;
+
+	/* determine memory needed for executable image */
+	sh = elfdata + h->e_shoff;
+	for (i=0; i < h->e_shnum; i++, sh++)
+		if (sh->sh_flags & SHF_ALLOC)
+			length = sh->sh_addr + sh->sh_size;
+
+	/* round up to page align */
+	bin_valid_bytes = length;
+	length = (length + 0xfff) & ~0xfffL;
+
+	/* allocate executable memory */
+	if (bin_image)
+		vfree(bin_image);
+	bin_image = vmalloc_exec(length);
+	memset(bin_image, 0, length);
+
+	/* iterate over sections */
+	sh = elfdata + h->e_shoff;
+	sh_strtbl = elfdata + sh[h->e_shstrndx].sh_offset;
+	for (i=0; i < h->e_shnum; i++, sh++) {
+
+		if (sh->sh_flags & SHF_ALLOC) {
+			if (sh->sh_type == SHT_NOBITS)
+				memset(bin_image + sh->sh_addr, 0, sh->sh_size);
+			else
+				memcpy(bin_image + sh->sh_addr, elfdata + sh->sh_offset, sh->sh_size);
+			if (sh->sh_flags & SHF_EXECINSTR)
+				start_offset = sh->sh_addr;
+		} else {
+			if (sh->sh_type == SHT_SYMTAB &&
+			    strcmp(sh_strtbl + sh->sh_name, ".symtab") == 0) {
+				symtbl = elfdata + sh->sh_offset;
+				symtbl_end = elfdata + sh->sh_offset + sh->sh_size;
+			}
+			if (sh->sh_type == SHT_STRTAB &&
+			    strcmp(sh_strtbl + sh->sh_name, ".strtab") == 0)
+				strtbl = elfdata + sh->sh_offset;
+		}
+	}
+	flush_icache_range((unsigned long)bin_image, length);
+	return 0;
+}
+
+static ssize_t run_show(struct device *dev,
+			  struct device_attribute *attr,
+			  char *buf)
+{
+	return sprintf(buf, "%lx\n", (long)bin_image);
+}
+
+static ssize_t run_store(struct device *dev,
+			   struct device_attribute *attr,
+			   const char *buf,
+			   size_t count)
+{
+	void *(*start_fn)(void *), (*version_fn)(char **);
+	struct kpcimgr_entry_points_t *ep;
+	struct module mod;
+	char *version;
+	int ret;
+
+	if (elfdata == NULL)
+		return -ENODEV;
+
+	ret = load_elf();
+	if (ret)
+		return ret;
+
+	start_fn = bin_image + start_offset;
+	ep = start_fn(NULL);
+
+	pr_info("pciesvc_loader: expected mgr ver=%d, lib version=%d.%d\n",
+	       ep->expected_mgr_version,
+	       ep->lib_version_major, ep->lib_version_minor);
+
+	version_fn = ep->entry_point[K_ENTRY_GET_VERSION];
+	(void) version_fn(&version);
+	pr_info("pciesvc_loader: lib returned version string '%s'\n", version);
+
+	mod.core_layout.base = bin_image;
+	mod.core_layout.size = bin_valid_bytes;
+	mod.init_layout.base = 0;
+	mod.init_layout.size = 0;
+	strcpy(mod.name, "pciesvc.lib");
+
+	ret = kpcimgr_module_register(&mod, ep, 1);
+	if (ret) {
+		pr_err("kpcimgr_module_register returned %d\n", ret);
+		pr_err("bin_image was at 0x%lx\n", (long)bin_image);
+		vfree(bin_image);
+		bin_image = NULL;
+	}
+
+	return count;
+}
+
+
+static ssize_t valid_show(struct device *dev,
+			  struct device_attribute *attr,
+			  char *buf)
+{
+	Elf64_Ehdr *h = elfdata;
+	int valid;
+
+	valid = (h && h->e_machine == EM_AARCH64 &&
+		 strncmp(h->e_ident, ELFMAG, SELFMAG) == 0);
+
+	return sprintf(buf, "%d\n", valid);
+}
+
+static ssize_t valid_store(struct device *dev,
+			   struct device_attribute *attr,
+			   const char *buf,
+			   size_t count)
+{
+	ssize_t rc;
+	long val;
+
+	rc = kstrtol(buf, 0, &val);
+	if (rc)
+		return rc;
+	elf_valid_bytes = val;
+	pr_info("%s: valid set to %d\n", __func__, elf_valid_bytes);
+
+	return count;
+}
+
+static ssize_t code_read(struct file *file, struct kobject *kobj,
+			   struct bin_attribute *attr, char *out,
+			   loff_t off, size_t count)
+{
+	if (elfdata == NULL)
+		return 0;
+
+	if (off > elf_valid_bytes)
+		return 0;
+	if (off + count > elf_valid_bytes)
+		count = elf_valid_bytes - off;
+
+	memcpy(out, elfdata + off, count);
+	return count;
+}
+
+static ssize_t code_write(struct file *filp, struct kobject *kobj,
+			     struct bin_attribute *bin_attr, char *buf,
+			     loff_t off, size_t count)
+{
+	static int code_size = 64*1024;
+
+	if (elfdata == NULL) {
+		elfdata = vmalloc(code_size);
+		if (elfdata == NULL) {
+			pr_err("module_alloc\n");
+			return -ENOMEM;
+		}
+	}
+
+	if (off + count > code_size) {
+		void *new = vmalloc(2*code_size);
+		if (new == NULL) {
+			pr_err("module_alloc\n");
+			return -ENOMEM;
+		}
+		memcpy(new, elfdata, code_size);
+		vfree(elfdata);
+		elfdata = new;
+		code_size = 2*code_size;
+	}
+
+	memcpy(elfdata + off, buf, count);
+	elf_valid_bytes = off + count;
+	return count;
+}
+
+struct kobject *pciesvc_kobj;
+static DEVICE_ATTR_RW(valid);
+static DEVICE_ATTR_RW(run);
+static struct attribute *dev_attrs[] = {
+	&dev_attr_valid.attr,
+	&dev_attr_run.attr,
+	NULL,
+};
+
+#define CODE_BLOCK_SIZE 256*1024
+static BIN_ATTR_RW(code, CODE_BLOCK_SIZE);
+static struct bin_attribute *dev_bin_attrs[] = {
+	&bin_attr_code,
+	NULL,
+};
+
+const struct attribute_group pciesvc_attr_group = {
+	.attrs = dev_attrs,
+	.bin_attrs = dev_bin_attrs,
+};
+
+
+static void pciesvc_sysfs_init(void)
+{
+	pciesvc_kobj = kobject_create_and_add("pciesvc", kernel_kobj);
+	if (pciesvc_kobj == NULL) {
+		pr_err("failed to create kernel obj\n");
+		return;
+	}
+
+	if (sysfs_create_group(pciesvc_kobj, &pciesvc_attr_group)) {
+		pr_err("sysfs_create_group failed\n");
+		return;
+	}
+}
+
+/*
+ * This is a routine that is called from an optional hook
+ * in kernel/kallsyms.c/kallsyms_lookup()
+ */
+char *pciesvc_address_lookup(unsigned long addr,
+			     unsigned long *symbolsize,
+			     unsigned long *offset,
+			     char **modname, char *namebuf)
+{
+	kstate_t *ks = get_kpci_state();
+	unsigned long base, code_sz;
+        unsigned long candidate = 0;
+        Elf64_Sym *sym;
+        int i, index;
+
+	base = (unsigned long) ks->code_base;
+	code_sz = ks->code_size;
+
+	/* range check */
+	if (addr < base || addr >= base + code_sz)
+		return NULL;
+
+	addr = addr - base;
+
+        if (!symtbl || !strtbl)
+                return NULL;
+
+        /* Look up symbol in our table */
+	/* Could sort this, but we typically would get here via panic */
+        for (i = 0, sym = symtbl; sym < symtbl_end; i++, sym++){
+                if (ELF64_ST_TYPE(sym->st_info) == STT_FUNC) {
+                        if (sym->st_value > candidate && sym->st_value <= addr){
+                                candidate = sym->st_value;
+				index = i;
+                        }
+                }
+        }
+
+	if (candidate) {
+		sym = &symtbl[index];
+		sprintf(namebuf, "%s", strtbl + sym->st_name);
+		if (symbolsize)
+			*symbolsize = sym->st_size;
+		if (offset)
+			*offset = addr - candidate;
+		*modname = "pciesvc.lib";
+		return namebuf;
+	}
+	else
+		return NULL;
+}
+
+/*
+ * Panic hook. On systems with kdump enabled, this won't get
+ * called unless you put "crash_kexec_post_notifiers" on the
+ * boot command line.
+ */
+static int pciesvc_panic(struct notifier_block *nb,
+			 unsigned long code, void *unused)
+{
+	unsigned long entries[48], offset, size;
+	struct stack_trace trace;
+	char *modname, buffer[256];
+	const char *name;
+	int i, len;
+
+	trace.nr_entries = 0;
+	trace.max_entries = ARRAY_SIZE(entries);
+	trace.entries = entries;
+	trace.skip = 0;
+
+	save_stack_trace(&trace);
+	pr_emerg("pciesvc stack trace:\n");
+	for (i=0; i<trace.nr_entries; i++) {
+		name = pciesvc_address_lookup(entries[i], &size, &offset,
+					      &modname, buffer);
+		if (name) {
+			len = strlen(buffer);
+			len += sprintf(buffer + len, "+%#lx/%#lx", offset, size);
+			if (modname)
+				len += sprintf(buffer + len, " [%s]", modname);
+		}
+		else
+			sprint_symbol(buffer, entries[i]);
+		pr_emerg("%s\n", buffer);
+	}
+
+	return NOTIFY_DONE;
+}
+
+struct notifier_block panic_notifier;
+#ifdef KERNEL_HAS_GENERIC_LOOKUP
+void register_generic_address_lookup(void *fn);
+#endif
+
+static int __init pciesvc_loader_probe(void)
+{
+	kstate_t *ks;
+
+	ks = get_kpci_state();
+	if (ks == NULL)
+		return -ENXIO;
+
+	pciesvc_sysfs_init();
+
+	/* register panic notifier */
+	panic_notifier.notifier_call = pciesvc_panic;
+        atomic_notifier_chain_register(&panic_notifier_list,
+                                       &panic_notifier);
+
+#ifdef KERNEL_HAS_GENERIC_LOOKUP
+	register_generic_address_lookup(pciesvc_address_lookup);
+#endif
+	return 0;
+}
+
+static void __exit pciesvc_loader_cleanup(void)
+{
+	kstate_t *ks;
+
+	/* unregister panic notifier */
+       atomic_notifier_chain_unregister(&panic_notifier_list,
+                                         &panic_notifier);
+
+#ifdef KERNEL_HAS_GENERIC_LOOKUP
+	register_generic_address_lookup(NULL);
+#endif
+	pr_info("Cleaning up module.\n");
+	sysfs_remove_group(pciesvc_kobj, &pciesvc_attr_group);
+	kobject_del(pciesvc_kobj);
+
+	ks = get_kpci_state();
+	vfree(ks);
+	vfree(elfdata);
+	vfree(bin_image);
+}
+
+module_init(pciesvc_loader_probe);
+module_exit(pciesvc_loader_cleanup);
+MODULE_LICENSE("GPL");

--- a/drivers/linux/pciesvc/pciesvc_system_extern.h
+++ b/drivers/linux/pciesvc/pciesvc_system_extern.h
@@ -5,13 +5,138 @@
 #ifndef __PCIESVC_SYSTEM_EXTERN_H__
 #define __PCIESVC_SYSTEM_EXTERN_H__
 
+#ifndef __KERNEL__
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#define __USE_GNU
+#include <string.h>
+#include <inttypes.h>
+#include <assert.h>
+#include <endian.h>
+#include <sys/param.h>
+#include <stdarg.h>
+#endif
+
 #include "kpcimgr_api.h"
+#include <linux/pci_regs.h>
 #include "pciesvc.h"
 #include "portcfg.h"
-
-#include <linux/pci_regs.h>
 #include "notify_entry.h"
 #include "cfgspace.h"
+
+
+#ifdef __KERNEL__
+#define MIN(x,y) ((x) < (y) ? x : y)
+#define MAX(x,y) ((x) > (y) ? x : y)
+
+#define PRIi64 "lld"
+
+#define PRIx8 "x"
+#define PRIx16 "x"
+#define PRIx32 "x"
+#define PRIx64 "llx"
+#define PRIu64 "llu"
+
+#define pciesvc_htobe32(x) __cpu_to_be32(x)
+#define pciesvc_be32toh(x) __be32_to_cpu(x)
+
+#define pciesvc_htole32(x) __cpu_to_le32(x)
+#define pciesvc_le32toh(x) __le32_to_cpu(x)
+
+#define pciesvc_htobe16(x) __cpu_to_be16(x)
+#define pciesvc_be16toh(x) __be16_to_cpu(x)
+
+#endif
+
+#ifndef __KERNEL__
+#define pciesvc_htobe32         htobe32
+#define pciesvc_be32toh         be32toh
+#define pciesvc_htobe16         htobe16
+#define pciesvc_be16toh         be16toh
+#define pciesvc_htole32         htole32
+#define pciesvc_le32toh         le32toh
+
+
+#define unlikely(X) (X)
+typedef __u64 u64;
+typedef __u32 u32;
+#define __force
+#define __iomem
+#define __le32 u32
+#define le32_to_cpu
+#define cpu_to_le32
+/* borrowed from "include/linux/kern_levels.h" */
+#define KERN_SOH        "\001"          /* ASCII Start Of Header */
+#define KERN_ERR        KERN_SOH "3"    /* error conditions */
+#define KERN_INFO       KERN_SOH "6"    /* informational */
+
+/* borrowed from "arch/arm64/include/asm/io.h" */
+#define __stringify_1(x...)     #x
+#define __stringify(x...)       __stringify_1(x)
+#define read_sysreg(r) ({                                       \
+        u64 __val;                                              \
+        asm volatile("mrs %0, " __stringify(r) : "=r" (__val)); \
+        __val;                                                  \
+})
+#define dmb(opt)        asm volatile("dmb " #opt : : : "memory")
+#define dsb(opt)        asm volatile("dsb " #opt : : : "memory")
+#define mb()            dsb(sy)
+#define dma_rmb()       dmb(oshld)
+#define dma_wmb()       dmb(oshst)
+
+/* readl/writel */
+/* IO barriers */
+#define __iormb(v)                                                      \
+({                                                                      \
+        unsigned long tmp;                                              \
+                                                                        \
+        dma_rmb();                                                              \
+                                                                        \
+        /*                                                              \
+         * Create a dummy control dependency from the IO read to any    \
+         * later instructions. This ensures that a subsequent call to   \
+         * udelay() will be ordered due to the ISB in get_cycles().     \
+         */                                                             \
+        asm volatile("eor       %0, %1, %1\n"                           \
+                     "cbnz      %0, ."                                  \
+                     : "=r" (tmp) : "r" ((unsigned long)(v))            \
+                     : "memory");                                       \
+})
+
+#define __raw_writel __raw_writel
+static inline void __raw_writel(u32 val, volatile void __iomem *addr)
+{
+        asm volatile("str %w0, [%1]" : : "rZ" (val), "r" (addr));
+}
+
+#define __raw_readl __raw_readl
+static inline u32 __raw_readl(const volatile void __iomem *addr)
+{
+        u32 val;
+        asm volatile("ldr %w0, [%1]"
+                     : "=r" (val) : "r" (addr));
+        return val;
+}
+
+#define __iowmb()               dma_wmb()
+#define readl_relaxed(c)        ({ u32 __r = le32_to_cpu((__force __le32)__raw_readl(c)); __r; })
+#define writel_relaxed(v,c)     ((void)__raw_writel((__force u32)cpu_to_le32(v),(c)))
+#define readl(c)                ({ u32 __v = readl_relaxed(c); __iormb(__v); __v; })
+#define writel(v,c)             ({ __iowmb(); writel_relaxed((v),(c)); })
+
+static inline kstate_t *get_kstate(void)
+{
+	extern kstate_t *kstate;
+	return kstate;
+}
+
+#endif /* !KERNEL */
+
 
 #define KPR_LINESZ 512
 #define kpr_err(fmt, ...) \
@@ -41,25 +166,6 @@
 #define pciesvc_ffs             ffs
 #define pciesvc_ffsll           __builtin_ffsl
 
-#define MIN(x,y) ((x) < (y) ? x : y)
-#define MAX(x,y) ((x) > (y) ? x : y)
-
-#define PRIi64 "lld"
-
-#define PRIx8 "x"
-#define PRIx16 "x"
-#define PRIx32 "x"
-#define PRIx64 "llx"
-#define PRIu64 "llu"
-
-#define pciesvc_htobe32(x) __cpu_to_be32(x)
-#define pciesvc_be32toh(x) __be32_to_cpu(x)
-
-#define pciesvc_htole32(x) __cpu_to_le32(x)
-#define pciesvc_le32toh(x) __le32_to_cpu(x)
-
-#define pciesvc_htobe16(x) __cpu_to_be16(x)
-#define pciesvc_be16toh(x) __be16_to_cpu(x)
 
 #define CLEAN                   0
 #define DIRTY                   1

--- a/drivers/linux/pciesvc/tools/reloc_check
+++ b/drivers/linux/pciesvc/tools/reloc_check
@@ -38,10 +38,12 @@ fi
 
 nm -u $1  | grep -v mcount | awk '{ print $2 }' | 
   {
-    read pattern
-    if [ "$pattern" != kpcimgr_module_register ]
+    if read pattern
     then
-	echo Caution: found undesirable symbol $pattern
+      if [ "$pattern" != kpcimgr_module_register ]
+      then
+  	  echo Caution: found undesirable symbol $pattern
+      fi
     fi
 
     while read symbol
@@ -52,9 +54,15 @@ nm -u $1  | grep -v mcount | awk '{ print $2 }' |
 	  echo Caution: found undesirable symbol $symbol
 	fi
     done
-    echo checking objects for any of these symbols: $pattern
 
-    nm kpci_entry.o kpcinterface.o pciesvc/src/*.o | grep -E $pattern >$tmp
+    if [ -z $pattern ]
+    then
+       echo No undesirable symbols founds
+       >$tmp
+    else
+       echo checking objects for any of these symbols: $pattern
+       nm kpci_entry.o kpcinterface.o pciesvc/src/*.o | grep -E $pattern >$tmp
+    fi
   }
 
 if [ -s $tmp ]


### PR DESCRIPTION
Overview:
Update module wrapper to support pciesvc_loader and pciesvc.lib. Maintain compatibility with pciesvc.ko module.
pciesvc version unchanged at 3.5

Internal patch list:

- kpcimgr: pciesvc.lib support
- pcisvc_lib: use TOOLCHAIN_PREFIX for toolchain
- kpcimgr: ksrc packs pciesvc_loader, CC -fno-store-merging support