### PR TITLE
ionic: use cancel_delayed_work

### DIFF
--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -69,7 +69,7 @@ ALL = eth
 endif
 
 ifeq ($(DVER),)
-    DVER = "24.04.2-002"
+    DVER = "24.04.2-003"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 

--- a/drivers/linux/eth/ionic/ionic_dev.c
+++ b/drivers/linux/eth/ionic/ionic_dev.c
@@ -72,11 +72,9 @@ static void ionic_doorbell_check_dwork(struct work_struct *work)
 					   doorbell_check_dwork.work);
 	struct ionic_lif *lif = ionic->lif;
 
-	if (test_bit(IONIC_LIF_F_IN_SHUTDOWN, lif->state))
+	if (test_bit(IONIC_LIF_F_IN_SHUTDOWN, lif->state) ||
+	    test_bit(IONIC_LIF_F_FW_RESET, lif->state))
 		return;
-
-	if (test_bit(IONIC_LIF_F_FW_RESET, lif->state))
-		goto out;
 
 	mutex_lock(&lif->queue_lock);
 	napi_schedule(&lif->adminqcq->napi);
@@ -109,7 +107,6 @@ static void ionic_doorbell_check_dwork(struct work_struct *work)
 	}
 	mutex_unlock(&lif->queue_lock);
 
-out:
 	ionic_queue_doorbell_check(ionic, IONIC_NAPI_DEADLINE);
 }
 

--- a/drivers/linux/eth/ionic/ionic_lif.c
+++ b/drivers/linux/eth/ionic/ionic_lif.c
@@ -3595,6 +3595,7 @@ int ionic_restart_lif(struct ionic_lif *lif)
 	clear_bit(IONIC_LIF_F_FW_RESET, lif->state);
 	ionic_link_status_check_request(lif, CAN_SLEEP);
 	netif_device_attach(lif->netdev);
+	ionic_queue_doorbell_check(ionic, IONIC_NAPI_DEADLINE);
 
 	return 0;
 
@@ -3701,8 +3702,8 @@ void ionic_lif_deinit(struct ionic_lif *lif)
 	if (!test_and_clear_bit(IONIC_LIF_F_INITED, lif->state))
 		return;
 
+	cancel_delayed_work_sync(&lif->ionic->doorbell_check_dwork);
 	if (!test_bit(IONIC_LIF_F_FW_RESET, lif->state)) {
-		cancel_work_sync(&lif->ionic->doorbell_check_dwork.work);
 		cancel_work_sync(&lif->deferred.work);
 		cancel_work_sync(&lif->tx_timeout_work);
 		ionic_rx_filters_deinit(lif);


### PR DESCRIPTION
Use cancel_delayed_work_sync() on our delayed work items rather than cancel_work_sync() to be sure the timers get cleaned up correctly.

Since the qcq's are down over FW_RESET, don't check them for missed doorbell issues.