### PR TITLE
dsc-drivers: update ionic drivers to 24.03.4-003

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,12 +195,15 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - fix 16bit math issue when PAGE_SIZE >= 64KB
  - restrict page-cache allocation to Rx queues
 
-23-12-14 - driver update for 23.12.2-001
+2023-12-14 - driver update for 23.12.2-001
  - updates from upstream kernel fixes
  - updates to FLR handling
  - added AER error handling
 
-24-03-19 - driver update for 24.03.1-002
+2024-03-19 - driver update for 24.03.1-002
  - Add XDP support
  - Refactor Tx and Rx fast paths for performance
  - Refactor struct sizes, layout, and usage for memory savings and performance
+
+2024-04-03 - driver update for 24.03.4-002
+ - Fix to reduce impact of missed doorbell workaround

--- a/README.md
+++ b/README.md
@@ -207,3 +207,6 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
 
 2024-04-03 - driver update for 24.03.4-002
  - Fix to reduce impact of missed doorbell workaround
+
+24-04-16 - driver update for 24.03.4-003
+ - Doorbell workaround now uses AdminQ's last used cpu

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -69,7 +69,7 @@ ALL = eth
 endif
 
 ifeq ($(DVER),)
-    DVER = "24.03.4-002"
+    DVER = "24.03.4-003"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -69,7 +69,7 @@ ALL = eth
 endif
 
 ifeq ($(DVER),)
-    DVER = "24.03.1-002"
+    DVER = "24.03.4-002"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 

--- a/drivers/linux/eth/ionic/ionic.h
+++ b/drivers/linux/eth/ionic/ionic.h
@@ -80,6 +80,7 @@ struct ionic {
 	struct rw_semaphore vf_op_lock;	/* lock for VF operations */
 	struct ionic_vf *vfs;
 	int num_vfs;
+	struct timer_list doorbell_timer;
 	struct timer_list watchdog_timer;
 	int watchdog_period;
 };

--- a/drivers/linux/eth/ionic/ionic_debugfs.c
+++ b/drivers/linux/eth/ionic/ionic_debugfs.c
@@ -519,6 +519,16 @@ static int lif_n_txrx_alloc_show(struct seq_file *seq, void *v)
 }
 DEFINE_SHOW_ATTRIBUTE(lif_n_txrx_alloc);
 
+static int lif_adminq_cpu_show(struct seq_file *seq, void *v)
+{
+	struct ionic_lif *lif = seq->private;
+
+	seq_printf(seq, "%u\n", lif->adminq_cpu);
+
+	return 0;
+}
+DEFINE_SHOW_ATTRIBUTE(lif_adminq_cpu);
+
 void ionic_debugfs_add_lif(struct ionic_lif *lif)
 {
 	struct dentry *lif_dentry;
@@ -538,6 +548,8 @@ void ionic_debugfs_add_lif(struct ionic_lif *lif)
 			    lif, &lif_filters_fops);
 	debugfs_create_file("txrx_alloc", 0400, lif->dentry,
 			    lif, &lif_n_txrx_alloc_fops);
+	debugfs_create_file("adminq_cpu", 0400, lif->dentry,
+			    lif, &lif_adminq_cpu_fops);
 }
 
 void ionic_debugfs_del_lif(struct ionic_lif *lif)

--- a/drivers/linux/eth/ionic/ionic_dev.c
+++ b/drivers/linux/eth/ionic/ionic_dev.c
@@ -48,7 +48,7 @@ void ionic_watchdog_cb(struct timer_list *t)
 
 		work->type = IONIC_DW_TYPE_RX_MODE;
 		netdev_dbg(lif->netdev, "deferred: rx_mode\n");
-		ionic_lif_deferred_enqueue(&lif->deferred, work);
+		ionic_lif_deferred_enqueue(lif, &lif->deferred, work);
 	}
 }
 
@@ -86,11 +86,11 @@ void ionic_doorbell_cb(struct timer_list *timer)
 		work = kzalloc(sizeof(*work), GFP_ATOMIC);
 		if (work) {
 			work->type = IONIC_DW_TYPE_DOORBELL;
-			ionic_lif_deferred_enqueue(&lif->deferred, work);
+			ionic_lif_deferred_enqueue(lif, &lif->deferred, work);
 		}
 	}
 
-	mod_timer(&ionic->doorbell_timer, jiffies + IONIC_NAPI_DEADLINE);
+	mod_timer(&ionic->doorbell_timer, jiffies + IONIC_ADMIN_DOORBELL_DEADLINE);
 }
 
 void ionic_init_devinfo(struct ionic *ionic)
@@ -302,7 +302,7 @@ do_check_time:
 			if (work) {
 				work->type = IONIC_DW_TYPE_LIF_RESET;
 				work->fw_status = fw_status_ready;
-				ionic_lif_deferred_enqueue(&lif->deferred, work);
+				ionic_lif_deferred_enqueue(lif, &lif->deferred, work);
 			}
 		}
 	}

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -33,7 +33,7 @@
 #define IONIC_DEV_INFO_REG_COUNT	32
 #define IONIC_DEV_CMD_REG_COUNT		32
 
-#define IONIC_NAPI_DEADLINE		(HZ / 200)	/* 5ms */
+#define IONIC_NAPI_DEADLINE		(HZ / 50)	/* 20ms */
 #define IONIC_ADMIN_DOORBELL_DEADLINE	(HZ / 2)	/* 500ms */
 #define IONIC_TX_DOORBELL_DEADLINE	(HZ / 100)	/* 10ms */
 #define IONIC_RX_MIN_DOORBELL_DEADLINE	(HZ / 100)	/* 10ms */
@@ -423,6 +423,7 @@ bool ionic_q_is_posted(struct ionic_queue *q, unsigned int pos);
 
 int ionic_heartbeat_check(struct ionic *ionic);
 bool ionic_is_fw_running(struct ionic_dev *idev);
+void ionic_doorbell_cb(struct timer_list *timer);
 void ionic_watchdog_cb(struct timer_list *t);
 void ionic_watchdog_init(struct ionic *ionic);
 

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -120,7 +120,6 @@ struct ionic_qcq {
 	u32 cmb_order;
 	bool armed;
 	struct dim dim;
-	struct timer_list napi_deadline;
 	struct ionic_queue q;
 	struct ionic_cq cq;
 	struct napi_struct napi;
@@ -142,6 +141,7 @@ enum ionic_deferred_work_type {
 	IONIC_DW_TYPE_RX_MODE,
 	IONIC_DW_TYPE_LINK_STATUS,
 	IONIC_DW_TYPE_LIF_RESET,
+	IONIC_DW_TYPE_DOORBELL,
 };
 
 struct ionic_deferred_work {

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -123,7 +123,6 @@ struct ionic_qcq {
 	struct ionic_queue q;
 	struct ionic_cq cq;
 	struct napi_struct napi;
-	struct ionic_qcq *napi_qcq;
 	struct ionic_intr_info intr;
 #ifdef IONIC_DEBUG_STATS
 	struct ionic_napi_stats napi_stats;
@@ -270,6 +269,7 @@ struct ionic_lif {
 	unsigned int index;
 	unsigned int hw_index;
 	unsigned int link_down_count;
+	unsigned int adminq_cpu;
 
 	u8 rss_hash_key[IONIC_RSS_HASH_KEY_SIZE];
 	u8 *rss_ind_tbl;
@@ -408,7 +408,8 @@ static inline bool ionic_txq_hwstamp_enabled(struct ionic_queue *q)
 	return q->features & IONIC_TXQ_F_HWSTAMP;
 }
 
-void ionic_lif_deferred_enqueue(struct ionic_deferred *def,
+void ionic_lif_deferred_enqueue(struct ionic_lif *lif,
+				struct ionic_deferred *def,
 				struct ionic_deferred_work *work);
 void ionic_link_status_check_request(struct ionic_lif *lif, bool can_sleep);
 #ifdef HAVE_VOID_NDO_GET_STATS64

--- a/drivers/linux/eth/ionic/ionic_main.c
+++ b/drivers/linux/eth/ionic/ionic_main.c
@@ -324,7 +324,7 @@ bool ionic_notifyq_service(struct ionic_cq *cq)
 				clear_bit(IONIC_LIF_F_FW_STOPPING, lif->state);
 			} else {
 				work->type = IONIC_DW_TYPE_LIF_RESET;
-				ionic_lif_deferred_enqueue(&lif->deferred, work);
+				ionic_lif_deferred_enqueue(lif, &lif->deferred, work);
 			}
 		}
 		break;

--- a/drivers/linux/eth/ionic/ionic_txrx.c
+++ b/drivers/linux/eth/ionic/ionic_txrx.c
@@ -1022,6 +1022,9 @@ void ionic_rx_fill(struct ionic_queue *q)
 
 	ionic_dbell_ring(q->lif->kern_dbpage, q->hw_type,
 			 q->dbval | q->head_idx);
+
+	q->dbell_deadline = IONIC_RX_MIN_DOORBELL_DEADLINE;
+	q->dbell_jiffies = jiffies;
 }
 
 void ionic_rx_empty(struct ionic_queue *q)


### PR DESCRIPTION
This is a combination of the earlier 24.03.4-002 patch and a refinement that makes sure the doorbell checking workqueue activity happens on the same cpu as the last AdminQ napi for a particular device.  This makes sure that the activity is following any related irqbalance movements of the device's cpu assignments.