### PR TITLE
pciesvc: pcie port bifurcation support

### DIFF
--- a/drivers/linux/pciesvc/kpci_constants.h
+++ b/drivers/linux/pciesvc/kpci_constants.h
@@ -29,7 +29,6 @@
 #define NORMAL 1
 #define NUM_PHASES 2
 
-#define MSI_INDIRECT_IDX	0	/* indirect vector */
-#define MSI_NOTIFY_IDX		1	/* notify vector */
-#define MSI_NVECTORS		2
-
+#define PCIE_NPORTS  			8
+#define MSI_NVECTORS_COMPAT		2
+#define MSI_NVECTORS     		(PCIE_NPORTS * 2) /* 2 vectors per port, indirect and notify */

--- a/drivers/linux/pciesvc/kpcimgr_api.h
+++ b/drivers/linux/pciesvc/kpcimgr_api.h
@@ -86,12 +86,17 @@ struct kpcimgr_entry_points_t {
 #define EARLY_POLL 9
 #define MAX_DATA 10
 
+typedef struct {
+	unsigned long msgaddr;
+	unsigned int msgdata;
+} msi_info_t;
+
 struct kpcimgr_state_t {
 	/* essential state */
 	int valid;
 	int debug;
 	int running;
-	int active_port;
+	int active_port_compat; /* old active_port field */
 	int have_persistent_mem;
 	int lib_version_major;
 	int lib_version_minor;
@@ -107,6 +112,8 @@ struct kpcimgr_state_t {
 			long uart_paddr;
 			int features;
 			int features_valid;
+			int active_port_mask;
+			msi_info_t msi[MSI_NVECTORS];
 		};
 	};
 
@@ -126,11 +133,8 @@ struct kpcimgr_state_t {
 	int nranges;
 	int hwmem_idx;
 
-	/* interrupt vectors */
-	struct msi_info {
-		unsigned long msgaddr;
-		unsigned int msgdata;
-	} msi[MSI_NVECTORS];
+	/* old single port interrupt vectors */
+	msi_info_t msi_compat[MSI_NVECTORS_COMPAT];
 
 	/* stats for work done */
 	int ind_cfgrd, ind_cfgwr;

--- a/drivers/linux/pciesvc/pciesvc/include/pcieshmem.h
+++ b/drivers/linux/pciesvc/pciesvc/include/pcieshmem.h
@@ -221,6 +221,7 @@ typedef struct pciehw_shmem_lo_s {
     u_int32_t allocpmt_vf0adj;          /* low pri vf0 adjust (never freed) */
     u_int32_t freeprt_slab;             /* prt free slab adjacent */
     int8_t notify_port[PCIEHW_NPORTS];  /* which ports are allocated for notify */
+    u_int64_t msi_intr_base;
 } pciehw_shmem_lo_t;
 
 typedef struct pciehw_shmem_hi_s {
@@ -253,6 +254,7 @@ typedef struct pciehw_shmem_hi_s {
     u_int8_t vpddata[PCIEHW_NDEVS_HI][PCIEHW_VPDSZ];
     u_int8_t serial[PCIEHW_NPORTS][PCIEHW_SERIALSZ];
     int8_t notify_port[PCIEHW_NPORTS];  /* which ports are allocated for notify */
+    u_int64_t msi_intr_base;
 } pciehw_shmem_hi_t;
 
 typedef struct pciehw_shmem_s {

--- a/drivers/linux/pciesvc/pciesvc/src/intrutils.h
+++ b/drivers/linux/pciesvc/pciesvc/src/intrutils.h
@@ -38,17 +38,23 @@ typedef struct intr_msixcfg_s {
 } __attribute__((packed)) intr_msixcfg_t;
 
 /* override these to avoid static link dups */
+#define intr_assert_addr        _pciesvc_intr_assert_addr
+#define intr_assert_data        _pciesvc_intr_assert_data
 #define intr_assert             _pciesvc_intr_assert
 #define intr_deassert           _pciesvc_intr_deassert
 #define intr_drvcfg_mask        _pciesvc_intr_drvcfg_mask
 #define intr_fwcfg_mode         _pciesvc_intr_fwcfg_mode
 #define intr_reset_pci          _pciesvc_intr_reset_pci
 #define intr_pba_clear          _pciesvc_intr_pba_clear
+#define intr_config_local_msi   _pciesvc_intr_config_local_msi
 
+u_int64_t intr_assert_addr(const int intr);
+u_int32_t intr_assert_data(void);
 void intr_assert(const int intr);
 void intr_deassert(const int intr);
 int intr_drvcfg_mask(const int intr, const int on);
 void intr_fwcfg_mode(const int intr, const int legacy, const int fmask);
+int intr_config_local_msi(const int intr, u_int64_t msgaddr, u_int32_t msgdata);
 
 u_int32_t intr_pba_clear(const int intr);
 

--- a/drivers/linux/pciesvc/pciesvc/src/req_int.c
+++ b/drivers/linux/pciesvc/pciesvc/src/req_int.c
@@ -17,7 +17,7 @@ typedef union req_int_u {
     u_int32_t w[REQ_INT_NWORDS];
 } req_int_t;
 
-static void
+void
 req_int_set(const u_int64_t reg, const u_int64_t addr, const u_int32_t data)
 {
     req_int_t in = { .data = data, .addrdw = addr >> 2 };
@@ -25,7 +25,7 @@ req_int_set(const u_int64_t reg, const u_int64_t addr, const u_int32_t data)
     pciesvc_reg_wr32w(reg, in.w, REQ_INT_NWORDS);
 }
 
-static void
+void
 req_int_get(const u_int64_t reg, u_int64_t *addrp, u_int32_t *datap)
 {
     req_int_t in;

--- a/drivers/linux/pciesvc/pciesvc/src/req_int.h
+++ b/drivers/linux/pciesvc/pciesvc/src/req_int.h
@@ -25,6 +25,12 @@ typedef enum {
     MDATA_FIXED
 } data_mode_t;
 
+void
+req_int_set(const u_int64_t reg, const u_int64_t addr, const u_int32_t data);
+
+void
+req_int_get(const u_int64_t reg, u_int64_t *addrp, u_int32_t *datap);
+
 int
 req_int_init(const u_int64_t reg,
              const int port, u_int64_t msgaddr, addr_mode_t addr_mode,


### PR DESCRIPTION
    Initialize interrupts for multiple pcie ports.

    So far this module was handling single port only,
    so it was doing pciesvc_init for single port.

    Now based on enabled port mask, need to do init
    for all enabled ports.

    Also when multiple ports are enabled, need to use
    local msi interrupt resources for indirect and
    notify interrupts, due to stride errata.