### PR TITLE
Fixes for compilation issues with GCC v11.3.1

### DIFF
--- a/drivers/linux/pciesvc/kpci_get_entry.c
+++ b/drivers/linux/pciesvc/kpci_get_entry.c
@@ -18,22 +18,10 @@
 #include "kpcimgr_api.h"
 #include "pciesvc_impl.h"
 #include "version.h"
+#include "kpcinterface.h"
 
 extern char pciesvc_end;
-extern void kpcimgr_init_intr(void *);
-extern void kpcimgr_init_fn(void *);
-extern void kpcimgr_version_fn(char **);
-extern void kpcimgr_init_poll(kstate_t *);
 extern void pciesvc_shut(int);
-extern void kpcimgr_poll(kstate_t *, int, int);
-extern unsigned long kpcimgr_get_holding_pen(unsigned long, unsigned int);
-extern int kpcimgr_ind_intr(void *, int);
-extern int kpcimgr_not_intr(void *, int);
-extern void kpcimgr_undefined_entry(void);
-extern int pciesvc_sysfs_cmd_read(void *, char *, int *);
-extern int pciesvc_sysfs_cmd_write(void *, char *, size_t, int *);
-extern void kpcimgr_features(long *, long, long, long);
-extern void kpcimgr_reboot(long , long, long, long);
 
 extern int pciesvc_version_major;
 extern int pciesvc_version_minor;

--- a/drivers/linux/pciesvc/kpci_kexec.c
+++ b/drivers/linux/pciesvc/kpci_kexec.c
@@ -14,6 +14,7 @@
 #include "pciesvc.h"
 #include "pciesvc_system.h"
 #include "kpci_uart.h"
+#include "kpcinterface.h"
 
 #define TICKS_PER_US 200LL
 #define TICKS_PER_MS  (1000*TICKS_PER_US)
@@ -23,6 +24,10 @@ int holding_pen_idx;
 unsigned long kstate_paddr;
 kstate_t *kstate = NULL;
 long spin_table_start_addr;
+
+void released(void);
+void kpcimgr_cpu_polling_loop(kstate_t *ks);
+void serial_input(char c);
 
 void set_kstate(kstate_t *ks)
 {
@@ -35,7 +40,7 @@ int virtual(void)
 }
 
 /* called in physical mode */
-void kpcimgr_nommu_poll(kstate_t *ks)
+static void kpcimgr_nommu_poll(kstate_t *ks)
 {
 	kpcimgr_poll(ks, 0, NOMMU);
 	ks->trace_data[NOMMU][LAST_CALL_TIME] = read_sysreg(cntvct_el0);
@@ -79,7 +84,6 @@ void kpcimgr_cpu_polling_loop(kstate_t *ks)
 	unsigned long start = read_sysreg(cntvct_el0);
 #endif
 	extern void pciesvc_quit(void);
-	void serial_input(char c);
 	int i, npolls = 0;
 	char c;
 
@@ -117,7 +121,7 @@ void kpcimgr_cpu_polling_loop(kstate_t *ks)
 	}
 }
 
-void serial_help(void)
+static void serial_help(void)
 {
 	kpr_err("Commands:\n");
 	kpr_err(" a      Show addresses and parameters\n");
@@ -139,7 +143,7 @@ void serial_help(void)
 #define WDOG_CONTROL_REG_OFFSET             0x00
 #define WDOG_CONTROL_REG_WDT_EN_MASK        0x01
 #define WDOG_CONTROL_REG_RESP_MODE_MASK     0x02
-void watchdog_reboot(void)
+static void watchdog_reboot(void)
 {
         u32 val = readl(WDOG_REGS + WDOG_CONTROL_REG_OFFSET);
 
@@ -160,7 +164,7 @@ void watchdog_reboot(void)
  * if char c is a valid hex digit, then set *val to the
  * numerical value of that digit
  */
-int is_hexdigit(char c, int *val)
+static int is_hexdigit(char c, int *val)
 {
 	if (c >= '0' && c <= '9')
 		*val = c - '0';
@@ -185,7 +189,7 @@ int is_hexdigit(char c, int *val)
  * Return value of 1 indicates that we've processed the
  * character, otherwise the caller should process it.
  */
-int cfgval_process(char c)
+static int cfgval_process(char c)
 {
 	static int cfgval = 0, modify = 0;
 	static int state = NORMAL_INPUT;
@@ -326,7 +330,8 @@ void serial_input(char c)
  * serial thread is not used anymore, but leaving
  * it here as an example
  */
-void kpcimgr_serial_thread(kstate_t *ks)
+#if 0
+ void kpcimgr_serial_thread(kstate_t *ks)
 {
 	unsigned long start = read_sysreg(cntvct_el0);
 	int warning_printed = 0;
@@ -345,7 +350,7 @@ void kpcimgr_serial_thread(kstate_t *ks)
 	}
 	kpr_err("pciesvc: %s done\n", __func__);
 }
-
+#endif
 
 /*
  * Called from kpcimgr when the secondary CPUs are being taken

--- a/drivers/linux/pciesvc/kpcimgr_api.h
+++ b/drivers/linux/pciesvc/kpcimgr_api.h
@@ -56,6 +56,7 @@ struct kpcimgr_entry_points_t {
 #define FLAG_GUEST		BIT_ULL(2)
 #define FLAG_PSCI_CPU_RELEASED	BIT_ULL(3)
 #define FLAG_KEXEC		BIT_ULL(4)
+#define FLAG_PORT_BIFURCATION	BIT_ULL(5)
 #define FLAG_FUTURE_FEATURE	BIT_ULL(15)
 
 /* upcalls */
@@ -203,6 +204,7 @@ void kpcimgr_sysfs_setup(struct platform_device *pfdev);
 void *kpci_memcpy(void *dst, const void *src, size_t n);
 void wake_up_event_queue(void);
 int aarch64_insn_read(void *addr, u32 *insnp);
+struct kpcimgr_entry_points_t *kpci_get_entry_points(void);
 extern spinlock_t kpcimgr_lock;
 
 #define reset_stats(k) \

--- a/drivers/linux/pciesvc/kpcimgr_module.c
+++ b/drivers/linux/pciesvc/kpcimgr_module.c
@@ -32,7 +32,6 @@ MODULE_PARM_DESC(relocate, "specifies whether or not to relocate module");
 
 static int __init pciesvc_dev_init(void)
 {
-	struct kpcimgr_entry_points_t *kpci_get_entry_points(void);
 	struct kpcimgr_entry_points_t *ep;
 	int ret;
 

--- a/drivers/linux/pciesvc/kpcinterface.c
+++ b/drivers/linux/pciesvc/kpcinterface.c
@@ -12,6 +12,7 @@
 #include "pciesvc_impl.h"
 #include "version.h"
 #include "kpci_uart.h"
+#include "kpcinterface.h"
 
 /*
  * This file contains only functions essential to the
@@ -31,9 +32,9 @@ void kpcimgr_version_fn(char **version)
 
 long using_psci, using_xen, protected_read;
 long uart_data_reg, uart_status_reg;
-long pciesvc_features = FLAG_PSCI | FLAG_GUEST;
+long pciesvc_features = FLAG_PSCI | FLAG_GUEST | FLAG_PORT_BIFURCATION;
 
-void set_uart_regs(long uart_addr)
+static void set_uart_regs(long uart_addr)
 {
 	kstate_t *ks = get_kstate();
 
@@ -56,12 +57,12 @@ void kpcimgr_features(long *features, long dummy1, long dummy2, long dummy3)
 	kstate_t *ks = get_kstate();
 	extern long kstate_paddr;
 
+	if (features)
+		*features = pciesvc_features;
+
 	/* if we are called from an old kernel, do nothing */
 	if (ks->features_valid != KSTATE_MAGIC)
 		return;
-
-	if (features)
-		*features = pciesvc_features;
 /*
  * Setting kstate_paddr here works because we are always called *before* kpcimgr
  * copies the pciesvc code/data out to persistent memory. This is better than the
@@ -86,7 +87,13 @@ void kpcimgr_features(long *features, long dummy1, long dummy2, long dummy3)
 void kpcimgr_reboot(long dummy0, long dummy1, long dummy2, long dummy3)
 {
 	kstate_t *ks = get_kstate();
+	extern long kstate_paddr;
 
+	kstate_paddr = ks->kstate_paddr;
+	if (ks->features & FLAG_PSCI)
+		using_psci = 1;
+	if (ks->features & FLAG_GUEST)
+		using_xen = ~0LL;
 	set_uart_regs(ks->uart_paddr);	/* set to physical address */
 	kpr_err("%s: pciesvc ack kexec\n", __func__);
 }
@@ -280,7 +287,7 @@ int kpcimgr_not_intr(kstate_t *ks, int port)
  * physical address.
  *
  */
-void *kpcimgr_va_get(unsigned long pa, unsigned long sz)
+static void *kpcimgr_va_get(unsigned long pa, unsigned long sz)
 {
 	kstate_t *ks = get_kstate();
 	int i;
@@ -552,7 +559,7 @@ pciesvc_log(const char *msg)
 		kdbg_puts((char *)msg);
 }
 
-void wakeup_event_queue(void)
+static void wakeup_event_queue(void)
 {
 	kstate_t *ks = get_kstate();
 	u64 (*upcall)(int req);

--- a/drivers/linux/pciesvc/kpcinterface.h
+++ b/drivers/linux/pciesvc/kpcinterface.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2021, 2022, 2025, AMD and/or its affiliates.
+ */
+#include "kpcimgr_api.h"
+
+void kpcimgr_init_intr(kstate_t *ks);
+void kpcimgr_init_fn(kstate_t *ks);
+void kpcimgr_version_fn(char **);
+void kpcimgr_init_poll(kstate_t *);
+void kpcimgr_poll(kstate_t *, int, int);
+int kpcimgr_ind_intr(kstate_t *ks, int);
+int kpcimgr_not_intr(kstate_t *ks, int);
+void kpcimgr_undefined_entry(void);
+void kpcimgr_features(long *, long, long, long);
+void kpcimgr_reboot(long , long, long, long);
+unsigned long kpcimgr_get_holding_pen(unsigned long old_entry,
+				      unsigned int cpu, unsigned long ks_paddr);
+
+int pciesvc_sysfs_cmd_read(kstate_t *ks, char *buf, loff_t off, size_t count, int *exists);
+int pciesvc_sysfs_cmd_write(kstate_t *ks, char *buf, loff_t off, size_t count, int *exists);

--- a/drivers/linux/pciesvc/pciesvc/src/indirect.c
+++ b/drivers/linux/pciesvc/pciesvc/src/indirect.c
@@ -401,6 +401,7 @@ pciehw_indirect_global_init(const int active_port)
     return 0;
 }
 
+#if defined(ASIC_CAPRI) || defined(ASIC_ELBA)
 int
 pciehw_indirect_intr_init(const int port,
                           const u_int64_t msgaddr, const u_int32_t msgdata)
@@ -424,6 +425,15 @@ pciehw_indirect_intr_init(const int port,
     }
     return ret;
 }
+#else
+int
+pciehw_indirect_intr_init(const int port,
+                          const u_int64_t msgaddr, const u_int32_t msgdata)
+{
+    return req_int_init(indirect_int_addr(), port,
+                        msgaddr, MADDR_AS_IS, msgdata, MDATA_ADD_PORT);
+}
+#endif
 
 static int
 pciehw_indirect_handle(const int port, const int polled)

--- a/drivers/linux/pciesvc/pciesvc/src/notify.c
+++ b/drivers/linux/pciesvc/pciesvc/src/notify.c
@@ -178,6 +178,7 @@ handle_notify(const int port, pciehw_port_t *p, notify_entry_t *nentry)
 /*
  * CFG_TGT_REQ_NOTIFY_INT
  */
+#if defined(ASIC_CAPRI) || defined(ASIC_ELBA)
 int
 pciehw_notify_intr_init(const int port, u_int64_t msgaddr, u_int32_t msgdata)
 {
@@ -202,6 +203,15 @@ pciehw_notify_intr_init(const int port, u_int64_t msgaddr, u_int32_t msgdata)
     }
     return ret;
 }
+#else
+int
+pciehw_notify_intr_init(const int port, u_int64_t msgaddr, u_int32_t msgdata)
+{
+    notify_enable();
+    return req_int_init(notify_int_addr(), port,
+                        msgaddr, MADDR_AS_IS, msgdata, MDATA_ADD_PORT);
+}
+#endif
 
 static int
 pciehw_notify_handle(const int port, const int polled)

--- a/drivers/linux/pciesvc/pciesvc/src/req_int.h
+++ b/drivers/linux/pciesvc/pciesvc/src/req_int.h
@@ -25,11 +25,13 @@ typedef enum {
     MDATA_FIXED
 } data_mode_t;
 
+#if defined(ASIC_CAPRI) || defined(ASIC_ELBA)
 void
 req_int_set(const u_int64_t reg, const u_int64_t addr, const u_int32_t data);
 
 void
 req_int_get(const u_int64_t reg, u_int64_t *addrp, u_int32_t *datap);
+#endif
 
 int
 req_int_init(const u_int64_t reg,

--- a/drivers/linux/pciesvc/pciesvc_end.c
+++ b/drivers/linux/pciesvc/pciesvc_end.c
@@ -19,6 +19,7 @@
  *
  * Author: rob.gardner@oracle.com
  */
-__attribute__((__noinline__)) void pciesvc_end(void)
+__attribute__((__noinline__)) void pciesvc_end(void);
+ __attribute__((__noinline__)) void pciesvc_end(void)
 {
 }

--- a/drivers/linux/pciesvc/pciesvc_system_extern.h
+++ b/drivers/linux/pciesvc/pciesvc_system_extern.h
@@ -250,4 +250,6 @@ void kpcimgr_report_stats(kstate_t *ks, int phase, int always, int rightnow);
 /* functions in kpci_kexec.c */
 void set_kstate(kstate_t *ks);
 
+void pciesvc_get_timestamp(uint64_t *ts);
+
 #endif /* __PCIESVC_SYSTEM_EXTERN_H__ */


### PR DESCRIPTION
- Mostly function prototype declaration before use
- Also introduced feature flag for port bifurcation