### PR TITLE
dsc-drivers: update ionic to 25.01.1-001

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,7 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - fix a bogus tx_timeout alarm
  - add ability to build mdev on a newer kernel
  - add int_mnic ip field in dev_info struct
+
+25-01-06 - driver update for 24.12.4-001
+ - new kernel config adaptations
+ - auxiliary_device for RDMA support

--- a/README.md
+++ b/README.md
@@ -224,6 +224,6 @@ As usual, if the Linux headers are elsewhere, add the appropriate -C magic:
  - add ability to build mdev on a newer kernel
  - add int_mnic ip field in dev_info struct
 
-25-01-06 - driver update for 24.12.4-001
+25-01-06 - driver update for 25.01.1-001
  - new kernel config adaptations
  - auxiliary_device for RDMA support

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -50,10 +50,21 @@ KSYMS_MNIC = $(KMOD_OUT_DIR)/Module.symvers.mnic
 KSYMS_UIO = $(KMOD_OUT_DIR)/Module.symvers.uio
 
 DVER = $(shell cd $(KMOD_SRC_DIR) ; git describe --tags 2>/dev/null)
+ifneq ($(DVER),)
+    XX = $(shell echo $(DVER) > $(KMOD_SRC_DIR)/git_tag ; ls $(KMOD_SRC_DIR) )
+else
+    DVER = $(shell cat $(KMOD_SRC_DIR)/git_tag)
+endif
 
 else
 
+# this host driver build assumes we're building in the linux-ionic directory
+# or from the drivers-linux-eth package ./drivers directory
+
 DVER = $(shell git describe --tags 2>/dev/null)
+ifeq ($(DVER),)
+    DVER = $(shell cat git_tag 2>/dev/null )
+endif
 
 # Ionic driver for host
 include linux_ver.mk
@@ -72,8 +83,9 @@ ALL = eth
 
 endif
 
+# fallback
 ifeq ($(DVER),)
-    DVER = "24.07.1-001"
+    DVER = "24.12.4-001"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 

--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -85,7 +85,7 @@ endif
 
 # fallback
 ifeq ($(DVER),)
-    DVER = "24.12.4-001"
+    DVER = "25.01.1-001"
 endif
 KCFLAGS += -Ddrv_ver=\\\"$(DVER)\\\"
 

--- a/drivers/linux/etc/Makefile.common
+++ b/drivers/linux/etc/Makefile.common
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2023-2024, Advanced Micro Devices, Inc.
+#
+# Note: you MUST set TOPDIR before including this file.
+
+ifdef KERNELRELEASE
+# kbuild part of makefile
+#
+
+# filechk
+FILECHK_TIMESTAMP := $(shell date +"%N")
+TMP_FILE := tmp.$(FILECHK_TIMESTAMP)
+
+define filecheck
+	$(Q)set -e;
+	$(if Q,echo '  CHK     $@';)        \
+	mkdir -p $(dir $@); \
+	$(call filechk_$(1)) < $< > $@.$(TMP_FILE);    \
+	if [ -r $@ ] && cmp -s $@ $@.$(TMP_FILE); then  \
+		rm -f $@.$(TMP_FILE);   \
+	else    \
+		$(if Q,echo '  UPD     $@';)    \
+		mv -f $@.$(TMP_FILE) $@;    \
+	fi
+endef
+
+# autocompat.h depends on the kernel compiled against.
+# However, there is nothing stopping the user compiling on multiple
+# machines in the same directory. The .kpath target provides a simple
+# dependency check for this.
+$(obj)/.kpath: FORCE
+	@if ! [ -f $@ ] || [ $$(cat $@) != $(objtree) ]; then		\
+		echo $(objtree) >$@;					\
+		$(if $(MMAKE_IN_KBUILD),,rm -f $(obj)/*.symvers;)	\
+	fi
+
+KSRC := $(or $(KBUILD_SRC), $(CURDIR))
+ODIR := $(CURDIR)
+ifeq ($(KSRC), $(KBUILD_EXTMOD))
+	KSRC := $(srctree)
+endif
+ifeq ($(ODIR), $(KBUILD_EXTMOD))
+	ODIR := $(srctree)
+endif
+
+ifeq ($(wildcard $(OFA_KSRC)),)
+define filechk_autocompat.h
+	$(src)/kernel_compat.sh -k $(KSRC) -o "$(ODIR)" -a $(ARCH) $(if $(filter 1,$(V)),-v,-q)
+endef
+else
+define filechk_autocompat.h
+	$(src)/kernel_compat.sh -k $(KSRC) -o "$(ODIR)" -a $(ARCH) -i '$(LINUXINCLUDE)' -f $(OFA_KSRC) $(if $(filter 1,$(V)),-v,-q)
+endef
+endif
+
+$(src)/autocompat.h: $(obj)/.kpath $(src)/kernel_compat.sh $(TOPDIR)/etc/kernel_compat_funcs.sh
+	+$(call filecheck,autocompat.h)
+	@touch $@
+
+endif

--- a/drivers/linux/etc/kernel_compat_funcs.sh
+++ b/drivers/linux/etc/kernel_compat_funcs.sh
@@ -1,0 +1,747 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2023-2024, Advanced Micro Devices, Inc.
+#
+
+err  () { echo >&2 "$*";    }
+log  () { err "$me: $*";    }
+vlog () { $verbose && err "$me: $*"; }
+fail () { log "$*"; exit 1; }
+try  () { "$@" || fail "'$*' failed"; }
+vmsg () { $quiet || log "$@"; }
+
+function usage()
+{
+    err
+    err "usage:"
+    err "  $me [options] <symbol1> <symbol2>"
+    err
+    err "description:"
+    err "  Produce a list of kernel compatibility macros to match the "
+    err "  kernel_compat.c and kernel_compat.h files"
+    err
+    err "options:"
+    err "  -k KPATH        -- Specify the path to the kernel build source tree"
+    err "                     defaults to /lib/modules/VERSION/build"
+    err "  -o PATH         -- Specify the output directory, if any"
+    err "                     defaults to KPATH"
+    err "  -r VERSION      -- Specify the kernel version instead to test"
+    err '                     defaults to `uname -r`'
+    err "  -a ARCH         -- Set the architecture to ARCH"
+    err "                     defaults to `uname -m`"
+    err "  -c CROSS_COMPILE-- Set the cross compiler"
+    err "                     defaults to none"
+    err "  -i include      -- kernel include path LINUXINCLUDE="
+    err "                     Use in case including different kernel header files"
+    err "  -f OFA ksrc     -- open fabrics kernel source"
+    err "                     if specified, OFA_KSRC= given priorify for grep"
+    err "                     instead of KBUILD_SRC="
+    err "  -m MAP          -- Specify a System map for the build kernel."
+    err "                     By default will look in KPATH and /boot"
+    err "  -q              -- Quieten the checks"
+    err "  -v              -- Verbose output"
+    err "  -s              -- Symbol list to use"
+    err "  <symbol>        -- Symbol to evaluate."
+    err "                     By default every symbol is evaluated"
+
+}
+
+######################################################################
+# Generic methods for standard symbol types
+
+# Look for up to 3 numeric components separated by dots and stop when
+# we find anything that doesn't match this.  Convert to a number like
+# the LINUX_VERSION_CODE macro does.
+function string_to_version_code
+{
+    local ver="$1"
+    local code=0
+    local place=65536
+    local num
+
+    while [ -n "$ver" ]; do
+    # Look for numeric component; if none found then we're done;
+    # otherwise add to the code
+    num=${ver%%[^0-9]*}
+    test -n "$num" || break
+    code=$((code + $num * $place))
+
+    # If this was the last component (place value = 1) then we're done;
+    # otherwise update place value
+    test $place -gt 1 || break
+    place=$((place / 256))
+
+    # Move past numeric component and following dot (if present)
+    ver=${ver#$num}
+    ver=${ver#.}
+    done
+
+    echo $code
+}
+
+# Test cases for string_to_version_code:
+# test $(string_to_version_code 1.2.3) = $((1 * 65536 + 2 * 256 + 3))
+# test $(string_to_version_code 12.34.56) = $((12 * 65536 + 34 * 256 + 56))
+# test $(string_to_version_code 12.34.56foo) = $((12 * 65536 + 34 * 256 + 56))
+# test $(string_to_version_code 12.34.56.78) = $((12 * 65536 + 34 * 256 + 56))
+# test $(string_to_version_code 12.34.56.foo) = $((12 * 65536 + 34 * 256 + 56))
+# test $(string_to_version_code 12.34.56-foo) = $((12 * 65536 + 34 * 256 + 56))
+# test $(string_to_version_code 12.34) = $((12 * 65536 + 34 * 256))
+# test $(string_to_version_code 12.34.0) = $((12 * 65536 + 34 * 256))
+# test $(string_to_version_code 12.34foo) = $((12 * 65536 + 34 * 256))
+# test $(string_to_version_code 12.34-56) = $((12 * 65536 + 34 * 256))
+# test $(string_to_version_code 12.34.foo) = $((12 * 65536 + 34 * 256))
+# test $(string_to_version_code 12.34-foo) = $((12 * 65536 + 34 * 256))
+
+function do_kver()
+{
+    shift 2;
+    local op="$1"
+    local right_ver="$2"
+
+    local left=$(string_to_version_code "$KVER")
+    local right=$(string_to_version_code "$right_ver")
+
+    local result=$((1 - ($left $op $right)))
+    local msg="$KVER $op $right_ver == $left $op $right == "
+    if [ $result = 0 ]; then
+        msg="$msg true"
+    else
+        msg="$msg false"
+    fi
+    vmsg "$msg"
+    return $result
+}
+
+function do_symbol()  { shift 2; test_symbol "$@"; }
+function do_nsymbol() { shift 2; ! test_symbol "$@"; }
+function do_symtype() { shift 2; defer_test_symtype pos "$@"; }
+function do_nsymtype() { shift 2; defer_test_symtype neg "$@"; }
+function do_member() { shift 2; defer_test_member pos "$@"; }
+function do_nmember() { shift 2; defer_test_member neg "$@"; }
+function do_memtype() { shift 2; defer_test_memtype pos "$@"; }
+function do_nmemtype() { shift 2; defer_test_memtype neg "$@"; }
+function do_bitfield() { shift 2; defer_test_bitfield pos "$@"; }
+function do_nbitfield() { shift 2; defer_test_bitfield neg "$@"; }
+function do_export()
+{
+    local sym=$3
+    shift 3
+
+    # Only scan header files for the symbol
+    test_symbol $sym $(echo "$@" | sed -r 's/ [^ ]+\.c/ /g') || return
+    test_export $sym "$@"
+}
+function do_nexport() { ! do_export "$@"; }
+function do_file()
+{
+    for file in "$@"; do
+        if [ -n "${OFA_KSRC:-}" ]; then
+            if [ -f $OFA_KSRC/$file ]; then
+                return 0
+            fi
+            if [ -f $KBUILD_SRC/$file ]; then
+               return 0
+            fi
+        fi
+    done
+    return 1
+}
+function do_nfile()   { ! do_file "$@"; }
+
+function do_custom()  { do_$1; }
+
+######################################################################
+# Implementation of kernel feature checking
+
+# Special return value for deferred test
+DEFERRED=42
+
+function atexit_cleanup()
+{
+    rc=$?
+    [ -n "$rmfiles" ] && rm -rf $rmfiles
+    return $rc
+}
+
+function strip_comments()
+{
+    local file=$1
+
+    cat $1 | sed -e '
+/\/\*/!b
+:a
+/\*\//!{
+N
+ba
+}
+s:/\*.*\*/::' | sed -e '/^#include/d'
+}
+
+function test_symbol()
+{
+    local symbol=$1
+    shift
+    local file
+    local prefix
+    local prefix_list
+
+    for file in "$@"; do
+        # For speed, lets just grep through the file. The symbol may
+        # be of any of these forms:
+        #     #define SYMBOL
+        #     typedef void (SYMBOL)(void)
+        #     extern void SYMBOL(void)
+        #     void (*SYMBOL)(void)
+        #     enum { SYMBOL, } void
+        #
+        # Since 3.7 headers can be in both $KBUILD_SRC/include
+        #     or $KBUILD_SRC/include/uapi so check both
+        # If the file contains "include/linux" then build set of
+        # prefixes
+
+        prefix=$(dirname $file)
+        file=$(basename $file)
+        if [ "$prefix" == "include/linux" ]; then
+            prefix_list="include/linux/ include/uapi/linux/"
+        else
+            prefix_list="$prefix/"
+        fi
+
+        for prefix in $prefix_list; do
+            if [ -n "${OFA_KSRC:-}" ]; then
+                if [ $verbose = true ]; then
+                    echo >&2 "Looking for '$symbol' in '$OFA_KSRC/$prefix$file'"
+                fi
+
+                [ -f "$OFA_KSRC/$prefix$file" ] &&  \
+                strip_comments $OFA_KSRC/$prefix$file | \
+                egrep -w "$symbol" >/dev/null && \
+
+                return 0
+            fi
+
+            if [ $verbose = true ]; then
+                echo >&2 "Looking for '$symbol' in '$KBUILD_SRC/$prefix$file'"
+            fi
+
+            [ -f "$KBUILD_SRC/$prefix$file" ] &&  \
+            strip_comments $KBUILD_SRC/$prefix$file | \
+            egrep -w "$symbol" >/dev/null && \
+
+            return 0
+        done
+    done
+    return 1
+}
+
+function defer_test_symtype()
+{
+    local sense=$1
+    local symbol=$2
+    local file=$3
+    shift 3
+    local type="$*"
+
+    if [ ${file:0:8} != "include/" ]; then
+        fail "defer_test_symtype() can work in include/ - request was '$file'"
+    fi
+
+    defer_test_compile $sense "
+#include <linux/types.h>
+#include <${file:8}>
+
+#include \"_autocompat.h\"
+
+__typeof($type) *kernel_compat_dummy = &$symbol;
+"
+}
+
+function defer_test_member()
+{
+    local sense=$1
+    local aggtype="${2/_/ }"
+    local memname=$3
+    local file=$4
+    shift 4
+
+    if [ ${file:0:8} != "include/" ]; then
+        fail "defer_test_member() can work in include/ - request was '$file'"
+    fi
+
+    defer_test_compile $sense "
+#include <${file:8}>
+extern void kernel_compat_dummy_func(void);
+void kernel_compat_dummy_func(void) {
+$aggtype kernel_compat_dummy = { .$memname = kernel_compat_dummy.$memname };
+}
+"
+}
+
+function defer_test_memtype()
+{
+    local sense=$1
+    local aggtype="${2/_/ }"
+    local memname=$3
+    local file=$4
+    shift 4
+    local memtype="$*"
+
+    if [ ${file:0:8} != "include/" ]; then
+        fail "defer_test_symtype() can work in include/ - request was '$file'"
+    fi
+
+    defer_test_compile $sense "
+#include <${file:8}>
+$aggtype kernel_compat_dummy_1;
+__typeof($memtype) *kernel_compat_dummy_2 = &kernel_compat_dummy_1.$memname;
+"
+}
+
+function defer_test_bitfield()
+{
+    local sense=$1
+    local aggtype="${2/_/ }"
+    local memname=$3
+    local file=$4
+    shift 4
+
+    if [ ${file:0:8} != "include/" ]; then
+        fail "defer_test_bitfield() only works in include/ - request was '$file'"
+    fi
+
+    defer_test_compile $sense "
+#include <${file:8}>
+$aggtype kernel_compat_dummy_1;
+unsigned long test(void) {
+    return kernel_compat_dummy_1.$memname;
+}
+"
+}
+
+function test_inline_symbol()
+{
+    local symbol=$1
+    local file=$2
+    local t=$(mktemp)
+    rmfiles="$rmfiles $t"
+
+    if [ -n "${OFA_KSRC:-}" ]; then
+        [ -f "$OFA_KSRC/$file" ] &&
+        [ -f "$KBUILD_SRC/$file" ] || return
+    fi
+
+    # TODO: This isn't very satisfactory. Alternative options are:
+    #   1. Come up with a clever sed version
+    #   2. Do a test compile, and look for an undefined symbol (extern)
+
+    # look for the inline..symbol. This is complicated since the inline
+    # and the symbol may be on different lines.
+    if [ -n "${OFA_KSRC:-}" ]; then
+        strip_comments $OFA_KSRC/$file | \
+        egrep -m 1 -B 1 '(^|[,\* \(])'"$symbol"'($|[,; \(\)])' > $t
+           [ $? = 0 ] || return $?
+
+        # there is either an inline on the final line, or an inline and
+        # no semicolon on the previous line
+        head -1 $t | egrep -q 'inline[^;]*$' && return
+        tail -1 $t | egrep -q 'inline' && return
+
+        strip_comments $KBUILD_SRC/$file | \
+        egrep -m 1 -B 1 '(^|[,\* \(])'"$symbol"'($|[,; \(\)])' > $t
+
+        [ $? = 0 ] || return $?
+
+        # there is either an inline on the final line, or an inline and
+        # no semicolon on the previous line
+        head -1 $t | egrep -q 'inline[^;]*$' && return
+        tail -1 $t | egrep -q 'inline' && return
+    fi
+
+    return 1
+}
+
+function test_export()
+{
+    local symbol=$1
+    shift
+    local files="$@"
+    local file match
+
+    # Looks for the given export symbol $symbol, defined in $file
+    # Since this symbol is exported, we can look for it in:
+    #     1. $KBUILD_MODULE_SYMVERS
+    #     2. If the full source is installed, look in there.
+    #        May give a false positive if the export is conditional.
+    #     3. The MAP file if present. May give a false positive
+    #        because it lists all extern (not only exported) symbols.
+    if [ -f $KBUILD_MODULE_SYMVERS ]; then
+        if [ $verbose = true ]; then
+            echo >&2 "Looking for export of $symbol in $KBUILD_MODULE_SYMVERS"
+        fi
+        [ -n "$(awk '/0x[0-9a-f]+[\t ]+'$symbol'[\t ]+/' $KBUILD_MODULE_SYMVERS)" ]
+    else
+        for file in $files; do
+            if [ -n "${OFA_KSRC:-}" ]; then
+                if [ $verbose = true ]; then
+                    echo >&2 "Looking for export of $symbol in $OFA_KSRC/$file"
+                fi
+                if [ -f $OFA_KSRC/$file ]; then
+                    egrep -q 'EXPORT_(PER_CPU)?SYMBOL(_GPL)?\('"$symbol"'\)' $OFA_KSRC/$file && return
+                fi
+
+                if [ $verbose = true ]; then
+                    echo >&2 "Looking for export of $symbol in $KBUILD_SRC/$file"
+                fi
+                if [ -f $KBUILD_SRC/$file ]; then
+                    egrep -q 'EXPORT_(PER_CPU)?SYMBOL(_GPL)?\('"$symbol"'\)' $KBUILD_SRC/$file && return
+                fi
+            fi
+        done
+        if [ -n "$MAP" ]; then
+            if [ $verbose = true ]; then
+                echo >&2 "Looking for export of $symbol in $MAP"
+            fi
+            egrep -q "[A-Z] $symbol\$" $MAP && return
+        fi
+        return 1
+    fi
+}
+
+function test_compile()
+{
+    local source="$1"
+    local rc
+    local dir=$(mktemp -d)
+    echo "$source" > $dir/test.c
+    cat > $dir/Makefile <<EOF
+$makefile_prefix
+obj-m := test.o
+EOF
+    if [ -n "${LINUXINCLUDE:-}" ]; then
+        make -rR CROSS_COMPILE=$CROSS_COMPILE -C $KPATH ARCH=$ARCH \
+        LINUXINCLUDE="$LINUXINCLUDE" M=$dir O=$KOUT ${CC:+CC="$CC"} >$dir/log 2>&1
+    else
+        make -rR CROSS_COMPILE=$CROSS_COMPILE -C $KPATH ARCH=$ARCH \
+        M=$dir O=$KOUT ${CC:+CC="$CC"} >$dir/log 2>&1
+    fi
+    rc=$?
+
+    if [ $verbose = true ]; then
+        echo >&2 "tried to compile:"
+        sed >&2 's/^/    /' $dir/test.c
+        echo >&2 "compiler output:"
+        sed >&2 's/^/    /' $dir/log
+    fi
+
+    rm -rf $dir
+    return $rc
+}
+
+function defer_test_compile()
+{
+    local sense=$1
+    local source="$2"
+    echo "$source" > "$compile_dir/test_$key.c"
+    echo "obj-m += test_$key.o" >> "$compile_dir/Makefile"
+    eval deferred_$sense=\"\$deferred_$sense $key\"
+    return $DEFERRED
+}
+
+function read_make_variables()
+{
+    local regexp=''
+    local split='('
+    local variable
+    local variables="$@"
+    local dir=$(mktemp -d)
+    for variable in $variables; do
+    echo "\$(warning $variable=\$($variable))" >> $dir/Makefile
+    regexp=$regexp$split$variable
+    split='|'
+    done
+    if [ -n "${LINUXINCLUDE:-}" ]; then
+        make -C $KPATH $EXTRA_MAKEFLAGS O=$KOUT \
+        LINUXINCLUDE="$LINUXINCLUDE" M=$dir \
+        2>&1 >/dev/null | sed -r "s#$dir/Makefile:.*: ($regexp)=.*$)#\1#; t; d"
+    else
+        make -C $KPATH $EXTRA_MAKEFLAGS O=$KOUT M=$dir \
+        2>&1 >/dev/null | sed -r "s#$dir/Makefile:.*: ($regexp)=.*$)#\1#; t; d"
+    fi
+    rc=$?
+
+    rm -rf $dir
+    return $rc
+}
+
+function read_define()
+{
+    local variable="$1"
+    local file="$2"
+    cat $KOUT/$2 | sed -r 's/#define '"$variable"' (.*)/\1/; t; d'
+}
+
+quiet=false
+verbose=false
+
+KVER=
+KPATH=
+KOUT=
+FILTER=
+MAP=
+EXTRA_MAKEFLAGS=
+kompat_symbols=
+ARCH=
+CROSS_COMPILE=
+LINUXINCLUDE=
+OFA_KSRC=
+
+# These variables from an outer build will interfere with our test builds
+unset KBUILD_EXTMOD
+unset KBUILD_SRC
+unset M
+unset TOPDIR
+unset sub_make_done
+unset OFA_KSRC
+
+# Filter out make options except for job-server (parallel make)
+old_MAKEFLAGS="${MAKEFLAGS:-}"
+MAKEFLAGS=
+next=
+for word in $old_MAKEFLAGS; do
+    case "$word" in
+    '-j' | '-l')
+        export MAKEFLAGS="$MAKEFLAGS $word"
+        next=1
+        ;;
+    '-j'* | '-l'*)
+        export MAKEFLAGS="$MAKEFLAGS $word"
+        ;;
+    '--jobserver-fds'* | '--jobs='* | '--jobs' | '--load-average'*)
+        export MAKEFLAGS="$MAKEFLAGS $word"
+        ;;
+    *)
+        test -n "$next" && export MAKEFLAGS="$MAKEFLAGS $word"
+        next=
+        ;;
+    esac
+done
+
+# Clean-up temporary files when we exit.
+rmfiles=
+trap atexit_cleanup EXIT
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -a) ARCH=$2; shift;;
+    -c) CROSS_COMPILE=$2; shift;;
+    -f) OFA_KSRC=$2; shift;;
+    -r) KVER=$2; shift;;
+    -i) LINUXINCLUDE=$2; shift;;
+    -k) KPATH=$2; shift;;
+    -o) KOUT=$2; shift;;
+    -q) quiet=true;;
+    -m) MAP=$2; shift;;
+    -v) verbose=true;;
+    -s) kompat_symbols="$2"; shift;;
+    -*) usage; exit -1;;
+    *)  [ -z $FILTER ] && FILTER=$1 || FILTER="$FILTER|$1";;
+    *)  break;
+    esac
+    shift
+done
+
+vmsg "MAKEFLAGS  := $MAKEFLAGS"
+
+# resolve KVER and KPATH
+[ -z "$KVER" ] && [ -z "$KPATH" ] && KVER=`uname -r`
+[ -z "$KPATH" ] && KPATH=/lib/modules/$KVER/build
+[ -z "$KOUT" ] && KOUT="$KPATH"
+
+# Need to set CC explicitly on the kernel make line
+# Needs to override top-level kernel Makefile setting
+# Somehow this script does the wrong thing when a space is used in $CC,
+# particularly when ccache is used, so disable that.
+if [ -n "${CC:-}" ]; then
+    CC=${CC/ccache /}
+    CC=${CC/ /}
+    EXTRA_MAKEFLAGS=CC=${CC}
+fi
+
+if [ -n "${CROSS_COMPILE:-}" ]; then
+    EXTRA_MAKEFLAGS="${EXTRA_MAKEFLAGS} CROSS_COMPILE=${CROSS_COMPILE} ARCH=${ARCH}"
+elif [ "${ARCH}" = "aarch64" ] || [ "${ARCH}" = "arm64" ]; then
+	CROSS_COMPILE="${CC%-gcc}-"
+	EXTRA_MAKEFLAGS="${EXTRA_MAKEFLAGS} CROSS_COMPILE=${CROSS_COMPILE} ARCH=${ARCH}"
+fi
+
+vmsg "EXTRA_MAKEFLAGS  := $EXTRA_MAKEFLAGS"
+vmsg "ARCH             := ${ARCH}"
+vmsg "CROSS_COMPILE    := ${CROSS_COMPILE}"
+
+# Select the right warnings - complicated by working out which options work
+makefile_prefix='
+ifndef try-run
+try-run = $(shell set -e;       \
+    TMP="$(obj)/.$$$$.tmp";     \
+    TMPO="$(obj)/.$$$$.o";      \
+    if ($(1)) >/dev/null 2>&1;  \
+    then echo "$(2)";       \
+    else echo "$(3)";       \
+    fi;             \
+    rm -f "$$TMP" "$$TMPO")
+endif
+ifndef cc-disable-warning
+cc-disable-warning = $(call try-run,\
+    $(CC) $(KBUILD_CPPFLAGS) $(KBUILD_CFLAGS) -W$(strip $(1)) -c -xc /dev/null -o "$$TMP",-Wno-$(strip $(1)))
+endif
+EXTRA_CFLAGS = -Werror $(call cc-disable-warning, unused-but-set-variable)
+'
+
+# Ensure it looks like a build tree and we can build a module
+[ -d "$KPATH" ] || fail "$KPATH is not a directory"
+[ -f "$KPATH/Makefile" ] || fail "$KPATH/Makefile is not present"
+
+[ -z "$ARCH" ] && ARCH="$(uname -m | sed -e s/i.86/x86/ -e s/x86_64/x86/ \
+                                  -e s/sun4u/sparc64/ \
+                                  -e s/arm.*/arm/ -e s/sa110/arm/ \
+                                  -e s/s390x/s390/ -e s/parisc64/parisc/ \
+                                  -e s/ppc.*/powerpc/ -e s/mips.*/mips/ \
+                                  -e s/sh[234].*/sh/ -e s/aarch64.*/arm64/)"
+
+test_compile "#include <linux/module.h>
+MODULE_LICENSE(\"GPL\");" || \
+    fail "Kernel build tree is unable to build modules"
+
+# strip the KVER out of UTS_RELEASE, and compare to the specified KVER
+_KVER=
+for F in include/generated/utsrelease.h include/linux/utsrelease.h include/linux/version.h; do
+    [ -f $KOUT/$F ] && _KVER="$(eval echo $(read_define UTS_RELEASE $F))" && break
+done
+[ -n "$_KVER" ] || fail "Unable to identify kernel version from $KOUT"
+if [ -n "$KVER" ]; then
+    [ "$KVER" = "$_KVER" ] || fail "$KOUT kernel version $_KVER does not match $KVER"
+fi
+KVER=$_KVER
+unset _KVER
+
+vmsg "KVER       := $KVER"
+vmsg "KPATH      := $KPATH"
+
+# Define:
+#     KBUILD_SRC:         Was renamed into abs_srctree in linux-5.3
+#     KBUILD_SRC:         If not already set, same as KPATH
+#     SRCARCH:            If not already set, same as ARCH
+#     WORDSUFFIX:         Suffix added to some filenames by the i386/amd64 merge
+[ -n "${KBUILD_SRC:-}" ] || KBUILD_SRC=${abs_srctree:-}
+[ -n "${KBUILD_SRC:-}" ] || KBUILD_SRC=$KPATH
+[ -n "${SRCARCH:-}" ] || SRCARCH=$ARCH
+if [ "$ARCH" = "i386" ] || [ "${CONFIG_X86_32:-}" = "y" ]; then
+    WORDSUFFIX=_32
+elif [ "$ARCH" = "x86_64" ] || [ "${CONFIG_X86_64:-}" = "y" ]; then
+    WORDSUFFIX=_64
+else
+    WORDSUFFIX=
+fi
+[ -f "$KBUILD_SRC/arch/$SRCARCH/Makefile" ] || fail "$KBUILD_SRC doesn't directly build $SRCARCH"
+
+vmsg "KBUILD_SRC := $KBUILD_SRC"
+vmsg "SRCARCH    := $SRCARCH"
+vmsg "WORDSUFFIX := $WORDSUFFIX"
+
+if [ -f "$KPATH/Module.symvers" ] ; then
+    KBUILD_MODULE_SYMVERS=$KPATH/Module.symvers
+elif [ -n "${O:-}" -a -f "${O:-}/Module.symvers" ] ; then
+    KBUILD_MODULE_SYMVERS="$O/Module.symvers"
+elif [ -f "$PWD/Module.symvers" ] ; then
+    KBUILD_MODULE_SYMVERS="$PWD/Module.symvers"
+else
+    KBUILD_MODULE_SYMVERS=""
+fi
+vmsg "KBUILD_MODULE_SYMVERS := $KBUILD_MODULE_SYMVERS"
+
+# try and find the System map [used by test_export]
+if [ -z "$MAP" ]; then
+    if [ -f /boot/System.map-$KVER ]; then
+    MAP=/boot/System.map-$KVER
+    elif [ $KVER = "`uname -r`" ] && [ -f /proc/kallsyms ]; then
+    MAP=/proc/kallsyms
+    elif [ -f $KBUILD_MODULE_SYMVERS ]; then
+    # can use this to find external symbols only
+    true
+    else
+    log "!!Unable to find a valid System map. Export symbol checks may not work"
+    fi
+fi
+
+if [ "$kompat_symbols" == "" ]; then
+    kompat_symbols="$(generate_kompat_symbols)"
+fi
+
+# filter the available symbols
+if [ -n "$FILTER" ]; then
+    kompat_symbols="$(echo "$kompat_symbols" | egrep "^($FILTER):")"
+fi
+
+compile_dir="$(mktemp -d)"
+rmfiles="$rmfiles $compile_dir"
+echo >"$compile_dir/Makefile" "$makefile_prefix"
+echo >"$compile_dir/_autocompat.h"
+deferred_pos=
+deferred_neg=
+
+# Note that for deferred tests this runs after the Makefile has run all tests
+function do_one_symbol() {
+    local key=$1
+    shift
+    # NB work is in the following if clause "do_${method}"
+    if "$@"; then
+    echo "#define $key yes"
+    # So that future compile tests can consume this
+    echo "#define $key yes" >> "${compile_dir}/_autocompat.h"
+    elif [ $? -ne $DEFERRED ]; then
+    echo "// #define $key"
+    fi
+}
+
+# process each symbol
+for symbol in $kompat_symbols; do
+    # split symbol at colons; disable globbing (pathname expansion)
+    set -o noglob
+    IFS=:
+    set -- $symbol
+    unset IFS
+    set +o noglob
+
+    key="$1"
+    method="$2"
+    do_one_symbol $key do_${method} "$@"
+done
+
+function deferred_compile() {
+    if [ -n "${LINUXINCLUDE:-}" ]; then
+        make -C $KPATH -k $EXTRA_MAKEFLAGS O="$KOUT" \
+        LINUXINCLUDE="$LINUXINCLUDE" M="$compile_dir" \
+        >"$compile_dir/log" 2>&1 \
+        || true
+    else
+        make -C $KPATH -k $EXTRA_MAKEFLAGS O="$KOUT" M="$compile_dir" \
+        >"$compile_dir/log" 2>&1 \
+        || true
+    fi
+
+    if [ $verbose = true ]; then
+        echo >&2 "compiler output:"
+        sed >&2 's/^/    /' "$compile_dir/log"
+    fi
+    for key in $deferred_pos; do
+        # Use existence of object file as evidence of compile without warning/errors
+        do_one_symbol $key test -f "$compile_dir/test_$key.o"
+    done
+    for key in $deferred_neg; do
+        do_one_symbol $key test ! -f "$compile_dir/test_$key.o"
+    done
+}
+
+# Run the deferred compile tests
+deferred_compile

--- a/drivers/linux/eth/ionic/Makefile
+++ b/drivers/linux/eth/ionic/Makefile
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright(c) 2017 - 2019 Pensando Systems, Inc
 
+IONIC_ETH_SRC = $(PWD)/eth/ionic
+
 obj-$(CONFIG_IONIC) := ionic.o
 obj-$(CONFIG_IONIC_MNIC) := ionic_mnic.o
 
@@ -10,7 +12,12 @@ ionic-y := ionic_main.o ionic_bus_pci.o ionic_dev.o ionic_ethtool.o \
 	   ionic_lif.o ionic_rx_filter.o ionic_txrx.o ionic_debugfs.o \
 	   ionic_api.o ionic_stats.o ionic_devlink.o kcompat.o ionic_fw.o \
 	   dim.o net_dim.o
+ifdef CONFIG_AUXILIARY_BUS
+ionic-y += ionic_aux.o
+endif
+
 ionic-$(CONFIG_PTP_1588_CLOCK) += ionic_phc.o
+ionic-$(CONFIG_SYSFS) += ionic_sysfs.o
 
 ionic_mnic-y := ionic_main.o ionic_bus_platform.o ionic_dev.o ionic_ethtool.o \
 	        ionic_lif.o ionic_rx_filter.o ionic_txrx.o ionic_debugfs.o \
@@ -19,4 +26,20 @@ ionic_mnic-y := ionic_main.o ionic_bus_platform.o ionic_dev.o ionic_ethtool.o \
 ionic_mnic-$(CONFIG_PTP_1588_CLOCK) += ionic_phc.o
 ifeq ($(KVER),5.10.28-1)
 ionic_mnic-$(CONFIG_PTP_1588_CLOCK) += ionic_phc_weak.o
+endif
+ionic_mnic-$(CONFIG_SYSFS) += ionic_sysfs.o
+ifdef CONFIG_AUXILIARY_BUS
+ionic_mnic-y += ionic_aux.o
+endif
+
+ifdef KERNELRELEASE
+IONIC_AUTOCOMPAT := $(src)/autocompat.h
+
+TOPDIR := $(src)/../..
+include $(TOPDIR)/etc/Makefile.common
+$(addprefix $(obj)/,$(ionic-y)): $(IONIC_AUTOCOMPAT)
+$(addprefix $(obj)/,$(ionic_mnic-y)): $(IONIC_AUTOCOMPAT)
+$(obj)/ionic_sysfs.o: $(IONIC_AUTOCOMPAT)
+$(obj)/ionic_phc.o: $(IONIC_AUTOCOMPAT)
+$(obj)/ionic_phc_weak.o: $(IONIC_AUTOCOMPAT)
 endif

--- a/drivers/linux/eth/ionic/ionic.h
+++ b/drivers/linux/eth/ionic/ionic.h
@@ -22,8 +22,6 @@ struct ionic_lif;
 #define PCI_DEVICE_ID_PENSANDO_IONIC_ETH_VF	0x1003
 #define PCI_DEVICE_ID_PENSANDO_IONIC_ETH_MGMT	0x1004
 
-#define IONIC_ASIC_TYPE_ELBA	2
-
 #define DEVCMD_TOUT_DEF 5
 #define DEVCMD_TIMEOUT  devcmd_timeout
 #define SHORT_TIMEOUT   1
@@ -39,6 +37,9 @@ extern unsigned int rx_fill_threshold;
 extern unsigned int tx_budget;
 extern unsigned int devcmd_timeout;
 extern unsigned long affinity_mask_override;
+
+// TODO: remove this -- short term override for expdb feature negotiation
+extern bool expdb_en;
 
 struct ionic_vf {
 	u16	 index;

--- a/drivers/linux/eth/ionic/ionic_api.c
+++ b/drivers/linux/eth/ionic/ionic_api.c
@@ -263,11 +263,12 @@ void ionic_api_put_intr(void *handle, int intr)
 }
 EXPORT_SYMBOL_GPL(ionic_api_put_intr);
 
-int ionic_api_get_cmb(void *handle, u32 *pgid, phys_addr_t *pgaddr, int order, u8 stride_log2)
+int ionic_api_get_cmb(void *handle, u32 *pgid, phys_addr_t *pgaddr, int order,
+		      u8 stride_log2, bool *expdb)
 {
 	struct ionic_lif *lif = handle;
 
-	return ionic_get_cmb(lif, pgid, pgaddr, order, stride_log2);
+	return ionic_get_cmb(lif, pgid, pgaddr, order, stride_log2, expdb);
 }
 EXPORT_SYMBOL_GPL(ionic_api_get_cmb);
 

--- a/drivers/linux/eth/ionic/ionic_api.c
+++ b/drivers/linux/eth/ionic/ionic_api.c
@@ -9,6 +9,19 @@
 #include "ionic_lif.h"
 #include "ionic_txrx.h"
 
+struct net_device *ionic_get_netdev_from_handle(void *handle)
+{
+	struct ionic_lif *lif = handle;
+
+	if (!lif)
+		return ERR_PTR(-ENXIO);
+
+	dev_hold(lif->netdev);
+
+	return lif->netdev;
+}
+EXPORT_SYMBOL_GPL(ionic_get_netdev_from_handle);
+
 void *ionic_get_handle_from_netdev(struct net_device *netdev,
 				   const char *api_version,
 				   enum ionic_api_prsn prsn)
@@ -135,6 +148,78 @@ const union ionic_lif_identity *ionic_api_get_identity(void *handle,
 }
 EXPORT_SYMBOL_GPL(ionic_api_get_identity);
 
+/* queuetype support level */
+static const u8 ionic_qtype_versions[IONIC_QTYPE_MAX] = {
+	[IONIC_QTYPE_ADMINQ]  = 0,   /* 0 = Base version with CQ support */
+	[IONIC_QTYPE_NOTIFYQ] = 0,   /* 0 = Base version */
+	[IONIC_QTYPE_RXQ]     = 2,   /* 0 = Base version with CQ+SG support
+				      * 1 =       ... with EQ
+				      * 2 =       ... with CMB rings
+				      */
+	[IONIC_QTYPE_TXQ]     = 3,   /* 0 = Base version with CQ+SG support
+				      * 1 =   ... with Tx SG version 1
+				      * 2 =       ... with EQ
+				      * 3 =       ... with CMB rings
+				      */
+};
+
+struct ionic_qtype_info ionic_api_get_queue_identity(void *handle, int qtype)
+{
+	union ionic_q_identity __iomem *q_ident;
+	struct ionic_lif *lif = handle;
+	struct ionic_qtype_info qti;
+	struct ionic_dev *idev;
+	struct ionic *ionic;
+	int err;
+
+	union ionic_dev_cmd cmd = {
+		.q_identify.opcode = IONIC_CMD_Q_IDENTIFY,
+		.q_identify.lif_type = cpu_to_le16(lif->lif_type),
+		.q_identify.type = qtype,
+		.q_identify.ver = ionic_qtype_versions[qtype],
+	};
+
+	ionic = lif->ionic;
+	idev = &lif->ionic->idev;
+	q_ident = (union ionic_q_identity __iomem *)&idev->dev_cmd_regs->data;
+
+	mutex_lock(&ionic->dev_cmd_lock);
+
+	ionic_dev_cmd_go(&ionic->idev, &cmd);
+	err = ionic_dev_cmd_wait(ionic, devcmd_timeout);
+
+	if (err)
+		netdev_warn(lif->netdev, "get_queue_identity: error %d\n", err);
+
+	qti.version   = ioread8(&q_ident->version);
+	qti.supported = ioread8(&q_ident->supported);
+	qti.features  = readq(&q_ident->features);
+	qti.desc_sz   = ioread16(&q_ident->desc_sz);
+	qti.comp_sz   = ioread16(&q_ident->comp_sz);
+	qti.sg_desc_sz   = ioread16(&q_ident->sg_desc_sz);
+	qti.max_sg_elems = ioread16(&q_ident->max_sg_elems);
+	qti.sg_desc_stride = ioread16(&q_ident->sg_desc_stride);
+
+	mutex_unlock(&ionic->dev_cmd_lock);
+
+	return qti;
+}
+EXPORT_SYMBOL_GPL(ionic_api_get_queue_identity);
+
+u8 ionic_api_get_expdb(void *handle)
+{
+	struct ionic_lif *lif = handle;
+	u8 ret = 0;
+
+	if (lif->ionic->idev.phy_cmb_expdb64_pages)
+		ret |= IONIC_EXPDB_64B_WQE;
+	if (lif->ionic->idev.phy_cmb_expdb128_pages)
+		ret |= IONIC_EXPDB_128B_WQE;
+
+	return ret;
+}
+EXPORT_SYMBOL_GPL(ionic_api_get_expdb);
+
 int ionic_api_get_intr(void *handle, int *irq)
 {
 	struct ionic_intr_info *intr_obj;
@@ -178,11 +263,11 @@ void ionic_api_put_intr(void *handle, int intr)
 }
 EXPORT_SYMBOL_GPL(ionic_api_put_intr);
 
-int ionic_api_get_cmb(void *handle, u32 *pgid, phys_addr_t *pgaddr, int order)
+int ionic_api_get_cmb(void *handle, u32 *pgid, phys_addr_t *pgaddr, int order, u8 stride_log2)
 {
 	struct ionic_lif *lif = handle;
 
-	return ionic_get_cmb(lif, pgid, pgaddr, order);
+	return ionic_get_cmb(lif, pgid, pgaddr, order, stride_log2);
 }
 EXPORT_SYMBOL_GPL(ionic_api_get_cmb);
 
@@ -264,3 +349,11 @@ int ionic_api_adminq_post(void *handle, struct ionic_admin_ctx *ctx)
 	return ionic_adminq_post(lif, ctx);
 }
 EXPORT_SYMBOL_GPL(ionic_api_adminq_post);
+
+int ionic_api_adminq_post_wait(void *handle, struct ionic_admin_ctx *ctx)
+{
+	struct ionic_lif *lif = handle;
+
+	return ionic_adminq_post_wait(lif, ctx);
+}
+EXPORT_SYMBOL_GPL(ionic_api_adminq_post_wait);

--- a/drivers/linux/eth/ionic/ionic_api.h
+++ b/drivers/linux/eth/ionic/ionic_api.h
@@ -7,6 +7,9 @@
 #include <linux/completion.h>
 #include <linux/netdevice.h>
 #include <linux/types.h>
+#ifdef CONFIG_AUXILIARY_BUS
+#include <linux/auxiliary_bus.h>
+#endif
 
 #include "ionic_if.h"
 #include "ionic_regs.h"
@@ -24,6 +27,40 @@
 #define IONIC_API_VERSION "8"
 
 struct dentry;
+
+#ifdef CONFIG_AUXILIARY_BUS
+/**
+ * IONIC_AUX_MODNAME - Auxiliary device name modname prefix
+ *
+ * Auxiliary device name is composed with KBUILD_MODNAME + device name.
+ * This is same as module name which creates the aux device. If module
+ * name is changed, then this also needs to be changed.
+ */
+#define IONIC_AUX_MODNAME "ionic"
+
+#define IONIC_AUX_DEVTYPE "rdma"
+#define IONIC_AUX_DEVNAME IONIC_AUX_MODNAME "." IONIC_AUX_DEVTYPE
+
+/**
+ * struct ionic_aux_dev - Auxiliary device information
+ * @handle:		Handle for this auxiliary device
+ * @idx:		Index identifier
+ * @adev:		Auxiliary device
+ */
+struct ionic_aux_dev {
+	void *handle;
+	int idx;
+
+	/* For compatibility with MOFED, keep adev at the end.
+	 *
+	 * The size of struct auxiliary_device in MOFED is different, due to having some
+	 * additional fields in the MOFED definition of the struct.  Since ionic_rdma
+	 * doesn't use any of the internals of adev, the only thing that matters is that
+	 * the offset of handle and idx are consistent between ionic and ionic_rdma.
+	 */
+	struct auxiliary_device adev;
+};
+#endif
 
 /**
  * struct ionic_devinfo - device information
@@ -50,6 +87,18 @@ enum ionic_api_prsn {
 	IONIC_PRSN_ETH,
 	IONIC_PRSN_RDMA,
 };
+
+/**
+ * ionic_get_netdev_from_handle() - Get a network device associated with the handle
+ * @handle:		Handle to lif
+ *
+ * This returns a network device associated with the lif handle.
+ * If network device is available it holds the reference to device. Caller must
+ * ensure that it releases the device using dev_put() after its usage.
+ *
+ * Return: Network device on success or ERR_PTR(error)
+ */
+struct net_device *ionic_get_netdev_from_handle(void *handle);
 
 /**
  * ionic_get_handle_from_netdev() - Get a handle if the netdev is ionic
@@ -149,6 +198,8 @@ const struct ionic_devinfo *ionic_api_get_devinfo(void *handle);
  */
 struct dentry *ionic_api_get_debug_ctx(void *handle);
 
+#define IONIC_EXPDB_64B_WQE	BIT(0)
+#define IONIC_EXPDB_128B_WQE	BIT(1)
 /**
  * ionic_api_get_identity() - Get result of device identification
  * @handle:		Handle to lif
@@ -158,6 +209,21 @@ struct dentry *ionic_api_get_debug_ctx(void *handle);
  */
 const union ionic_lif_identity *ionic_api_get_identity(void *handle,
 						       int *lif_index);
+
+struct ionic_qtype_info {
+	u8  version;
+	u8  supported;
+	u64 features;
+	u16 desc_sz;
+	u16 comp_sz;
+	u16 sg_desc_sz;
+	u16 max_sg_elems;
+	u16 sg_desc_stride;
+};
+
+struct ionic_qtype_info ionic_api_get_queue_identity(void *handle,
+						     int qtype);
+u8 ionic_api_get_expdb(void *handle);
 
 /**
  * ionic_api_get_intr() - Reserve a device interrupt index
@@ -185,10 +251,11 @@ void ionic_api_put_intr(void *handle, int intr);
  * @pgid:		First page index
  * @pgaddr:		First page bus addr (contiguous)
  * @order:		Log base two number of pages (PAGE_SIZE)
+ * @stride_log2:	Size of stride to determine CMB pool
  *
  * Return: zero or negative error status
  */
-int ionic_api_get_cmb(void *handle, u32 *pgid, phys_addr_t *pgaddr, int order);
+int ionic_api_get_cmb(void *handle, u32 *pgid, phys_addr_t *pgaddr, int order, u8 stride_log2);
 
 /**
  * ionic_api_put_cmb() - Release cmb pages
@@ -263,6 +330,20 @@ struct ionic_admin_ctx {
  * Return: zero or negative error status
  */
 int ionic_api_adminq_post(void *handle, struct ionic_admin_ctx *ctx);
+
+/**
+ * ionic_api_adminq_post_wait() - Post an admin command and wait for response
+ * @handle:             Handle to lif
+ * @ctx:                API admin command context
+ *
+ * Post the command to an admin queue in the ethernet driver.  If this command
+ * succeeds, then the command has been posted, but that does not indicate a
+ * completion.  If this command returns success, then the completion callback
+ * will eventually be called.
+ *
+ * Return: zero or negative error status
+ */
+int ionic_api_adminq_post_wait(void *handle, struct ionic_admin_ctx *ctx);
 
 /**
  * ionic_error_to_errno() - Transform ionic_if errors to os errno

--- a/drivers/linux/eth/ionic/ionic_api.h
+++ b/drivers/linux/eth/ionic/ionic_api.h
@@ -252,10 +252,12 @@ void ionic_api_put_intr(void *handle, int intr);
  * @pgaddr:		First page bus addr (contiguous)
  * @order:		Log base two number of pages (PAGE_SIZE)
  * @stride_log2:	Size of stride to determine CMB pool
+ * @expdb:		Will be set to true if this CMB region has expdb enabled
  *
  * Return: zero or negative error status
  */
-int ionic_api_get_cmb(void *handle, u32 *pgid, phys_addr_t *pgaddr, int order, u8 stride_log2);
+int ionic_api_get_cmb(void *handle, u32 *pgid, phys_addr_t *pgaddr, int order,
+		      u8 stride_log2, bool *expdb);
 
 /**
  * ionic_api_put_cmb() - Release cmb pages

--- a/drivers/linux/eth/ionic/ionic_aux.c
+++ b/drivers/linux/eth/ionic/ionic_aux.c
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (C) 2023-2024, Advanced Micro Devices, Inc. */
+
+#include <linux/kernel.h>
+#include "ionic.h"
+#include "ionic_lif.h"
+#include "ionic_aux.h"
+
+static DEFINE_IDA(aux_ida);
+
+static void ionic_auxbus_release(struct device *dev)
+{
+	/* Dummy function for aux bus registration */
+}
+
+int ionic_auxbus_register(struct ionic_lif *lif)
+{
+	struct ionic_aux_dev *ionic_adev;
+	struct auxiliary_device *aux_dev;
+	int rc, id;
+
+	if (!lif->ionic->nrdma_eqs_per_lif)
+		return 0;
+
+	ionic_adev = kzalloc(sizeof(*ionic_adev), GFP_KERNEL);
+	if (!ionic_adev)
+		return -ENOMEM;
+
+	aux_dev = &ionic_adev->adev;
+
+	id = ida_alloc_range(&aux_ida, 0, INT_MAX, GFP_KERNEL);
+	if (id < 0) {
+		dev_err(lif->ionic->dev, "Failed to allocate aux id: %d, aborting\n", id);
+		rc = id;
+		goto err_adev_free;
+	}
+
+	aux_dev->id = id;
+	aux_dev->name = IONIC_AUX_DEVTYPE;
+	aux_dev->dev.parent = &lif->ionic->pdev->dev;
+	aux_dev->dev.release = ionic_auxbus_release;
+	ionic_adev->handle = lif;
+	rc = auxiliary_device_init(aux_dev);
+	if (rc) {
+		dev_err(lif->ionic->dev, "Failed to initialize aux device: %d, aborting\n", rc);
+		goto err_ida_free;
+	}
+
+	rc = auxiliary_device_add(aux_dev);
+	if (rc) {
+		dev_err(lif->ionic->dev, "Failed to add auxiliary device: %d, aborting\n", rc);
+		goto err_aux_uninit;
+	}
+
+	lif->ionic_adev = ionic_adev;
+
+	return rc;
+err_aux_uninit:
+	auxiliary_device_uninit(aux_dev);
+err_ida_free:
+	ida_free(&aux_ida, id);
+err_adev_free:
+	kfree(ionic_adev);
+
+	return rc;
+}
+
+void ionic_auxbus_unregister(struct ionic_lif *lif)
+{
+	struct auxiliary_device *aux_dev;
+
+	if (!lif->ionic_adev)
+		return;
+
+	aux_dev = &lif->ionic_adev->adev;
+
+	auxiliary_device_delete(aux_dev);
+	ida_free(&aux_ida, aux_dev->id);
+	auxiliary_device_uninit(aux_dev);
+
+	kfree(lif->ionic_adev);
+	lif->ionic_adev = NULL;
+}

--- a/drivers/linux/eth/ionic/ionic_aux.h
+++ b/drivers/linux/eth/ionic/ionic_aux.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2023-2024, Advanced Micro Devices, Inc. */
+
+#ifndef _IONIC_AUX_H_
+#define _IONIC_AUX_H_
+
+#ifdef CONFIG_AUXILIARY_BUS
+int ionic_auxbus_register(struct ionic_lif *lif);
+void ionic_auxbus_unregister(struct ionic_lif *lif);
+#else
+static inline int ionic_auxbus_register(struct ionic_lif *lif __always_unused)
+{
+	return 0;
+}
+
+static inline void ionic_auxbus_unregister(struct ionic_lif *lif __always_unused)
+{
+}
+
+#endif
+#endif /* _IONIC_AUX_H_ */

--- a/drivers/linux/eth/ionic/ionic_debugfs.c
+++ b/drivers/linux/eth/ionic/ionic_debugfs.c
@@ -283,25 +283,25 @@ void ionic_debugfs_add_qcq(struct ionic_lif *lif, struct ionic_qcq *qcq)
 		txqstats = &lif->txqstats[q->index];
 
 		debugfs_create_u64("dma_map_err", 0400, stats_dentry,
-				   &txqstats[q->index].dma_map_err);
+				   &txqstats->dma_map_err);
 		debugfs_create_u64("pkts", 0400, stats_dentry,
-				   &txqstats[q->index].pkts);
+				   &txqstats->pkts);
 		debugfs_create_u64("bytes", 0400, stats_dentry,
-				   &txqstats[q->index].bytes);
+				   &txqstats->bytes);
 		debugfs_create_u64("clean", 0400, stats_dentry,
-				   &txqstats[q->index].clean);
+				   &txqstats->clean);
 		debugfs_create_u64("linearize", 0400, stats_dentry,
-				   &txqstats[q->index].linearize);
+				   &txqstats->linearize);
 		debugfs_create_u64("csum_none", 0400, stats_dentry,
-				   &txqstats[q->index].csum_none);
+				   &txqstats->csum_none);
 		debugfs_create_u64("csum", 0400, stats_dentry,
-				   &txqstats[q->index].csum);
+				   &txqstats->csum);
 		debugfs_create_u64("crc32_csum", 0400, stats_dentry,
-				   &txqstats[q->index].crc32_csum);
+				   &txqstats->crc32_csum);
 		debugfs_create_u64("tso", 0400, stats_dentry,
-				   &txqstats[q->index].tso);
+				   &txqstats->tso);
 		debugfs_create_u64("frags", 0400, stats_dentry,
-				   &txqstats[q->index].frags);
+				   &txqstats->frags);
 	}
 
 	if (qcq->flags & IONIC_QCQ_F_RX_STATS) {
@@ -311,19 +311,19 @@ void ionic_debugfs_add_qcq(struct ionic_lif *lif, struct ionic_qcq *qcq)
 		rxqstats = &lif->rxqstats[q->index];
 
 		debugfs_create_u64("dma_map_err", 0400, stats_dentry,
-				   &rxqstats[q->index].dma_map_err);
+				   &rxqstats->dma_map_err);
 		debugfs_create_u64("alloc_err", 0400, stats_dentry,
-				   &rxqstats[q->index].alloc_err);
+				   &rxqstats->alloc_err);
 		debugfs_create_u64("pkts", 0400, stats_dentry,
-				   &rxqstats[q->index].pkts);
+				   &rxqstats->pkts);
 		debugfs_create_u64("bytes", 0400, stats_dentry,
-				   &rxqstats[q->index].bytes);
+				   &rxqstats->bytes);
 		debugfs_create_u64("csum_none", 0400, stats_dentry,
-				   &rxqstats[q->index].csum_none);
+				   &rxqstats->csum_none);
 		debugfs_create_u64("csum_complete", 0400, stats_dentry,
-				   &rxqstats[q->index].csum_complete);
+				   &rxqstats->csum_complete);
 		debugfs_create_u64("csum_error", 0400, stats_dentry,
-				   &rxqstats[q->index].csum_error);
+				   &rxqstats->csum_error);
 	}
 
 	cq_dentry = debugfs_create_dir("cq", qcq->dentry);

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -39,6 +39,9 @@
 #define IONIC_RX_MIN_DOORBELL_DEADLINE	(HZ / 100)	/* 10ms */
 #define IONIC_RX_MAX_DOORBELL_DEADLINE	(HZ * 4)	/* 4s */
 
+#define IONIC_EXPDB_64B_WQE_LG2		6
+#define IONIC_EXPDB_128B_WQE_LG2	7
+
 struct ionic_dev_bar {
 	void __iomem *vaddr;
 	phys_addr_t bus_addr;
@@ -169,6 +172,9 @@ struct ionic_dev {
 	unsigned long *cmb_inuse;
 	dma_addr_t phy_cmb_pages;
 	u32 cmb_npages;
+
+	dma_addr_t phy_cmb_expdb64_pages;
+	dma_addr_t phy_cmb_expdb128_pages;
 
 	u32 port_info_sz;
 	struct ionic_port_info *port_info;
@@ -400,7 +406,8 @@ void ionic_dev_cmd_adminq_init(struct ionic_dev *idev, struct ionic_qcq *qcq,
 
 int ionic_db_page_num(struct ionic_lif *lif, int pid);
 
-int ionic_get_cmb(struct ionic_lif *lif, u32 *pgid, phys_addr_t *pgaddr, int order);
+void ionic_map_cmb(struct ionic *ionic);
+int ionic_get_cmb(struct ionic_lif *lif, u32 *pgid, phys_addr_t *pgaddr, int order, u8 stride_log2);
 void ionic_put_cmb(struct ionic_lif *lif, u32 pgid, int order);
 
 int ionic_cq_init(struct ionic_lif *lif, struct ionic_cq *cq,

--- a/drivers/linux/eth/ionic/ionic_dev.h
+++ b/drivers/linux/eth/ionic/ionic_dev.h
@@ -407,7 +407,8 @@ void ionic_dev_cmd_adminq_init(struct ionic_dev *idev, struct ionic_qcq *qcq,
 int ionic_db_page_num(struct ionic_lif *lif, int pid);
 
 void ionic_map_cmb(struct ionic *ionic);
-int ionic_get_cmb(struct ionic_lif *lif, u32 *pgid, phys_addr_t *pgaddr, int order, u8 stride_log2);
+int ionic_get_cmb(struct ionic_lif *lif, u32 *pgid, phys_addr_t *pgaddr,
+		  int order, u8 stride_log2, bool *expdb);
 void ionic_put_cmb(struct ionic_lif *lif, u32 pgid, int order);
 
 int ionic_cq_init(struct ionic_lif *lif, struct ionic_cq *cq,

--- a/drivers/linux/eth/ionic/ionic_devlink.c
+++ b/drivers/linux/eth/ionic/ionic_devlink.c
@@ -8,6 +8,7 @@
 #include "ionic_bus.h"
 #include "ionic_lif.h"
 #include "ionic_devlink.h"
+#include "ionic_aux.h"
 
 #ifdef IONIC_DEVLINK
 #ifdef HAVE_DEVLINK_UPDATE_PARAMS
@@ -96,6 +97,103 @@ static const struct devlink_ops ionic_dl_ops = {
 	.flash_update	= ionic_dl_flash_update,
 };
 
+enum ionic_devlink_param_id {
+	IONIC_DEVLINK_PARAM_ID_BASE = DEVLINK_PARAM_GENERIC_ID_MAX,
+#ifndef HAVE_DEVLINK_GENERIC_RDMA_ID
+	IONIC_DEVLINK_PARAM_ID_ENABLE_RDMA,
+#endif
+};
+
+static bool is_aux_enabled(struct ionic *ionic)
+{
+#ifdef CONFIG_AUXILIARY_BUS
+	return ionic->lif->ionic_adev ? true : false;
+#else
+	return false;
+#endif
+}
+
+static int ionic_devlink_enable_rdma_get(struct devlink *dl, u32 id,
+					 struct devlink_param_gset_ctx *ctx)
+{
+	ctx->val.vbool = is_aux_enabled(devlink_priv(dl));
+	return 0;
+}
+
+#ifdef HAVE_DEVLINK_EXTRACT_PARAM
+static int ionic_devlink_enable_rdma_set(struct devlink *dl, u32 id,
+					 struct devlink_param_gset_ctx *ctx,
+					 struct netlink_ext_ack *extack)
+#else
+static int ionic_devlink_enable_rdma_set(struct devlink *dl, u32 id,
+					 struct devlink_param_gset_ctx *ctx)
+#endif
+{
+	struct ionic *ionic = devlink_priv(dl);
+	int err = 0;
+
+	if (ctx->val.vbool == is_aux_enabled(ionic))
+		return err;
+
+	if (ctx->val.vbool)
+		err = ionic_auxbus_register(ionic->lif);
+	else
+		ionic_auxbus_unregister(ionic->lif);
+
+	return err;
+}
+
+static int ionic_devlink_enable_rdma_validate(struct devlink *dl, u32 id,
+					      union devlink_param_value val,
+					      struct netlink_ext_ack *extack)
+{
+	struct ionic *ionic = devlink_priv(dl);
+	bool new_state = val.vbool;
+
+	if (new_state && !ionic->nrdma_eqs_per_lif)
+		return -EOPNOTSUPP;
+	return 0;
+}
+
+static const struct devlink_param ionic_dl_rdma_params[] = {
+#ifdef HAVE_DEVLINK_GENERIC_RDMA_ID
+	DEVLINK_PARAM_GENERIC(ENABLE_RDMA, BIT(DEVLINK_PARAM_CMODE_RUNTIME),
+			      ionic_devlink_enable_rdma_get, ionic_devlink_enable_rdma_set,
+			      ionic_devlink_enable_rdma_validate),
+#else
+	DEVLINK_PARAM_DRIVER(IONIC_DEVLINK_PARAM_ID_ENABLE_RDMA,
+			     "enable_rdma", DEVLINK_PARAM_TYPE_BOOL,
+			     BIT(DEVLINK_PARAM_CMODE_RUNTIME),
+			     ionic_devlink_enable_rdma_get, ionic_devlink_enable_rdma_set,
+			     ionic_devlink_enable_rdma_validate),
+#endif
+};
+
+static int ionic_dl_rdma_params_register(struct devlink *dl)
+{
+	int err;
+
+	if (!IS_ENABLED(CONFIG_AUXILIARY_BUS))
+		return 0;
+
+	err = devlink_params_register(dl, ionic_dl_rdma_params, ARRAY_SIZE(ionic_dl_rdma_params));
+	if (err)
+		return err;
+
+#ifdef IONIC_HAVE_DEVLINK_PARAMS_PUBLISH
+	devlink_params_publish(dl);
+#endif
+	return 0;
+}
+
+static void ionic_devlink_rdma_params_unregister(struct devlink *dl)
+{
+	if (!IS_ENABLED(CONFIG_AUXILIARY_BUS))
+		return;
+
+	devlink_params_unregister(dl, ionic_dl_rdma_params, ARRAY_SIZE(ionic_dl_rdma_params));
+}
+
 struct ionic *ionic_devlink_alloc(struct device *dev)
 {
 	struct devlink *dl;
@@ -119,11 +217,10 @@ int ionic_devlink_register(struct ionic *ionic)
 	struct devlink *dl = priv_to_devlink(ionic);
 	int err;
 
-#ifdef HAVE_VOID_DEVLINK_REGISTER
+#ifdef IONIC_HAVE_VOID_DEVLINK_REGISTER
 	err = devlink_port_register(dl, &ionic->dl_port, 0);
 	if (err) {
 		dev_err(ionic->dev, "devlink_port_register failed: %d\n", err);
-		devlink_unregister(dl);
 		return err;
 	}
 
@@ -145,13 +242,27 @@ int ionic_devlink_register(struct ionic *ionic)
 
 	devlink_port_type_eth_set(&ionic->dl_port, ionic->lif->netdev);
 #endif
+
+	err = ionic_dl_rdma_params_register(dl);
+	if (err) {
+		dev_err(ionic->dev, "ionic_dl_rdma_params_register failed: %d\n", err);
+		goto err_unreg_all;
+	}
+
 	return 0;
+
+err_unreg_all:
+	devlink_port_unregister(&ionic->dl_port);
+	devlink_unregister(dl);
+
+	return err;
 }
 
 void ionic_devlink_unregister(struct ionic *ionic)
 {
 	struct devlink *dl = priv_to_devlink(ionic);
 
+	ionic_devlink_rdma_params_unregister(dl);
 	devlink_port_unregister(&ionic->dl_port);
 	devlink_unregister(dl);
 }

--- a/drivers/linux/eth/ionic/ionic_devlink.h
+++ b/drivers/linux/eth/ionic/ionic_devlink.h
@@ -27,14 +27,14 @@ void ionic_devlink_unregister(struct ionic *ionic);
 #define ionic_devlink_free(i)     devm_kfree(i->dev, i)
 
 #define ionic_devlink_register(x)    0
-#define ionic_devlink_unregister(x)
+#define ionic_devlink_unregister(x) do {} while (0)
 #endif
 
 #if !IS_ENABLED(CONFIG_NET_DEVLINK)
 #define priv_to_devlink(i)  0
-#define devlink_flash_update_begin_notify(d)
-#define devlink_flash_update_end_notify(d)
-#define devlink_flash_update_status_notify(d, s, c, n, t)
+#define devlink_flash_update_begin_notify(d) do {} while (0)
+#define devlink_flash_update_end_notify(d) do {} while (0)
+#define devlink_flash_update_status_notify(d, s, c, n, t) do {} while (0)
 #endif /* CONFIG_NET_DEVLINK */
 
 #endif /* _IONIC_DEVLINK_H_ */

--- a/drivers/linux/eth/ionic/ionic_fw.c
+++ b/drivers/linux/eth/ionic/ionic_fw.c
@@ -98,7 +98,7 @@ int ionic_firmware_update(struct ionic_lif *lif, const struct firmware *fw)
 
 	netdev_dbg(netdev,
 		   "downloading firmware - size %d part_sz %d nparts %lu\n",
-		   (int)fw->size, buf_sz, DIV_ROUND_UP(fw->size, buf_sz));
+		   (int)fw->size, buf_sz, (unsigned long)DIV_ROUND_UP(fw->size, buf_sz));
 
 	devlink_flash_update_status_notify(dl, "Downloading", NULL, 0, fw->size);
 	offset = 0;
@@ -115,7 +115,7 @@ int ionic_firmware_update(struct ionic_lif *lif, const struct firmware *fw)
 		if (err) {
 			netdev_err(netdev,
 				   "download failed offset 0x%x addr 0x%lx len 0x%x\n",
-				   offset, offsetof(union ionic_dev_cmd_regs, data),
+				   offset, (unsigned long)offsetof(union ionic_dev_cmd_regs, data),
 				   copy_sz);
 			goto err_out;
 		}

--- a/drivers/linux/eth/ionic/ionic_if.h
+++ b/drivers/linux/eth/ionic/ionic_if.h
@@ -364,9 +364,11 @@ union ionic_drv_identity {
 /**
  * enum ionic_dev_capability - Device capabilities
  * @IONIC_DEV_CAP_VF_CTRL:     Device supports VF ctrl operations
+ * @IONIC_DEV_CAP_DISC_CMB:    Device supports CMB discovery operations
  */
 enum ionic_dev_capability {
 	IONIC_DEV_CAP_VF_CTRL        = BIT(0),
+	IONIC_DEV_CAP_DISC_CMB       = BIT(1),
 };
 
 /**
@@ -487,6 +489,7 @@ enum ionic_logical_qtype {
  * @IONIC_Q_F_4X_DESC:      Quadruple main descriptor size
  * @IONIC_Q_F_4X_CQ_DESC:   Quadruple cq descriptor size
  * @IONIC_Q_F_4X_SG_DESC:   Quadruple sg descriptor size
+ * @IONIC_QIDENT_F_EXPDB:   Queue supports express doorbell
  */
 enum ionic_q_feature {
 	IONIC_QIDENT_F_CQ		= BIT_ULL(0),
@@ -499,6 +502,7 @@ enum ionic_q_feature {
 	IONIC_Q_F_4X_DESC		= BIT_ULL(7),
 	IONIC_Q_F_4X_CQ_DESC		= BIT_ULL(8),
 	IONIC_Q_F_4X_SG_DESC		= BIT_ULL(9),
+	IONIC_QIDENT_F_EXPDB		= BIT_ULL(10),
 };
 
 /**
@@ -650,7 +654,8 @@ union ionic_lif_identity {
 			u8 rrq_stride;
 			u8 rsq_stride;
 			u8 dcqcn_profiles;
-			u8 rsvd_dimensions[10];
+			u8 udma_shift;
+			u8 rsvd_dimensions[9];
 			struct ionic_lif_logical_qtype aq_qtype;
 			struct ionic_lif_logical_qtype sq_qtype;
 			struct ionic_lif_logical_qtype rq_qtype;
@@ -1338,7 +1343,10 @@ enum ionic_xcvr_pid {
 	IONIC_XCVR_PID_SFP_25GBASE_CR_S  = 3,
 	IONIC_XCVR_PID_SFP_25GBASE_CR_L  = 4,
 	IONIC_XCVR_PID_SFP_25GBASE_CR_N  = 5,
-
+	IONIC_XCVR_PID_QSFP_50G_CR2_FC   = 6,
+	IONIC_XCVR_PID_QSFP_50G_CR2      = 7,
+	IONIC_XCVR_PID_QSFP_200G_CR4     = 8,
+	IONIC_XCVR_PID_QSFP_400G_CR4     = 9,
 	/* Fiber */
 	IONIC_XCVR_PID_QSFP_100G_AOC    = 50,
 	IONIC_XCVR_PID_QSFP_100G_ACC    = 51,
@@ -1364,6 +1372,15 @@ enum ionic_xcvr_pid {
 	IONIC_XCVR_PID_SFP_25GBASE_ACC  = 71,
 	IONIC_XCVR_PID_SFP_10GBASE_T    = 72,
 	IONIC_XCVR_PID_SFP_1000BASE_T   = 73,
+	IONIC_XCVR__PID_QSFP_200G_AOC   = 74,
+	IONIC_XCVR__PID_QSFP_200G_FR4   = 75,
+	IONIC_XCVR__PID_QSFP_200G_DR4   = 76,
+	IONIC_XCVR__PID_QSFP_200G_SR4   = 77,
+	IONIC_XCVR__PID_QSFP_200G_ACC   = 78,
+	IONIC_XCVR__PID_QSFP_400G_FR4   = 79,
+	IONIC_XCVR__PID_QSFP_400G_DR4   = 80,
+	IONIC_XCVR__PID_QSFP_400G_SR4   = 81,
+	IONIC_XCVR__PID_QSFP_400G_VR4   = 82,
 };
 
 /**
@@ -1452,6 +1469,8 @@ struct ionic_xcvr_status {
  */
 union ionic_port_config {
 	struct {
+#define IONIC_SPEED_400G	400000	/* 400G in Mbps */
+#define IONIC_SPEED_200G	200000	/* 200G in Mbps */
 #define IONIC_SPEED_100G	100000	/* 100G in Mbps */
 #define IONIC_SPEED_50G		50000	/* 50G in Mbps */
 #define IONIC_SPEED_40G		40000	/* 40G in Mbps */
@@ -3462,16 +3481,27 @@ union ionic_adminq_comp {
 
 /* BAR0 */
 #define IONIC_BAR0_SIZE				0x8000
-#define IONIC_BAR2_SIZE				0x800000
 
 #define IONIC_BAR0_DEV_INFO_REGS_OFFSET		0x0000
 #define IONIC_BAR0_DEV_CMD_REGS_OFFSET		0x0800
 #define IONIC_BAR0_DEV_CMD_DATA_REGS_OFFSET	0x0c00
 #define IONIC_BAR0_INTR_STATUS_OFFSET		0x1000
 #define IONIC_BAR0_INTR_CTRL_OFFSET		0x2000
+
+/* BAR2 */
+#define IONIC_BAR2_SIZE				0x800000
+
+#define IONIC_BAR2_CMB_ENTRY_SIZE		0x800000
+#define IONIC_BAR2_CMB_ENTRY_64B_OFFSET		IONIC_BAR2_CMB_ENTRY_SIZE
+#define IONIC_BAR2_CMB_ENTRY_128B_OFFSET	(2 * IONIC_BAR2_CMB_ENTRY_SIZE)
+
 #define IONIC_DEV_CMD_DONE			0x00000001
 
-#define IONIC_ASIC_TYPE_CAPRI			0
+#define IONIC_ASIC_TYPE_NONE			0
+#define IONIC_ASIC_TYPE_CAPRI			1
+#define IONIC_ASIC_TYPE_ELBA			2
+#define IONIC_ASIC_TYPE_GIGLIO			3
+#define IONIC_ASIC_TYPE_SALINA			4
 
 /**
  * struct ionic_doorbell - Doorbell register layout

--- a/drivers/linux/eth/ionic/ionic_lif.c
+++ b/drivers/linux/eth/ionic/ionic_lif.c
@@ -693,7 +693,7 @@ static int ionic_qcq_alloc(struct ionic_lif *lif, unsigned int type,
 			new->cmb_order = order_base_2(new->cmb_q_size / PAGE_SIZE);
 
 			err = ionic_get_cmb(lif, &new->cmb_pgid, &new->cmb_q_base_pa,
-					    new->cmb_order, 0);
+					    new->cmb_order, 0, NULL);
 			if (err) {
 				netdev_err(lif->netdev,
 					   "Cannot allocate queue order %d from cmb: err %d\n",

--- a/drivers/linux/eth/ionic/ionic_lif.h
+++ b/drivers/linux/eth/ionic/ionic_lif.h
@@ -218,17 +218,6 @@ struct ionic_lif_cfg {
 	void (*reset_cb)(void *priv);
 };
 
-struct ionic_qtype_info {
-	u8  version;
-	u8  supported;
-	u64 features;
-	u16 desc_sz;
-	u16 comp_sz;
-	u16 sg_desc_sz;
-	u16 max_sg_elems;
-	u16 sg_desc_stride;
-};
-
 struct ionic_phc;
 
 #define IONIC_LIF_NAME_MAX_SZ		32
@@ -295,6 +284,9 @@ struct ionic_lif {
 	union ionic_lif_identity *identity;
 	struct ionic_qtype_info qtype_info[IONIC_QTYPE_MAX];
 
+#ifdef CONFIG_AUXILIARY_BUS
+	struct ionic_aux_dev *ionic_adev;
+#endif
 	struct ionic_rx_filters rx_filters;
 	u32 rx_coalesce_usecs;		/* what the user asked for */
 	u32 rx_coalesce_hw;		/* what the hw is using */
@@ -310,6 +302,9 @@ struct ionic_lif {
 
 	struct dentry *dentry;
 	struct bpf_prog *xdp_prog;
+
+	__be32 int_mnic_ip;
+	u8 int_mnic_subnet;
 };
 
 #if IS_ENABLED(CONFIG_PTP_1588_CLOCK)

--- a/drivers/linux/eth/ionic/ionic_sysfs.c
+++ b/drivers/linux/eth/ionic/ionic_sysfs.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright(c) 2024 Advanced Micro Devices, Inc */
+
+#include <linux/ctype.h>
+#include <linux/inet.h>
+#include <linux/inetdevice.h>
+#include "ionic.h"
+#include "ionic_if.h"
+#include "ionic_lif.h"
+#include "ionic_sysfs.h"
+
+/**
+ * ionic_sysfs_emit - scnprintf equivalent, aware of PAGE_SIZE buffer.
+ * @buf: start of PAGE_SIZE buffer.
+ * @fmt: format
+ * @...: optional arguments to @format
+ *
+ * Returns number of characters written to @buf.
+ */
+static int ionic_sysfs_emit(char *buf, const char *fmt, ...)
+{
+	va_list args;
+	int len;
+
+	if (WARN(!buf || offset_in_page(buf),
+		 "invalid sysfs_emit: buf:%p\n", buf))
+		return 0;
+
+	va_start(args, fmt);
+	len = vscnprintf(buf, PAGE_SIZE, fmt, args);
+	va_end(args);
+
+	return len;
+}
+
+static ssize_t int_mnic_ip_show(struct device *dev,
+				struct device_attribute *attr, char *buf)
+{
+	struct net_device *netdev = to_net_dev(dev);
+	struct ionic_lif *lif = netdev_priv(netdev);
+
+	return ionic_sysfs_emit(buf, "%pI4/%u\n", &lif->int_mnic_ip,
+				lif->int_mnic_subnet);
+}
+
+static int ionic_set_attr_mgmt_ip(struct ionic_lif *lif, __be32 addr, u8 subnet)
+{
+	struct ionic_admin_ctx ctx = {
+		.work = COMPLETION_INITIALIZER_ONSTACK(ctx.work),
+		.cmd.lif_setattr = {
+			.opcode = IONIC_CMD_LIF_SETATTR,
+			.index = cpu_to_le16(lif->index),
+			.attr = IONIC_LIF_ATTR_MGMT_IPV4,
+			.mgmt_ipv4.addr = addr,
+			.mgmt_ipv4.subnet = subnet,
+		},
+	};
+
+	/* don't alarm users when setting int-mnic address is unsupported by the firmware */
+	return ionic_adminq_post_wait(lif, &ctx);
+}
+
+static int ionic_set_mgmt_ip(struct ionic_lif *lif, __be32 addr, u8 subnet)
+{
+	int err;
+
+	if (!lif->ionic->is_mgmt_nic)
+		return -EOPNOTSUPP;
+
+	err = ionic_set_attr_mgmt_ip(lif, addr, subnet);
+	if (err)
+		return err;
+
+	lif->int_mnic_ip = addr;
+	lif->int_mnic_subnet = subnet;
+
+	return 0;
+}
+
+static ssize_t int_mnic_ip_store(struct device *dev,
+				 struct device_attribute *attr, const char *buf,
+				 size_t count)
+{
+	struct net_device *netdev = to_net_dev(dev);
+	const char *end;
+	__be32 addr;
+	u8 subnet;
+	int err;
+
+	if (!in4_pton(buf, -1, (void *)&addr, -1, &end)) {
+		netdev_err(netdev, "Invalid address: %s", buf);
+		return -EINVAL;
+	}
+
+	/* point to start of subnet */
+	if (*end++ != '/') {
+		netdev_err(netdev, "Invalid format, expected format: 1.2.3.4/24\n");
+		return -EINVAL;
+	}
+
+	if (!isdigit(*end)) {
+		netdev_err(netdev, "Invalid subnet");
+		return -EINVAL;
+	}
+
+	err = kstrtou8(end, 10, &subnet);
+	if (subnet >= 32 || !subnet) {
+		netdev_err(netdev, "Invalid out of range subnet %u\n", subnet);
+		return -ERANGE;
+	}
+
+	err = ionic_set_mgmt_ip(netdev_priv(netdev), addr, subnet);
+	if (err) {
+		netdev_err(netdev, "Failed to set int-mnic address: %pI4 subnet: %u, err: %d\n",
+			   &addr, subnet, err);
+		return err;
+	}
+
+	netdev_dbg(netdev, "Successfully set int-mnic address: %pI4 subnet: %u\n",
+		   &addr, subnet);
+
+	return count;
+}
+
+DEVICE_ATTR_RW(int_mnic_ip);
+
+static struct attribute *dev_attrs[] = {
+	&dev_attr_int_mnic_ip.attr,
+	NULL,
+};
+
+ATTRIBUTE_GROUPS(dev);
+
+void ionic_lif_set_mgmt_nic_sysfs_group(struct ionic_lif *lif)
+{
+	if (lif->ionic->is_mgmt_nic)
+		lif->netdev->sysfs_groups[0] = dev_groups[0];
+}

--- a/drivers/linux/eth/ionic/ionic_sysfs.h
+++ b/drivers/linux/eth/ionic/ionic_sysfs.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright(c) 2024 Advanced Micro Devices, Inc */
+
+#ifndef _IONIC_SYSFS_H
+#define _IONIC_SYSFS_H
+
+#include "ionic_lif.h"
+
+#ifdef CONFIG_SYSFS
+void ionic_lif_set_mgmt_nic_sysfs_group(struct ionic_lif *lif);
+#else
+static inline void ionic_lif_set_mgmt_nic_sysfs_group(struct ionic_lif *lif) { }
+#endif
+
+#endif /* _IONIC_SYSFS_H */

--- a/drivers/linux/eth/ionic/ionic_txrx.c
+++ b/drivers/linux/eth/ionic/ionic_txrx.c
@@ -1082,7 +1082,11 @@ static void ionic_dim_update(struct ionic_qcq *qcq, int napi_mode)
 	dim_update_sample_with_comps(qcq->cq.bound_intr->rearm_count,
 				     pkts, bytes, 0, &dim_sample);
 
+#if defined(IONIC_HAVE_NET_DIM_SAMPLE_PTR) && IS_ENABLED(CONFIG_DIMLIB)
+	net_dim(&qcq->dim, &dim_sample);
+#else
 	net_dim(&qcq->dim, dim_sample);
+#endif
 }
 int ionic_tx_napi(struct napi_struct *napi, int budget)
 {
@@ -1423,9 +1427,6 @@ unsigned int ionic_tx_cq_service(struct ionic_cq *cq,
 	unsigned int work_done = 0;
 	unsigned int bytes = 0;
 	unsigned int pkts = 0;
-
-	if (work_to_do == 0)
-		return 0;
 
 	while (ionic_tx_service(cq, &pkts, &bytes, in_napi)) {
 		if (cq->tail_idx == cq->num_descs - 1)

--- a/drivers/linux/eth/ionic/kcompat.h
+++ b/drivers/linux/eth/ionic/kcompat.h
@@ -6812,17 +6812,9 @@ static inline struct devlink *_kc_devlink_alloc(const struct devlink_ops *ops,
 #define ndo_eth_ioctl ndo_do_ioctl
 #endif
 
-#if (RHEL_RELEASE_CODE && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))
-#define HAVE_DEVLINK_GENERIC_RDMA_ID
-#endif /* RHEL 9.5 */
-
 #else
 
 #define	HAVE_NDO_SIOCDEVPRIVATE
-
-#if IS_ENABLED(CONFIG_NET_DEVLINK)
-#define	HAVE_DEVLINK_GENERIC_RDMA_ID
-#endif
 
 #endif /* 5.15.0 */
 

--- a/drivers/linux/eth/ionic/kernel_compat.sh
+++ b/drivers/linux/eth/ionic/kernel_compat.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -eu
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2023-2024, Advanced Micro Devices, Inc.
+#
+
+me=$(basename "$0")
+
+######################################################################
+# Symbol definition map
+
+function generate_kompat_symbols() {
+    echo "
+IONIC_HAVE_TCP_ALL_HEADERS			symbol		skb_tcp_all_headers		include/linux/tcp.h
+IONIC_HAVE_INNER_TCP_ALL_HEADERS		symbol		skb_inner_tcp_all_headers	include/linux/tcp.h
+IONIC_HAVE_DEVLINK_DRIVER_NAME_PUT		symbol		devlink_info_driver_name_put	include/net/devlink.h
+IONIC_HAVE_SET_NETDEV_DEVLINK_PORT		symbol		SET_NETDEV_DEVLINK_PORT		include/linux/netdevice.h
+IONIC_HAVE_DEVLINK_PARAMS_PUBLISH		symtype		devlink_params_publish		include/net/devlink.h		void(struct devlink *)
+IONIC_HAVE_DEVLINK_ALLOC_DEV			symtype		devlink_alloc			include/net/devlink.h   struct devlink *(const struct devlink_ops *, size_t, struct device *)
+IONIC_HAVE_VOID_DEVLINK_REGISTER		symtype		devlink_register		include/net/devlink.h   void(struct devlink *)
+IONIC_HAVE_DEVLINK_REGISTER_WITH_DEV		symtype		devlink_register		include/net/devlink.h   int(struct devlink *, struct device *)
+IONIC_HAVE_NET_DIM_SAMPLE_PTR			symtype		net_dim				include/linux/dim.h	void(struct dim *dim, const struct dim_sample *end_sample)
+IONIC_HAVE_ETHTOOL_COALESCE_CQE			memtype		struct_ethtool_ops		get_coalesce	include/linux/ethtool.h int (*)(struct net_device *, struct ethtool_coalesce *, struct kernel_ethtool_coalesce *, struct netlink_ext_ack *)
+IONIC_HAVE_ETHTOOL_SET_RINGPARAM_EXTACK		memtype		struct_ethtool_ops		set_ringparam	include/linux/ethtool.h int (*)(struct net_device *, struct ethtool_ringparam *, struct kernel_ethtool_ringparam *, struct netlink_ext_ack *)
+" | egrep -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
+}
+
+TOPDIR=$(dirname "$0")/../..
+source $TOPDIR/etc/kernel_compat_funcs.sh

--- a/drivers/linux/eth/ionic/kernel_compat.sh
+++ b/drivers/linux/eth/ionic/kernel_compat.sh
@@ -14,6 +14,7 @@ function generate_kompat_symbols() {
 IONIC_HAVE_TCP_ALL_HEADERS			symbol		skb_tcp_all_headers		include/linux/tcp.h
 IONIC_HAVE_INNER_TCP_ALL_HEADERS		symbol		skb_inner_tcp_all_headers	include/linux/tcp.h
 IONIC_HAVE_DEVLINK_DRIVER_NAME_PUT		symbol		devlink_info_driver_name_put	include/net/devlink.h
+IONIC_HAVE_DEVLINK_GENERIC_RDMA_ID		symbol		DEVLINK_PARAM_GENERIC_ID_ENABLE_RDMA	include/net/devlink.h
 IONIC_HAVE_SET_NETDEV_DEVLINK_PORT		symbol		SET_NETDEV_DEVLINK_PORT		include/linux/netdevice.h
 IONIC_HAVE_DEVLINK_PARAMS_PUBLISH		symtype		devlink_params_publish		include/net/devlink.h		void(struct devlink *)
 IONIC_HAVE_DEVLINK_ALLOC_DEV			symtype		devlink_alloc			include/net/devlink.h   struct devlink *(const struct devlink_ops *, size_t, struct device *)


### PR DESCRIPTION
Several updates including:
  - support for new Salina device RDMA driver
  - new kernel_compat.sh feature for better auto-configure of various distribution kernels
  - better ethtool support for 50, 200, and 400 Gbe QSFP modules

Internal patch list:
        ionic: fix debugfs q stats pointer
        ionic_rdma: clear CMB requested region in eth driver (AI-367)
        ionic: change devlink registration sequence
        ionic: rework compat handling of devlink param ENABLE_RDMA
        ionic_rdma: queue group oriented dual-udma
        ionic: MOFED aux device compatibility
        ionic: updates for Linux kernel v6.13
        ionic: set pci max seg size to 1G.
        ionic: use ee->offset when returning sprom data
        ionic: add new qsfp type support
        ionic: remove unsupported rx rule related code
        ionic: kcompat tweaks for RHEL 9.5
        ionic: Fix the ethtool outputs issues
        PS-13181: Configure CMB mapping for WQE size 128 B
        ionic_rdma: autocompat bitfield members
        tools: autocompat: change outdir to KPATH if taking module path
        tools: autocompat: Take kbuild path from $(srctree) for 6.13 onwards
        tools: autocompat: use custom filechk to store temp autocompat.h
        eth: add autocompat support for OL related failures
        ionic: add speed defines for 200G and 400G
        build: tools: add auto compat functionality for compilation on diff flavors
        ionic: override expdb feature negotiation
        ionic_rdma: expdb support 2 mappings
        Add autocompat for eth and mnic driver
        build: tools: add auto compat functionality for compilation on diff flavors
        ionic: export ionic_api_adminq_post_wait API
        PS-13017: add CMB discovery feature bits
        ionic: add ASIC_TYPE defines to ionic_if
        ionic: fix kcompat for oracle kernel 8.8
        ionic: fix kcompat for oracle kernel 8.9
        create auxiliary device from device probe
        Register auxbus driver from ionic rdma driver
        add enable_rdma devlink parameter support
        Register aux device from ionic pcie driver.
        ionic: Prevent phc worker from running/restarting during shutdown
        ionic: Fix compilation issue to to mismatched format specifier
        ionic: Fix compilation issue on linux mainline when !CONFIG_NET_DEVLINK
        ionic: no double destroy workqueue
        ionic: Add kcompat(ish) support for sysfs_emit
        ionic: Translate IONIC_RC_ENOSUPP to EOPNOTSUPP
        ionic: Add net sysfs support for setting the DSC's int_mnic address
        ionic: Kcompat for v6.11 ethtool timestamp API changes
        ionic: Fix netpoll case where budget == 0
        ionic: Use VLAN_ETH_HLEN when possible
