### PR TITLE
dsc-drivers: update to 24.07.1-001

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,8 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - ionic header files moved from common to eth/ionic
  - upstream code sync
  - various code cleanups
+
+24-08-13 - driver update for 24.07.1-001
+ - fix a bogus tx_timeout alarm
+ - add ability to build mdev on a newer kernel
+ - add int_mnic ip field in dev_info struct

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -32,7 +32,11 @@ KMOD_SRC_DIR ?= ${TOPDIR}/platform/drivers/linux-ionic
 ETH_KOPT += CONFIG_IONIC_MNIC=m
 ETH_KOPT += CONFIG_MDEV=m
 ETH_KOPT += CONFIG_MNET_UIO_PDRV_GENIRQ=m
+ifeq ($(TOOLCHAIN_VERSION),11)
+KOPT += CROSS_COMPILE=aarch64-none-linux-gnu-
+else
 KOPT += CROSS_COMPILE=aarch64-linux-gnu-
+endif
 KOPT += ARCH=arm64
 KCFLAGS += -DCONFIG_IONIC_MNIC
 KCFLAGS += -DCONFIG_MDEV
@@ -69,7 +73,7 @@ ALL = eth
 endif
 
 ifeq ($(DVER),)
-    DVER = "24.06.2-002"
+    DVER = "24.07.1-001"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 

--- a/drivers/linux/eth/ionic/Makefile
+++ b/drivers/linux/eth/ionic/Makefile
@@ -16,4 +16,7 @@ ionic_mnic-y := ionic_main.o ionic_bus_platform.o ionic_dev.o ionic_ethtool.o \
 	        ionic_lif.o ionic_rx_filter.o ionic_txrx.o ionic_debugfs.o \
 	        ionic_api.o ionic_stats.o ionic_devlink.o kcompat.o ionic_fw.o \
 		dim.o net_dim.o
-ionic_mnic-$(CONFIG_PTP_1588_CLOCK) += ionic_phc.o ionic_phc_weak.o
+ionic_mnic-$(CONFIG_PTP_1588_CLOCK) += ionic_phc.o
+ifeq ($(KVER),5.10.28-1)
+ionic_mnic-$(CONFIG_PTP_1588_CLOCK) += ionic_phc_weak.o
+endif

--- a/drivers/linux/eth/ionic/ionic_bus_platform.c
+++ b/drivers/linux/eth/ionic/ionic_bus_platform.c
@@ -126,10 +126,10 @@ int ionic_bus_get_irq(struct ionic *ionic, unsigned int num)
 	struct msi_desc *desc;
 	int i = 0;
 
-	for_each_msi_entry(desc, ionic->dev) {
+	MSI_FOR_EACH_DESC(desc, ionic->dev) {
 		if (i == num) {
 			dev_info(ionic->dev, "[i = %d] msi_entry: %d.%d\n",
-				 i, desc->platform.msi_index, desc->irq);
+				 i, MSI_INDEX(desc), desc->irq);
 
 			return desc->irq;
 		}
@@ -147,10 +147,10 @@ const char *ionic_bus_info(struct ionic *ionic)
 static void ionic_mnic_set_msi_msg(struct msi_desc *desc, struct msi_msg *msg)
 {
 	dev_dbg(desc->dev, "msi_index: [%d] (msi_addr hi_lo): %x_%x msi_data: %x\n",
-		desc->platform.msi_index, msg->address_hi,
+		MSI_INDEX(desc), msg->address_hi,
 		msg->address_lo, msg->data);
 
-	ionic_intr_msixcfg(desc->dev, desc->platform.msi_index,
+	ionic_intr_msixcfg(desc->dev, MSI_INDEX(desc),
 			   (((u64)msg->address_hi << 32) | msg->address_lo),
 			   msg->data, 0/*vctrl*/);
 }

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -37,7 +37,7 @@
 #define IONIC_ADMIN_DOORBELL_DEADLINE	(HZ / 2)	/* 500ms */
 #define IONIC_TX_DOORBELL_DEADLINE	(HZ / 100)	/* 10ms */
 #define IONIC_RX_MIN_DOORBELL_DEADLINE	(HZ / 100)	/* 10ms */
-#define IONIC_RX_MAX_DOORBELL_DEADLINE	(HZ * 5)	/* 5s */
+#define IONIC_RX_MAX_DOORBELL_DEADLINE	(HZ * 4)	/* 4s */
 
 struct ionic_dev_bar {
 	void __iomem *vaddr;

--- a/drivers/linux/eth/ionic/ionic_if.h
+++ b/drivers/linux/eth/ionic/ionic_if.h
@@ -3364,6 +3364,7 @@ struct ionic_hwstamp_regs {
  * @serial_num:      Serial number
  * @fw_version:      Firmware version
  * @oprom_regs:      oprom_regs to store oprom debug enable/disable and bmp
+ * @int_mnic_ip:     Int mnic ip address 169.254.<port>.1, byte 3 is 169
  * @hwstamp:         Hardware current timestamp registers
  */
 union ionic_dev_info_regs {
@@ -3381,7 +3382,8 @@ union ionic_dev_info_regs {
 		char   fw_version[IONIC_DEVINFO_FWVERS_BUFLEN];
 		char   serial_num[IONIC_DEVINFO_SERIAL_BUFLEN];
 		struct ionic_oprom_regs oprom_regs;
-		u8     rsvd_pad1024[916];
+		u8     int_mnic_ip[4];
+		u8     rsvd_pad1024[912];
 		struct ionic_hwstamp_regs hwstamp;
 	};
 	u32 words[512];

--- a/drivers/linux/eth/ionic/ionic_lif.c
+++ b/drivers/linux/eth/ionic/ionic_lif.c
@@ -3455,7 +3455,7 @@ int ionic_lif_alloc(struct ionic *ionic)
 		netdev->netdev_ops = &ionic_netdev_ops;
 
 	ionic_ethtool_set_ops(netdev);
-	netdev->watchdog_timeo = 2 * HZ;
+	netdev->watchdog_timeo = 5 * HZ;
 	netif_carrier_off(netdev);
 
 	lif->nrdma_eqs_avail = ionic->nrdma_eqs_per_lif;

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -6845,8 +6845,13 @@ static inline struct devlink *_kc_devlink_alloc(const struct devlink_ops *ops,
 #define txq_trans_cond_update txq_trans_update
 #endif
 
+#define MSI_INDEX(desc)			desc->platform.msi_index
+#define MSI_FOR_EACH_DESC(desc, dev)	for_each_msi_entry((desc), dev)
+
 #else
 #define HAVE_RINGPARAM_EXTACK
+#define MSI_INDEX(desc)			desc->msi_index
+#define MSI_FOR_EACH_DESC(desc, dev)	msi_for_each_desc((desc), dev, MSI_DESC_ALL)
 #endif /* 5.17 */
 
 #ifndef PCI_ERROR_RESPONSE

--- a/drivers/linux/mdev/mdev_drv.c
+++ b/drivers/linux/mdev/mdev_drv.c
@@ -583,7 +583,11 @@ static int __init mdev_init(void)
 {
 	int ret;
 
+#if (KERNEL_VERSION(6, 4, 0) > LINUX_VERSION_CODE)
 	mdev_class = class_create(THIS_MODULE, DRV_NAME);
+#else
+	mdev_class = class_create(DRV_NAME);
+#endif
 	if (IS_ERR(mdev_class)) {
 		ret = PTR_ERR(mdev_class);
 		goto error_out;


### PR DESCRIPTION
Small updates

Internal patch list:
    ionic: Prevent tx_timeout due to frequent doorbell ringing
    ionic_mnic: fix up ptp connections for newer kernel
    ionic_mnic: fix up msi search for newer kernel
    mdev: fix up for building with buildroot_2024
    build: fix Makefile for buildroot_2024
    ionic: Store int_mnic ip in dev info region of host mgmt