### PR TITLE
dsc-drivers: update drivers to 24.04.2-002

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,7 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - Add XDP support
  - Refactor Tx and Rx fast paths for performance
  - Refactor struct sizes, layout, and usage for memory savings and performance
+
+24-04-25 - driver update for 24.04.2-002
+ - reworked ionic's missed-doorbell fix to reduce latency and throughput issues seen
+ - ionic_mnic work in preparation for future platform device model changes

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -69,7 +69,7 @@ ALL = eth
 endif
 
 ifeq ($(DVER),)
-    DVER = "24.03.1-002"
+    DVER = "24.04.2-001"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -69,7 +69,7 @@ ALL = eth
 endif
 
 ifeq ($(DVER),)
-    DVER = "24.04.2-001"
+    DVER = "24.04.2-002"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 

--- a/drivers/linux/eth/ionic/ionic.h
+++ b/drivers/linux/eth/ionic/ionic.h
@@ -59,8 +59,9 @@ struct ionic {
 	struct dentry *dentry;
 	struct ionic_dev_bar bars[IONIC_BARS_MAX];
 	unsigned int num_bars;
-	struct ionic_identity ident;
 	bool is_mgmt_nic;
+	struct ionic_identity ident;
+	struct workqueue_struct *wq;
 	struct ionic_lif *lif;
 	unsigned int nnqs_per_lif;
 	unsigned int nrdma_eqs_per_lif;
@@ -72,6 +73,7 @@ struct ionic {
 #ifndef HAVE_PCI_IRQ_API
 	struct msix_entry *msix;
 #endif
+	struct delayed_work doorbell_check_dwork;
 	struct work_struct nb_work;
 	struct notifier_block nb;
 #ifdef IONIC_DEVLINK
@@ -82,6 +84,8 @@ struct ionic {
 	int num_vfs;
 	struct timer_list watchdog_timer;
 	int watchdog_period;
+
+	const char *mnet_netdev_name;
 };
 
 int ionic_adminq_post(struct ionic_lif *lif, struct ionic_admin_ctx *ctx);

--- a/drivers/linux/eth/ionic/ionic_bus.h
+++ b/drivers/linux/eth/ionic/ionic_bus.h
@@ -10,7 +10,6 @@ int ionic_bus_alloc_irq_vectors(struct ionic *ionic, unsigned int nintrs);
 void ionic_bus_free_irq_vectors(struct ionic *ionic);
 int ionic_bus_register_driver(void);
 void ionic_bus_unregister_driver(void);
-struct net_device *ionic_alloc_netdev(struct ionic *ionic);
 void __iomem *ionic_bus_map_dbpage(struct ionic *ionic, int page_num);
 void ionic_bus_unmap_dbpage(struct ionic *ionic, void __iomem *page);
 phys_addr_t ionic_bus_phys_dbpage(struct ionic *ionic, int page_num);

--- a/drivers/linux/eth/ionic/ionic_bus_pci.c
+++ b/drivers/linux/eth/ionic/ionic_bus_pci.c
@@ -76,15 +76,6 @@ void ionic_bus_free_irq_vectors(struct ionic *ionic)
 #endif
 }
 
-struct net_device *ionic_alloc_netdev(struct ionic *ionic)
-{
-	dev_dbg(ionic->dev, "nxqs=%d nintrs=%d\n",
-		ionic->ntxqs_per_lif, ionic->nintrs);
-
-	return alloc_etherdev_mqs(sizeof(struct ionic_lif),
-				  ionic->ntxqs_per_lif, ionic->ntxqs_per_lif);
-}
-
 static int ionic_map_bars(struct ionic *ionic)
 {
 	struct pci_dev *pdev = ionic->pdev;
@@ -440,6 +431,7 @@ static int ionic_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 
 	mod_timer(&ionic->watchdog_timer,
 		  round_jiffies(jiffies + ionic->watchdog_period));
+	ionic_queue_doorbell_check(ionic, IONIC_NAPI_DEADLINE);
 
 	return 0;
 

--- a/drivers/linux/eth/ionic/ionic_dev.c
+++ b/drivers/linux/eth/ionic/ionic_dev.c
@@ -62,8 +62,7 @@ void ionic_doorbell_napi_work(struct work_struct *work)
 	then = qcq->q.dbell_jiffies;
 	dif = now - then;
 
-	/* Use a larger check value here to minimize impact */
-	if (dif > IONIC_NAPI_DEADLINE / 2)
+	if (dif > qcq->q.dbell_deadline)
 		napi_schedule(&qcq->napi);
 }
 

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -33,7 +33,7 @@
 #define IONIC_DEV_INFO_REG_COUNT	32
 #define IONIC_DEV_CMD_REG_COUNT		32
 
-#define IONIC_NAPI_DEADLINE		(HZ / 200)	/* 5ms */
+#define IONIC_NAPI_DEADLINE		(HZ)		/* 1 sec */
 #define IONIC_ADMIN_DOORBELL_DEADLINE	(HZ / 2)	/* 500ms */
 #define IONIC_TX_DOORBELL_DEADLINE	(HZ / 100)	/* 10ms */
 #define IONIC_RX_MIN_DOORBELL_DEADLINE	(HZ / 100)	/* 10ms */
@@ -327,6 +327,7 @@ struct ionic_cq {
 	bool done_color;
 	unsigned int num_descs;
 	unsigned int desc_size;
+	unsigned int last_cpu;
 #ifdef IONIC_DEBUG_STATS
 	u64 compl_count;
 #endif
@@ -424,7 +425,9 @@ bool ionic_q_is_posted(struct ionic_queue *q, unsigned int pos);
 int ionic_heartbeat_check(struct ionic *ionic);
 bool ionic_is_fw_running(struct ionic_dev *idev);
 void ionic_watchdog_cb(struct timer_list *t);
-void ionic_watchdog_init(struct ionic *ionic);
+int ionic_watchdog_init(struct ionic *ionic);
+void ionic_doorbell_napi_work(struct work_struct *work);
+void ionic_queue_doorbell_check(struct ionic *ionic, int delay);
 
 bool ionic_adminq_poke_doorbell(struct ionic_queue *q);
 bool ionic_txq_poke_doorbell(struct ionic_queue *q);

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -120,15 +120,14 @@ struct ionic_qcq {
 	u32 cmb_order;
 	bool armed;
 	struct dim dim;
-	struct timer_list napi_deadline;
 	struct ionic_queue q;
 	struct ionic_cq cq;
 	struct napi_struct napi;
-	struct ionic_qcq *napi_qcq;
 	struct ionic_intr_info intr;
 #ifdef IONIC_DEBUG_STATS
 	struct ionic_napi_stats napi_stats;
 #endif
+	struct work_struct doorbell_napi_work;
 	struct dentry *dentry;
 };
 
@@ -408,7 +407,7 @@ static inline bool ionic_txq_hwstamp_enabled(struct ionic_queue *q)
 	return q->features & IONIC_TXQ_F_HWSTAMP;
 }
 
-void ionic_lif_deferred_enqueue(struct ionic_deferred *def,
+void ionic_lif_deferred_enqueue(struct ionic_lif *lif,
 				struct ionic_deferred_work *work);
 void ionic_link_status_check_request(struct ionic_lif *lif, bool can_sleep);
 #ifdef HAVE_VOID_NDO_GET_STATS64

--- a/drivers/linux/eth/ionic/ionic_main.c
+++ b/drivers/linux/eth/ionic/ionic_main.c
@@ -324,7 +324,7 @@ bool ionic_notifyq_service(struct ionic_cq *cq)
 				clear_bit(IONIC_LIF_F_FW_STOPPING, lif->state);
 			} else {
 				work->type = IONIC_DW_TYPE_LIF_RESET;
-				ionic_lif_deferred_enqueue(&lif->deferred, work);
+				ionic_lif_deferred_enqueue(lif, work);
 			}
 		}
 		break;


### PR DESCRIPTION
This is a driver update for testing of a different algorithm for handling the missed-doorbell fix in the ionic driver.

A latency test in a scaled out setting (many VMs with many queues) uncovered an issue with our earlier missed doorbell fix.  The basic issue is that we're delaying things with a timer for every single queue periodically using mod_timer() to reset itself, and mod_timer() becomes a more and more expensive thing as there are more and more VFs and queues each with their own timer.  A ping-pong latency test tends to exacerbate the effect such that every napi is doing a mod_timer() in every cycle.

This version replaces all the per-queue timers with a new workqueue per device, using a periodically workitem scheduled on the AdminQ's last cpu which queues a workitem per running queue, each of which will call napi_schedule on the specific queue if it hasn't already been run within a certain time period.

This update is intended only for the PCI host driver use.  There are a couple other changes related to some rework in our internal platform support - those can be ignored for the PCI host driver.